### PR TITLE
Implementation of integral_templated_variant

### DIFF
--- a/include/dice/template-library/integral_templated_variant.hpp
+++ b/include/dice/template-library/integral_templated_variant.hpp
@@ -1,0 +1,146 @@
+#ifndef DICE_TEMPLATE_LIBRARY_INTEGRAL_TEMPLATED_VARIANT_HPP
+#define DICE_TEMPLATE_LIBRARY_INTEGRAL_TEMPLATED_VARIANT_HPP
+
+#include <algorithm>
+#include <concepts>
+#include <utility>
+#include <variant>
+
+namespace dice::template_library {
+
+	namespace itv_detail {
+
+		/**
+		 * generates the std::integer_sequence<Int, FIRST, ..., LAST>
+		 * @note FIRST is allowed to be greater than LAST
+		 *
+		 * @tparam Int the integral type of the std::integer_sequence
+		 * @tparam FIRST the starting integer
+		 * @tparam LAST the end integer
+		 */
+		template<typename Int, Int FIRST, Int LAST, Int ...IXS>
+		consteval auto make_integer_sequence(std::integer_sequence<Int, IXS...> = {}) {
+			std::integer_sequence<Int, IXS..., FIRST> const acc;
+
+			if constexpr (FIRST == LAST) {
+				return acc;
+			} else if constexpr (FIRST < LAST) {
+				return make_integer_sequence<Int, FIRST + 1, LAST>(acc);
+			} else {
+				return make_integer_sequence<Int, FIRST - 1, LAST>(acc);
+			}
+		}
+
+		/**
+		 * Generates the actual std::variant type
+		 * for an IntegralTemplatedTuple<FIRST, LAST, T> where Ixs = 0, 1, ..., LAST - FIRST
+		 * aka std::variant<T<FIRST + 0>, T<FIRST + 1>, ...>.
+		 *
+		 * Note: This function does not have an implementation because it is only used in decltype context.
+		 */
+		template<template<std::integral auto> typename T, typename Int, Int ...IXS>
+		std::variant<T<IXS>...> make_itv_type_impl(std::integer_sequence<Int, IXS...>);
+
+		/**
+		 * Generates the std::variant type corresponding to
+		 * integral_templated_variant<FIRST, LAST, T> by calling make_itv_type_impl with the correct index_sequence.
+		 *
+		 * Note: only callable in decltype context
+		 */
+		template<std::integral auto FIRST, std::integral auto LAST, template<std::integral auto> typename T>
+		consteval auto make_itv_type() {
+			using integral_t = std::common_type_t<decltype(FIRST), decltype(LAST)>;
+			return make_itv_type_impl<T>(make_integer_sequence<integral_t, FIRST, LAST>());
+		}
+
+		template<std::integral auto Min, std::integral auto Max, template<std::integral auto> typename T>
+		using itv_type_t = std::invoke_result_t<decltype(make_itv_type<Min, Max, T>)>;
+	} // namespace itv_detail
+
+	/**
+	 * A wrapper type for std::variant guarantees to only contain variants
+	 * of the form T<IX>. Where IX is in FIRST..LAST (inclusive).
+	 *
+	 * @tparam FIRST the first IX for T<IX>
+	 * @tparam LAST the last IX for T<IX>
+	 * @tparam T the template that gets instantiated with T<IX> for IX in FIRST..LAST (inclusive)
+	 */
+	template<template<std::integral auto> typename T, std::integral auto FIRST, std::integral auto LAST>
+	struct integral_templated_variant {
+		static constexpr std::integral auto MIN = std::min(FIRST, LAST);
+		static constexpr std::integral auto MAX = std::max(FIRST, LAST);
+
+		template<std::integral auto IX>
+		using value_type = T<IX>;
+
+	private:
+		using variant_t = itv_detail::itv_type_t<MIN, MAX, T>;
+		variant_t repr;
+
+		template<std::integral auto IX>
+		static consteval void check_ix() {
+			static_assert(IX >= MIN && IX <= MAX, "Index out of range");
+		}
+
+	public:
+		constexpr integral_templated_variant(integral_templated_variant const &other)
+			: repr{other.repr} {
+		}
+
+		constexpr integral_templated_variant(integral_templated_variant &&other)
+			: repr{std::move(other.repr)} {
+		}
+
+		template<std::integral auto IX>
+		constexpr integral_templated_variant(T<IX> const &value) noexcept(std::is_nothrow_copy_constructible_v<T<IX>>)
+			: repr{value} {
+			check_ix<IX>();
+		}
+
+		template<std::integral auto IX>
+		constexpr integral_templated_variant(T<IX> &&value) noexcept(std::is_nothrow_move_constructible_v<T<IX>>)
+			: repr{std::move(value)} {
+			check_ix<IX>();
+		}
+
+		template<typename U, typename ...Args>
+		explicit constexpr integral_templated_variant(std::in_place_type_t<U>, Args &&...args)
+			: repr{std::in_place_type<U>, std::forward<Args>(args)...} {
+		}
+
+		template<std::integral auto IX>
+		friend constexpr T<IX> &get(integral_templated_variant &variant) {
+			check_ix<IX>();
+			return std::get<T<IX>>(variant.repr);
+		}
+
+		template<std::integral auto IX>
+		friend constexpr T<IX> const &get(integral_templated_variant const &variant) {
+			check_ix<IX>();
+			return std::get<T<IX>>(variant.repr);
+		}
+
+		template<std::integral auto IX>
+		friend constexpr T<IX> &&get(integral_templated_variant &&variant) {
+			check_ix<IX>();
+			return std::get<T<IX>>(std::move(variant.repr));
+		}
+
+		template<std::integral auto IX>
+		friend constexpr T<IX> const &&get(integral_templated_variant const &&variant) {
+			check_ix<IX>();
+			return std::get<T<IX>>(static_cast<variant_t const &&>(variant.repr));
+		}
+
+		template<typename Visitor, typename ...ITVariants>
+		friend constexpr decltype(auto) visit(Visitor &&visitor, ITVariants &&...vars);
+	};
+
+	template<typename Visitor, typename ...ITVariants>
+	constexpr decltype(auto) visit(Visitor &&visitor, ITVariants &&...vars) {
+		return std::visit(std::forward<Visitor>(visitor), std::forward<ITVariants>(vars).repr...);
+	}
+
+} // namespace dice::template_library
+
+#endif//DICE_TEMPLATE_LIBRARY_INTEGRAL_TEMPLATED_VARIANT_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,5 +33,9 @@ add_executable(tests_integral_templated_tuple
                tests_integral_templated_tuple.cpp)
 custom_add_test(tests_integral_templated_tuple)
 
+add_executable(tests_integral_templated_variant
+        tests_integral_templated_variant.cpp)
+custom_add_test(tests_integral_templated_variant)
+
 add_executable(tests_for tests_for.cpp)
 custom_add_test(tests_for)

--- a/tests/tests_integral_templated_variant.cpp
+++ b/tests/tests_integral_templated_variant.cpp
@@ -1,0 +1,154 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include <dice/template-library/integral_templated_variant.hpp>
+
+#include <doctest/doctest.h>
+
+#include <algorithm>
+#include <iostream>
+
+namespace dice::template_library {
+
+	template<auto N>
+	struct Data {
+		operator int() const { return static_cast<int>(N); }
+	};
+
+	template<auto N>
+	struct CompoundData {
+		double d;
+		float f;
+		int a;
+
+		CompoundData(double d, float f, int a) : d{d}, f{f}, a{a} {}
+
+		operator int() const { return static_cast<int>(d + f + a + N); }
+	};
+
+	void call_counted(Data<1> const &) {
+		static int call_count = 0;
+		call_count += 1;
+		CHECK(call_count == 1);
+	}
+
+	void call_counted(Data<1> &&) {
+		static int call_count = 0;
+		call_count += 1;
+		CHECK(call_count == 1);
+	}
+
+	TEST_SUITE("integral_templated_variant") {
+		TEST_CASE("asc pos") {
+			integral_templated_variant<Data, 2, 7> itv{Data<5>{}};
+			integral_templated_variant<Data, 2, 7> lower{Data<2>{}};
+			integral_templated_variant<Data, 2, 7> upper{Data<7>{}};
+
+			CHECK(get<5>(itv) == 5);
+			CHECK(get<2>(lower) == 2);
+			CHECK(get<7>(upper) == 7);
+
+			visit([]<auto N>(Data<N> const &) {
+				CHECK(N == 5);
+			}, itv);
+
+			visit([]<auto N>(Data<N> const &) {
+				CHECK(N == 2);
+			}, lower);
+
+			visit([]<auto N>(Data<N> const &) {
+				CHECK(N == 7);
+			}, upper);
+		}
+
+		TEST_CASE("desc pos") {
+			integral_templated_variant<Data, 5, 1> itv{Data<3>{}};
+			integral_templated_variant<Data, 5, 1> lower{Data<5>{}};
+			integral_templated_variant<Data, 5, 1> upper{Data<1>{}};
+
+			CHECK(get<3>(itv) == 3);
+			CHECK(get<5>(lower) == 5);
+			CHECK(get<1>(upper) == 1);
+
+			visit([]<auto N>(Data<N> const &) {
+				CHECK(N == 3);
+			}, itv);
+
+			visit([]<auto N>(Data<N> const &) {
+				CHECK(N == 5);
+			}, lower);
+
+			visit([]<auto N>(Data<N> const &) {
+				CHECK(N == 1);
+			}, upper);
+		}
+
+		TEST_CASE("asc neg") {
+			integral_templated_variant<Data, -6, -1> itv{Data<-3>{}};
+			integral_templated_variant<Data, -6, -1> lower{Data<-6>{}};
+			integral_templated_variant<Data, -6, -1> upper{Data<-1>{}};
+
+			CHECK(get<-3>(itv) == -3);
+			CHECK(get<-6>(lower) == -6);
+			CHECK(get<-1>(upper) == -1);
+
+			visit([]<auto N>(Data<N> const &) {
+				CHECK(N == -3);
+			}, itv);
+
+			visit([]<auto N>(Data<N> const &) {
+				CHECK(N == -6);
+			}, lower);
+
+			visit([]<auto N>(Data<N> const &) {
+				CHECK(N == -1);
+			}, upper);
+		}
+
+		TEST_CASE("desc pos") {
+			integral_templated_variant<Data, -2, -8> itv{Data<-5>{}};
+			integral_templated_variant<Data, -2, -8> lower{Data<-2>{}};
+			integral_templated_variant<Data, -2, -8> upper{Data<-8>{}};
+
+			CHECK(get<-5>(itv) == -5);
+			CHECK(get<-2>(lower) == -2);
+			CHECK(get<-8>(upper) == -8);
+
+			visit([]<auto N>(Data<N> const &) {
+				CHECK(N == -5);
+			}, itv);
+
+			visit([]<auto N>(Data<N> const &) {
+				CHECK(N == -2);
+			}, lower);
+
+			visit([]<auto N>(Data<N> const &) {
+				CHECK(N == -8);
+			}, upper);
+		}
+
+		TEST_CASE("single entry") {
+			integral_templated_variant<Data, 0, 0> itv{Data<0>{}};
+			CHECK(get<0>(itv) == 0);
+		}
+
+		TEST_CASE("in place construction") {
+			integral_templated_variant<CompoundData, 0, 2> itv{std::in_place_type<CompoundData<1>>, 2.0, 3.f, 5};
+			CHECK(get<1>(itv) == 1 + 2 + 3 + 5);
+		}
+
+		TEST_CASE("visit forwarding") {
+			integral_templated_variant<Data, 1, 1> const copyable{std::in_place_type<Data<1>>};
+
+			visit([](auto &&x) {
+				call_counted(std::forward<decltype(x)>(x));
+			}, copyable);
+
+			integral_templated_variant<Data, 1, 1> movable{std::in_place_type<Data<1>>};
+
+			visit([](auto &&x) {
+				call_counted(std::forward<decltype(x)>(x));
+			}, std::move(movable));
+		}
+	}
+
+} // dice::template_library


### PR DESCRIPTION
This is a generalized version of the integral templated variant I needed in hypertrie. It is simmilar to integral_templated_tuple, and since that lives here now moving this type into here probably also makes sense.