### PR TITLE
General library overhaul

### DIFF
--- a/.github/workflows/code_testing.yaml
+++ b/.github/workflows/code_testing.yaml
@@ -13,10 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - os: ubuntu-20.04
-            compiler: clang-10
           - os: ubuntu-22.04
-            compiler: gcc-10
+            compiler: clang-12
+          - os: ubuntu-22.04
+            compiler: gcc-12
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.os }} (${{ matrix.config.compiler }})
     defaults:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 project(
   dice-template-library
-  VERSION 0.3.2
+  VERSION 1.0.0
   DESCRIPTION
     "This template library is a collection of template-oriented code that we, the Data Science Group at UPB, found pretty handy. It contains: `switch_cases` (Use runtime values in compile-time context), `integral_template_tuple` (Create a tuple-like structure that instantiates a template for a range of values), `integral_template_variant` (A wrapper type for `std::variant` guarantees to only contain variants of the form `T<IX>` and `for_{types,values,range}` (Compile time for loops for types, values or ranges))."
   HOMEPAGE_URL "https://dice-research.org/")

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ add
 FetchContent_Declare(
         dice-template-library
         GIT_REPOSITORY "https://github.com/dice-group/dice-template-library.git"
-        GIT_TAG v0.3.2
+        GIT_TAG v1.0.0
         GIT_SHALLOW TRUE)
 
 FetchContent_MakeAvailable(dice-template-library)
@@ -84,7 +84,7 @@ target_link_libraries(your_target
 ### conan
 
 You can use it with [conan](https://conan.io/).
-To do so, you need to add `dice-template-library/0.3.0` to the `[requires]` section of your conan file.
+To do so, you need to add `dice-template-library/1.0.0` to the `[requires]` section of your conan file.
 
 ## Build and Run Tests and Examples
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It contains:
 
 - `switch_cases`: Use runtime values in compile-time context.
 - `integral_template_tuple`: Create a tuple-like structure that instantiates a template for a range of values.
-- `integral_template_variant`: A wrapper type for `std::variant` guarantees to only contain variants of the form `T<IX>` where $\texttt{IX}\in [\texttt{FIRST},\texttt{LAST}]$ (inclusive).
+- `integral_template_variant`: A wrapper type for `std::variant` guarantees to only contain variants of the form `T<ix>` where $\texttt{ix}\in [\texttt{first},\texttt{last}]$ (inclusive).
 - `for_{types,values,range}`: Compile time for loops for types, values or ranges
 
 ## Usage

--- a/examples/examples_integral_template_tuple.cpp
+++ b/examples/examples_integral_template_tuple.cpp
@@ -27,27 +27,27 @@ std::ostream &operator<<(std::ostream &os, int_array<N> const &arr) {
 int main() {
 	{
 		std::cout << "tuple of integer arrays, size 5 to 8, default constructor:\n";
-		integral_template_tuple<int_array, 5, 8> itt;
-		std::cout << "  " << itt.get<5>() << '\n';
-		std::cout << "  " << itt.get<6>() << '\n';
-		std::cout << "  " << itt.get<7>() << '\n';
-		std::cout << "  " << itt.get<8>() << "\n\n";
+		integral_template_tuple<5UL, 8, int_array> itt;
+		std::cout << "  " << itt.template get<5>() << '\n';
+		std::cout << "  " << itt.template get<6>() << '\n';
+		std::cout << "  " << itt.template get<7>() << '\n';
+		std::cout << "  " << itt.template get<8>() << "\n\n";
 	}
 
 	{
 		std::cout << "tuple of integer arrays, size 5 to 8, specific constructor:\n";
-		auto itt = make_integral_template_tuple<int_array, 5, 8>(42);
-		std::cout << "  " << itt.get<5>() << '\n';
-		std::cout << "  " << itt.get<6>() << '\n';
-		std::cout << "  " << itt.get<7>() << '\n';
-		std::cout << "  " << itt.get<8>() << "\n\n";
+		integral_template_tuple<5UL, 8, int_array> itt{individual_construct, 42};
+		std::cout << "  " << itt.template get<5>() << '\n';
+		std::cout << "  " << itt.template get<6>() << '\n';
+		std::cout << "  " << itt.template get<7>() << '\n';
+		std::cout << "  " << itt.template get<8>() << "\n\n";
 	}
 
 	{
-		std::cout << "tuple of integer arrays, size 5 to 8, cast down:\n";
-		integral_template_tuple<int_array, 5, 8> itt;
-		auto *casted_itt = reinterpret_cast<integral_template_tuple<int_array, 5, 6> *>(&itt);
-		std::cout << "  " << casted_itt->get<5>() << '\n';
-		std::cout << "  " << casted_itt->get<6>() << '\n';
+		std::cout << "tuple of integer arrays, size 5 to 8, subtuple:\n";
+		integral_template_tuple<5UL, 8, int_array> itt;
+		auto &sub_itt = itt.template subtuple<6, 7>();
+		std::cout << "  " << sub_itt.template get<6>() << '\n';
+		std::cout << "  " << sub_itt.template get<7>() << '\n';
 	}
 }

--- a/examples/examples_integral_template_tuple.cpp
+++ b/examples/examples_integral_template_tuple.cpp
@@ -36,7 +36,7 @@ int main() {
 
 	{
 		std::cout << "tuple of integer arrays, size 5 to 8, specific constructor:\n";
-		integral_template_tuple<5UL, 8, int_array> itt{individual_construct, 42};
+		integral_template_tuple<5UL, 8, int_array> itt{uniform_construct, 42};
 		std::cout << "  " << itt.template get<5>() << '\n';
 		std::cout << "  " << itt.template get<6>() << '\n';
 		std::cout << "  " << itt.template get<7>() << '\n';

--- a/examples/examples_integral_template_variant.cpp
+++ b/examples/examples_integral_template_variant.cpp
@@ -27,25 +27,25 @@ std::ostream &operator<<(std::ostream &os, int_array<N> const &arr) {
 int main() {
 	{
 		std::cout << "get:\n";
-		integral_template_variant<int_array, 5, 8> itv{int_array<6>{1}};
-		std::cout << "  " << get<6>(itv) << '\n';
+		integral_template_variant<5UL, 8, int_array> itv{int_array<6>{1}};
+		std::cout << "  " << itv.template get<6>() << '\n';
 
-		itv = integral_template_variant<int_array, 5, 8>{int_array<7>{2}};
-		std::cout << "  " << get<7>(itv) << "\n\n";
+		itv = integral_template_variant<5UL, 8, int_array>{int_array<7>{2}};
+		std::cout << "  " << itv.template get<7>() << "\n\n";
 	}
 
 	{
 		std::cout << "visit:\n";
-		integral_template_variant<int_array, 5, 8> itv{int_array<6>{3}};
+		integral_template_variant<5UL, 8, int_array> itv{int_array<6>{3}};
 
-		visit([](auto const &array) {
+		itv.visit([](auto const &array) {
 			std::cout << array << "\n\n";
-		}, itv);
+		});
 	}
 
 	{
 		std::cout << "in-place construction:\n";
-		integral_template_variant<int_array, 1, 9> itv{std::in_place_type<int_array<7>>, 78};
-		std::cout << get<7>(itv) << '\n';
+		integral_template_variant<1UL, 9, int_array> itv{std::in_place_type<int_array<7>>, 78};
+		std::cout << itv.template get<7>() << '\n';
 	}
 }

--- a/include/dice/template-library/integral_template_tuple.hpp
+++ b/include/dice/template-library/integral_template_tuple.hpp
@@ -281,11 +281,11 @@ namespace dice::template_library {
 		 * @return subtuple
 		 */
 		template<index_type new_first, index_type new_last>
-		constexpr integral_template_tuple<new_first, new_last, value_type> const &subtuple() const noexcept {
+		constexpr integral_template_tuple<new_first, new_last, T> const &subtuple() const noexcept {
 			static_assert(first <= last ? (new_first >= first && new_last <= last) : (new_first <= first && new_last >= last),
 						  "Cannot add elements to a tuple by casting");
 
-			return *reinterpret_cast<integral_template_tuple<new_first, new_last, value_type> const *>(this);
+			return *reinterpret_cast<integral_template_tuple<new_first, new_last, T> const *>(this);
 		}
 
 		/**
@@ -296,11 +296,11 @@ namespace dice::template_library {
 		 * @return subtuple
 		 */
 		template<index_type new_first, index_type new_last>
-		constexpr integral_template_tuple<new_first, new_last, value_type> &subtuple() noexcept {
+		constexpr integral_template_tuple<new_first, new_last, T> &subtuple() noexcept {
 			static_assert(first <= last ? (new_first >= first && new_last <= last) : (new_first <= first && new_last >= last),
 						  "Cannot add elements to a tuple by casting");
 
-			return *reinterpret_cast<integral_template_tuple<new_first, new_last, value_type> *>(this);
+			return *reinterpret_cast<integral_template_tuple<new_first, new_last, T> *>(this);
 		}
 	};
 }// namespace dice::template_library

--- a/include/dice/template-library/integral_template_tuple.hpp
+++ b/include/dice/template-library/integral_template_tuple.hpp
@@ -4,108 +4,266 @@
 #include <algorithm>
 #include <concepts>
 #include <cstdint>
+#include <functional>
 #include <tuple>
 #include <utility>
 
 namespace dice::template_library {
-	/**
-	 * This class is a wrapper around a tuple std::tuple<T<FIRST> .. T<LAST>>.
-	 * FIRST is allowed to be smaller then LAST.
-	 * It allows access to the elements via get<i>() -> T<I>.
-	 * Elements are memory aligned from FIRST to LAST which means you can reinterpret
-	 * an IntegralTemplatedTuple<T,1,5> as an IntegralTemplatedTuple<T,1,3>
-	 * and will still be able to access the elements 1-3.
-	 * You can give the constructor parameters to pass through to the constructors of
-	 * the elements. However all elements will get exactly the same parameter.
-	 * You can use the function make_integral_template_tuple to create an
-	 * IntegralTemplatedTuple without explicitly listing the Args parameters.
-	 * @tparam entry_type_template T in the text above.
-	 * @tparam FIRST
-	 * @tparam LAST
-	 * @tparam Args Types of the constructor parameters.
-	 */
-	template<template<std::integral auto> typename entry_type_template, std::integral auto FIRST, std::integral auto LAST, typename... Args>
-	class integral_template_tuple {
-		static constexpr bool USE_SIGNED = FIRST < 0 or LAST < 0;
-		using integral_type = std::conditional_t<USE_SIGNED, intmax_t, uintmax_t>;
-		static constexpr integral_type MIN = std::min(integral_type(FIRST), integral_type(LAST));
-		static constexpr integral_type MAX = std::max(integral_type(FIRST), integral_type(LAST));
-		static constexpr uint64_t LENGTH = MAX + 1 - MIN;
-		static constexpr enum class Direction : bool {
-			up = true,
-			down = false
-		} DIRECTION = static_cast<const Direction>(integral_type(FIRST) <= integral_type(LAST));
 
-	public:
-		template<integral_type N>
-		using Entry = entry_type_template<N>;
+	namespace itt_detail {
+		/**
+		 * generates the std::integer_sequence<Int, first, ..., last>
+		 * @note first is allowed to be greater than last
+		 *
+		 * @tparam Int the integral type of the std::integer_sequence
+		 * @tparam first the starting integer
+		 * @tparam last the end integer
+		 */
+		template<std::integral Int, Int first, Int last, Int ...ixs>
+		consteval auto make_integer_sequence(std::integer_sequence<Int, ixs...> = {}) {
+			std::integer_sequence<Int, ixs..., first> const acc;
 
-	private:
-		/** A helper struct to generate tuples of the Form (T<MIN>, T<MIN+1>,..., T<MAX>).
-         */
-		struct tuple_generator {
-			/** Generates the tuple based on entries of an integer_sequence.
-			 * @tparam IDS The indices itself.
-			 */
-			template<integral_type... IDS>
-			static auto gen_tuple(std::integer_sequence<integral_type, IDS...>, Args &&...args) {
-				if constexpr (DIRECTION == Direction::up)
-					return std::make_tuple(Entry<integral_type(MIN + LENGTH - 1 - IDS)>{args...}...);
-				else
-					return std::make_tuple(Entry<integral_type(MAX - LENGTH + 1 + IDS)>{args...}...);
+			if constexpr (first == last) {
+				return acc;
+			} else if constexpr (first < last) {
+				return make_integer_sequence<Int, first + 1, last>(acc);
+			} else {
+				return make_integer_sequence<Int, first - 1, last>(acc);
 			}
+		}
 
-			/** Wrapper for gen_tuple.
-			 * @return The constructed tuple.
-			 */
-			static auto make_tuple(Args &&...args) {
-				return gen_tuple(std::make_integer_sequence<integral_type, LENGTH>(), std::forward<Args>(args)...);
-			}
+		template<size_t index, typename ...Ts>
+		struct nth_type;
 
-			/* CAUTION: has to be __after__ the make_tuple function.
-			 * Also make_tuple isn't allowed to have overloads.
-			 */
-			using type = std::invoke_result_t<decltype(make_tuple), Args &&...>;
+		template<typename First, typename ...Rest>
+		struct nth_type<0, First, Rest...> {
+			using type = First;
 		};
 
-		typename tuple_generator::type count_tuple_;
+		template<size_t index, typename First, typename ...Rest>
+		struct nth_type<index, First, Rest...> {
+			using type = typename nth_type<index - 1, Rest...>::type;
+		};
 
-	public:
-		explicit integral_template_tuple(Args &&...args)
-			: count_tuple_(tuple_generator::make_tuple(std::forward<Args>(args)...)) {}
+		template<size_t, typename T>
+		struct struct_tuple_leaf {
+			T value;
+		};
+
+		template<typename Markers, typename ...Ts>
+		struct struct_tuple_base;
+
+		template<size_t ...ixs, typename ...Ts>
+		struct struct_tuple_base<std::index_sequence<ixs...>, Ts...> : struct_tuple_leaf<ixs, Ts>... {
+			template<size_t ix>
+			[[nodiscard]] constexpr auto const &get() const & noexcept {
+				return static_cast<typename nth_type<ix, struct_tuple_leaf<ixs, Ts>...>::type const &>(*this).value;
+			}
+
+			template<size_t ix>
+			[[nodiscard]] constexpr auto &get() & noexcept {
+				return static_cast<typename nth_type<ix, struct_tuple_leaf<ixs, Ts>...>::type &>(*this).value;
+			}
+
+			template<size_t ix>
+			[[nodiscard]] constexpr auto const &&get() const && noexcept {
+				return static_cast<typename nth_type<ix, struct_tuple_leaf<ixs, Ts>...>::type const &&>(*this).value;
+			}
+
+			template<size_t ix>
+			[[nodiscard]] constexpr auto &&get() && noexcept {
+				return static_cast<typename nth_type<ix, struct_tuple_leaf<ixs, Ts>...>::type &&>(*this).value;
+			}
+
+			template<typename Self, typename Visitor>
+			[[nodiscard]] static constexpr decltype(auto) visit(Self &&self, Visitor &&visitor) {
+				return (std::invoke(visitor, std::forward<Self>(self).template get<ixs>()), ...);
+			}
+		};
+
+		/**
+		 * A std::tuple-like type that is guaranteed to have struct-equivalent layout.
+		 * I.e. layout(struct_tuple<Ts...>) == layout(struct { Ts... })
+		 *
+		 * This type exists because the standard does not have any layout guarantees for std::tuple,
+		 * so its members can be in arbitrary order (and offset).
+		 */
+		template<typename ...Ts>
+		struct struct_tuple : struct_tuple_base<std::make_index_sequence<sizeof...(Ts)>, Ts...> {
+			static constexpr size_t size = sizeof...(Ts);
+		};
+
+		/**
+		 * Generates the actual tuple type
+		 * for an integral_template_tuple<first, last, T> where Ixs = 0, 1, ..., last - first
+		 * aka struct_tuple<T<first + 0>, T<first + 1>, ...>.
+		 *
+		 * Note: This function does not have an implementation because it is only used in decltype context.
+		 */
+		template<std::integral Int, template<Int> typename T, Int ...ixs>
+		struct_tuple<T<ixs>...> make_itt_type_impl(std::integer_sequence<Int, ixs...>);
+
+		/**
+		 * Generates the std::tuple type corresponding to
+		 * integral_template_variant<first, last, T> by calling make_itv_type_impl with the correct index_sequence.
+		 *
+		 * Note: only callable in decltype context
+		 */
+		template<std::integral Int, Int first, Int last, template<Int> typename T>
+		consteval auto make_itt_type() {
+			return make_itt_type_impl<Int, T>(make_integer_sequence<Int, first, last>());
+		}
+
+		template<std::integral Int, Int first, Int last, template<Int> typename T>
+		using itt_type_t = std::invoke_result_t<decltype(make_itt_type<Int, first, last, T>)>;
+	} // namespace itt_detail
+
+	struct individual_construct_t {};
+	inline constexpr individual_construct_t individual_construct;
+
+	/**
+	 * A std::tuple-like type holding elements T<first> .. T<last> (inclusive).
+	 *
+	 * @tparam first first ix to provide to T<ix>
+	 * @tparam last last ix to provide to T<ix>
+	 * @tparam T the template that gets instantiated with T<ix> for ix in first..last (inclusive)
+	 *
+	 * @note first is allowed to be smaller then last.
+	 */
+	template<std::integral auto first, decltype(first) last, template<decltype(first)> typename T>
+	struct integral_template_tuple {
+		using index_type = decltype(first);
+
+		template<index_type ix>
+		using value_type = T<ix>;
 
 	private:
-		/** Because FIRST can be larger than LAST the indexing must change based on those values.
-		 * This function does exactly that.
-		 * @tparam I Index between FIRST and LAST or rather LAST and FIRST.
-		 * @return The indexed value.
-		 */
-		template<integral_type I>
-		static constexpr std::size_t calcPos() {
-			static_assert(MIN <= I && I <= MAX);
-			constexpr std::size_t pos =
-					(DIRECTION == Direction::up)
-							? MAX - I
-							: I - MIN;
-			static_assert(0 <= pos and pos < LENGTH);
-			return pos;
+		using underlying_type = itt_detail::itt_type_t<index_type, first, last, T>;
+		underlying_type repr_;
+
+		template<index_type ix>
+		static consteval void check_ix() {
+			static_assert(ix >= std::min(first, last) && ix <= std::max(first, last), "Index out of range");
+		}
+
+		template<index_type ix>
+		static consteval size_t make_index() {
+			return first <= last ? static_cast<size_t>(ix - first) : static_cast<size_t>(first - ix);
+		}
+
+		template<typename ...Args, index_type ...ixs>
+		static constexpr underlying_type make_underlying(std::integer_sequence<index_type, ixs...>, Args &&...args) noexcept((std::is_nothrow_constructible_v<value_type<ixs>, decltype(args)...> && ...)) {
+			return underlying_type{value_type<ixs>{args...}...};
 		}
 
 	public:
-		template<integral_type I>
-		[[nodiscard]] constexpr Entry<I> &get() noexcept {
-			return std::get<calcPos<I>()>(count_tuple_);
+		constexpr integral_template_tuple() noexcept(std::is_nothrow_default_constructible_v<underlying_type>) = default;
+		constexpr integral_template_tuple(integral_template_tuple const &other) noexcept(std::is_nothrow_copy_constructible_v<underlying_type>) = default;
+		constexpr integral_template_tuple(integral_template_tuple &&other) noexcept(std::is_nothrow_move_constructible_v<underlying_type>) = default;
+		constexpr integral_template_tuple &operator=(integral_template_tuple const &other) noexcept(std::is_nothrow_copy_assignable_v<underlying_type>) = default;
+		constexpr integral_template_tuple &operator=(integral_template_tuple &&other) noexcept(std::is_nothrow_move_assignable_v<underlying_type>) = default;
+		constexpr ~integral_template_tuple() noexcept(std::is_nothrow_destructible_v<underlying_type>) = default;
+
+		template<typename ...Args>
+		explicit constexpr integral_template_tuple(Args &&...args) noexcept(std::is_nothrow_constructible_v<underlying_type, decltype(std::forward<Args>(args))...>)
+			: repr_{std::forward<Args>(args)...} {
 		}
 
-		template<integral_type I>
-		[[nodiscard]] constexpr const Entry<I> &get() const noexcept {
-			return std::get<calcPos<I>()>(count_tuple_);
+		/**
+		 * Constructs the integral_template_tuple by providing each element with args...
+		 * @param args args to provide to each element for construction
+		 */
+		template<typename ...Args>
+		explicit constexpr integral_template_tuple(individual_construct_t, Args &&...args) noexcept(noexcept(make_underlying(itt_detail::make_integer_sequence<index_type, first, last>(), std::forward<Args>(args)...)))
+			: repr_{make_underlying(itt_detail::make_integer_sequence<index_type, first, last>(), std::forward<Args>(args)...)} {
+		}
+
+		[[nodiscard]] static constexpr size_t size() noexcept {
+			return underlying_type::size;
+		}
+
+		template<index_type ix>
+		[[nodiscard]] constexpr value_type<ix> const &get() const & noexcept {
+			check_ix<ix>();
+			return repr_.template get<make_index<ix>()>();
+		}
+
+		template<index_type ix>
+		[[nodiscard]] constexpr value_type<ix> &get() & noexcept {
+			check_ix<ix>();
+			return repr_.template get<make_index<ix>()>();
+		}
+
+		template<index_type ix>
+		[[nodiscard]] constexpr value_type<ix> const &get() const && noexcept {
+			check_ix<ix>();
+			return std::move(repr_).template get<make_index<ix>()>();
+		}
+
+		template<index_type ix>
+		[[nodiscard]] constexpr value_type<ix> &get() && noexcept {
+			check_ix<ix>();
+			return std::move(repr_).template get<make_index<ix>()>();
+		}
+
+		/**
+		 * Visits each element using visitor
+		 *
+		 * @param visitor function to be called on each element
+		 * @return whatever the last invocation (on the last element) of visitor returned
+		 */
+		template<typename Visitor>
+		constexpr decltype(auto) visit(Visitor &&visitor) const & {
+			return underlying_type::visit(repr_, std::forward<Visitor>(visitor));
+		}
+
+		template<typename Visitor>
+		constexpr decltype(auto) visit(Visitor &&visitor) & {
+			return underlying_type::visit(repr_, std::forward<Visitor>(visitor));
+		}
+
+		template<typename Visitor>
+		constexpr decltype(auto) visit(Visitor &&visitor) const && {
+			return underlying_type::visit(std::move(repr_), std::forward<Visitor>(visitor));
+		}
+
+		template<typename Visitor>
+		constexpr decltype(auto) visit(Visitor &&visitor) && {
+			return underlying_type::visit(std::move(repr_), std::forward<Visitor>(visitor));
+		}
+
+		constexpr auto operator<=>(integral_template_tuple const &other) const noexcept = default;
+
+		/**
+		 * Returns a reference to the subtuple of this obtained by dropping every element T<IX> where IX not in first..new_last (inclusive)
+		 *
+		 * @tparam new_first new first value
+		 * @tparam new_last new last value
+		 * @return subtuple
+		 */
+		template<index_type new_first, index_type new_last>
+		constexpr integral_template_tuple<new_first, new_last, value_type> const &subtuple() const noexcept {
+			static_assert(first <= last ? (new_first >= first && new_last <= last) : (new_first <= first && new_last >= last),
+						  "Cannot add elements to a tuple by casting");
+
+			return *reinterpret_cast<integral_template_tuple<new_first, new_last, value_type> const *>(this);
+		}
+
+		/**
+		 * Returns a reference to the subtuple of this obtained by dropping every element T<IX> where IX not in first..new_last (inclusive)
+		 *
+		 * @tparam new_first new first value
+		 * @tparam new_last new last value
+		 * @return subtuple
+		 */
+		template<index_type new_first, index_type new_last>
+		constexpr integral_template_tuple<new_first, new_last, value_type> &subtuple() noexcept {
+			static_assert(first <= last ? (new_first >= first && new_last <= last) : (new_first <= first && new_last >= last),
+						  "Cannot add elements to a tuple by casting");
+
+			return *reinterpret_cast<integral_template_tuple<new_first, new_last, value_type> *>(this);
 		}
 	};
-	template<template<auto> typename entry_type_template, std::integral auto FIRST, std::integral auto LAST, typename... Args>
-	auto make_integral_template_tuple(Args &&...args) {
-		return integral_template_tuple<entry_type_template, FIRST, LAST, Args...>(std::forward<Args>(args)...);
-	}
 }// namespace dice::template_library
 
 #endif//HYPERTRIE_INTEGRALTEMPLATEDTUPLE_HPP

--- a/include/dice/template-library/integral_template_tuple.hpp
+++ b/include/dice/template-library/integral_template_tuple.hpp
@@ -26,7 +26,7 @@ namespace dice::template_library {
 		 * @tparam last the end integer
 		 */
 		template<std::integral Int, Int first, Int last, Int ...ixs>
-		consteval auto make_integer_sequence(std::integer_sequence<Int, ixs...> = {}) {
+		constexpr auto make_integer_sequence(std::integer_sequence<Int, ixs...> = {}) {
 			std::integer_sequence<Int, ixs..., first> const acc;
 
 			if constexpr (first == last) {
@@ -148,7 +148,7 @@ namespace dice::template_library {
 		 * Note: only callable in decltype context
 		 */
 		template<std::integral Int, Int first, Int last, template<Int> typename T>
-		consteval auto make_itt_type() {
+		auto make_itt_type() {
 			return make_itt_type_impl<Int, T>(make_integer_sequence<Int, first, last>());
 		}
 

--- a/include/dice/template-library/integral_template_tuple.hpp
+++ b/include/dice/template-library/integral_template_tuple.hpp
@@ -252,6 +252,17 @@ namespace dice::template_library {
 		 *
 		 * @param visitor function to be called on each element
 		 * @return whatever the last invocation (on the last element) of visitor returned
+		 *
+		 * @example
+		 * A typical use case for the return value would be accumulation of some value over all elements:
+		 *
+		 * @code
+		 * integral_template_tuple<1, 5, some_container_type> tup;
+		 *
+		 * auto combined_size = tup.visit([acc = 0ul](auto const &c) mutable {
+		 *     return acc += c.size();
+		 * });
+		 * @endcode
 		 */
 		template<typename Visitor>
 		constexpr decltype(auto) visit(Visitor &&visitor) const & {

--- a/include/dice/template-library/integral_template_tuple.hpp
+++ b/include/dice/template-library/integral_template_tuple.hpp
@@ -67,7 +67,9 @@ namespace dice::template_library {
 				: value_{std::forward<Arg>(arg)} {
 			}
 
-			constexpr auto operator<=>(struct_tuple_leaf const &other) const noexcept = default;
+			constexpr auto operator<=>(struct_tuple_leaf const &other) const noexcept requires requires (T const &value) { value <=> value; } {
+				return value_ <=> other.value_;
+			}
 		};
 
 		template<typename Markers, typename ...Ts>

--- a/include/dice/template-library/integral_template_variant.hpp
+++ b/include/dice/template-library/integral_template_variant.hpp
@@ -32,7 +32,7 @@ namespace dice::template_library {
 
 		/**
 		 * Generates the actual std::variant type
-		 * for an IntegralTemplatedTuple<first, last, T> where Ixs = 0, 1, ..., last - first
+		 * for an integral_template_variant<first, last, T> where Ixs = 0, 1, ..., last - first
 		 * aka std::variant<T<first + 0>, T<first + 1>, ...>.
 		 *
 		 * Note: This function does not have an implementation because it is only used in decltype context.

--- a/include/dice/template-library/integral_template_variant.hpp
+++ b/include/dice/template-library/integral_template_variant.hpp
@@ -18,7 +18,7 @@ namespace dice::template_library {
 		 * @tparam last the end integer
 		 */
 		template<std::integral Int, Int first, Int last, Int ... ixs>
-		consteval auto make_integer_sequence(std::integer_sequence<Int, ixs...> = {}) {
+		constexpr auto make_integer_sequence(std::integer_sequence<Int, ixs...> = {}) {
 			std::integer_sequence<Int, ixs..., first> const acc;
 
 			if constexpr (first == last) {
@@ -47,7 +47,7 @@ namespace dice::template_library {
 		 * Note: only callable in decltype context
 		 */
 		template<std::integral Int, Int first, Int last, template<Int> typename T>
-		consteval auto make_itv_type() {
+		auto make_itv_type() {
 			return make_itv_type_impl<Int, T>(make_integer_sequence<Int, first, last>());
 		}
 

--- a/include/dice/template-library/integral_template_variant.hpp
+++ b/include/dice/template-library/integral_template_variant.hpp
@@ -9,135 +9,180 @@
 namespace dice::template_library {
 
 	namespace itv_detail {
-
 		/**
-		 * generates the std::integer_sequence<Int, FIRST, ..., LAST>
-		 * @note FIRST is allowed to be greater than LAST
+		 * generates the std::integer_sequence<Int, first, ..., last>
+		 * @note first is allowed to be greater than last
 		 *
 		 * @tparam Int the integral type of the std::integer_sequence
-		 * @tparam FIRST the starting integer
-		 * @tparam LAST the end integer
+		 * @tparam first the starting integer
+		 * @tparam last the end integer
 		 */
-		template<typename Int, Int FIRST, Int LAST, Int ...IXS>
-		consteval auto make_integer_sequence(std::integer_sequence<Int, IXS...> = {}) {
-			std::integer_sequence<Int, IXS..., FIRST> const acc;
+		template<std::integral Int, Int first, Int last, Int ... ixs>
+		consteval auto make_integer_sequence(std::integer_sequence<Int, ixs...> = {}) {
+			std::integer_sequence<Int, ixs..., first> const acc;
 
-			if constexpr (FIRST == LAST) {
+			if constexpr (first == last) {
 				return acc;
-			} else if constexpr (FIRST < LAST) {
-				return make_integer_sequence<Int, FIRST + 1, LAST>(acc);
+			} else if constexpr (first < last) {
+				return make_integer_sequence<Int, first + 1, last>(acc);
 			} else {
-				return make_integer_sequence<Int, FIRST - 1, LAST>(acc);
+				return make_integer_sequence<Int, first - 1, last>(acc);
 			}
 		}
 
 		/**
 		 * Generates the actual std::variant type
-		 * for an IntegralTemplatedTuple<FIRST, LAST, T> where Ixs = 0, 1, ..., LAST - FIRST
-		 * aka std::variant<T<FIRST + 0>, T<FIRST + 1>, ...>.
+		 * for an IntegralTemplatedTuple<first, last, T> where Ixs = 0, 1, ..., last - first
+		 * aka std::variant<T<first + 0>, T<first + 1>, ...>.
 		 *
 		 * Note: This function does not have an implementation because it is only used in decltype context.
 		 */
-		template<template<std::integral auto> typename T, typename Int, Int ...IXS>
-		std::variant<T<IXS>...> make_itv_type_impl(std::integer_sequence<Int, IXS...>);
+		template<std::integral Int, template<Int> typename T, Int ...ixs>
+		std::variant<T<ixs>...> make_itv_type_impl(std::integer_sequence<Int, ixs...>);
 
 		/**
 		 * Generates the std::variant type corresponding to
-		 * integral_template_variant<FIRST, LAST, T> by calling make_itv_type_impl with the correct index_sequence.
+		 * integral_template_variant<first, last, T> by calling make_itv_type_impl with the correct index_sequence.
 		 *
 		 * Note: only callable in decltype context
 		 */
-		template<std::integral auto FIRST, std::integral auto LAST, template<std::integral auto> typename T>
+		template<std::integral Int, Int first, Int last, template<Int> typename T>
 		consteval auto make_itv_type() {
-			using integral_t = std::common_type_t<decltype(FIRST), decltype(LAST)>;
-			return make_itv_type_impl<T>(make_integer_sequence<integral_t, FIRST, LAST>());
+			return make_itv_type_impl<Int, T>(make_integer_sequence<Int, first, last>());
 		}
 
-		template<std::integral auto Min, std::integral auto Max, template<std::integral auto> typename T>
-		using itv_type_t = std::invoke_result_t<decltype(make_itv_type<Min, Max, T>)>;
+		template<std::integral Int, Int first, Int last, template<Int> typename T>
+		using itv_type_t = std::invoke_result_t<decltype(make_itv_type<Int, first, last, T>)>;
 	} // namespace itv_detail
 
 	/**
-	 * A wrapper type for std::variant guarantees to only contain variants
-	 * of the form T<IX>. Where IX is in FIRST..LAST (inclusive).
+	 * A std::variant-like type that holds variants of T<first> .. T<last> (inclusive)
 	 *
-	 * @tparam FIRST the first IX for T<IX>
-	 * @tparam LAST the last IX for T<IX>
-	 * @tparam T the template that gets instantiated with T<IX> for IX in FIRST..LAST (inclusive)
+	 * @tparam first the first ix for T<ix>
+	 * @tparam last the last ix for T<ix>
+	 * @tparam T the template that gets instantiated with T<ix> for ix in first..last (inclusive)
+	 *
+	 * @note first is allowed to be smaller than last.
 	 */
-	template<template<std::integral auto> typename T, std::integral auto FIRST, std::integral auto LAST>
+	template<std::integral auto first, decltype(first) last, template<decltype(first)> typename T>
 	struct integral_template_variant {
-		static constexpr std::integral auto MIN = std::min(FIRST, LAST);
-		static constexpr std::integral auto MAX = std::max(FIRST, LAST);
+		using index_type = decltype(first);
 
-		template<std::integral auto IX>
-		using value_type = T<IX>;
+		template<index_type ix>
+		using value_type = T<ix>;
 
 	private:
-		using variant_t = itv_detail::itv_type_t<MIN, MAX, T>;
-		variant_t repr;
+		using underlying_type = itv_detail::itv_type_t<index_type, first, last, T>;
+		underlying_type repr_;
 
-		template<std::integral auto IX>
+		template<index_type ix>
 		static consteval void check_ix() {
-			static_assert(IX >= MIN && IX <= MAX, "Index out of range");
+			static_assert(ix >= std::min(first, last) && ix <= std::max(first, last), "Index out of range");
 		}
 
 	public:
-		constexpr integral_template_variant(integral_template_variant const &other) = default;
-		constexpr integral_template_variant(integral_template_variant &&other) = default;
-		constexpr integral_template_variant &operator=(integral_template_variant const &other) = default;
-		constexpr integral_template_variant &operator=(integral_template_variant &&other) = default;
+		constexpr integral_template_variant() noexcept(std::is_nothrow_default_constructible_v<underlying_type>) = default;
+		constexpr integral_template_variant(integral_template_variant const &other) noexcept(std::is_copy_constructible_v<underlying_type>) = default;
+		constexpr integral_template_variant(integral_template_variant &&other) noexcept(std::is_nothrow_move_constructible_v<underlying_type>) = default;
+		constexpr integral_template_variant &operator=(integral_template_variant const &other) noexcept(std::is_nothrow_copy_assignable_v<underlying_type>) = default;
+		constexpr integral_template_variant &operator=(integral_template_variant &&other) noexcept(std::is_nothrow_move_assignable_v<underlying_type>) = default;
+		constexpr ~integral_template_variant() noexcept(std::is_nothrow_destructible_v<underlying_type>) = default;
 
-		template<std::integral auto IX>
-		constexpr integral_template_variant(T<IX> const &value) noexcept(std::is_nothrow_copy_constructible_v<T<IX>>)
-			: repr{value} {
-			check_ix<IX>();
+		template<index_type ix>
+		constexpr integral_template_variant(T<ix> const &value) noexcept(std::is_nothrow_copy_constructible_v<T<ix>>)
+			: repr_{value} {
+			check_ix<ix>();
 		}
 
-		template<std::integral auto IX>
-		constexpr integral_template_variant(T<IX> &&value) noexcept(std::is_nothrow_move_constructible_v<T<IX>>)
-			: repr{std::move(value)} {
-			check_ix<IX>();
+		template<index_type ix>
+		constexpr integral_template_variant(T<ix> &&value) noexcept(std::is_nothrow_move_constructible_v<T<ix>>)
+			: repr_{std::move(value)} {
+			check_ix<ix>();
 		}
 
 		template<typename U, typename ...Args>
-		explicit constexpr integral_template_variant(std::in_place_type_t<U>, Args &&...args)
-			: repr{std::in_place_type<U>, std::forward<Args>(args)...} {
+		explicit constexpr integral_template_variant(std::in_place_type_t<U>, Args &&...args) noexcept(std::is_nothrow_constructible_v<U, decltype(std::forward<Args>(args))...>)
+			: repr_{std::in_place_type<U>, std::forward<Args>(args)...} {
 		}
 
-		template<std::integral auto IX>
-		friend constexpr T<IX> &get(integral_template_variant &variant) {
-			check_ix<IX>();
-			return std::get<T<IX>>(variant.repr);
+		[[nodiscard]] static constexpr size_t size() noexcept {
+			return std::variant_size_v<underlying_type>;
 		}
 
-		template<std::integral auto IX>
-		friend constexpr T<IX> const &get(integral_template_variant const &variant) {
-			check_ix<IX>();
-			return std::get<T<IX>>(variant.repr);
+		[[nodiscard]] constexpr index_type index() const noexcept {
+			if constexpr (first < last) {
+				return first + static_cast<index_type>(repr_.index());
+			} else {
+				return first - static_cast<index_type>(repr_.index());
+			}
 		}
 
-		template<std::integral auto IX>
-		friend constexpr T<IX> &&get(integral_template_variant &&variant) {
-			check_ix<IX>();
-			return std::get<T<IX>>(std::move(variant.repr));
+		template<index_type ix>
+		constexpr value_type<ix> const &get() const & {
+			check_ix<ix>();
+			return std::get<T<ix>>(repr_);
 		}
 
-		template<std::integral auto IX>
-		friend constexpr T<IX> const &&get(integral_template_variant const &&variant) {
-			check_ix<IX>();
-			return std::get<T<IX>>(static_cast<variant_t const &&>(variant.repr));
+		template<index_type ix>
+		constexpr value_type<ix> &get() & {
+			check_ix<ix>();
+			return std::get<T<ix>>(repr_);
 		}
 
-		template<typename Visitor, typename ...ITVariants>
-		friend constexpr decltype(auto) visit(Visitor &&visitor, ITVariants &&...vars);
+		template<index_type ix>
+		constexpr value_type<ix> const &&get() const && {
+			check_ix<ix>();
+			return std::get<T<ix>>(std::move(repr_));
+		}
+
+		template<index_type ix>
+		constexpr value_type<ix> &&get() && {
+			check_ix<ix>();
+			return std::get<T<ix>>(std::move(repr_));
+		}
+
+		template<typename Visitor>
+		constexpr decltype(auto) visit(Visitor &&visitor) & {
+			return std::visit(std::forward<Visitor>(visitor), repr_);
+		}
+
+		template<typename Visitor>
+		constexpr decltype(auto) visit(Visitor &&visitor) const & {
+			return std::visit(std::forward<Visitor>(visitor), repr_);
+		}
+
+		template<typename Visitor>
+		constexpr decltype(auto) visit(Visitor &&visitor) && {
+			return std::visit(std::forward<Visitor>(visitor), std::move(repr_));
+		}
+
+		template<typename Visitor>
+		constexpr decltype(auto) visit(Visitor &&visitor) const && {
+			return std::visit(std::forward<Visitor>(visitor), std::move(repr_));
+		}
+
+		constexpr auto operator<=>(integral_template_variant const &other) const noexcept = default;
 	};
 
-	template<typename Visitor, typename ...ITVariants>
-	constexpr decltype(auto) visit(Visitor &&visitor, ITVariants &&...vars) {
-		return std::visit(std::forward<Visitor>(visitor), std::forward<ITVariants>(vars).repr...);
+	template<std::integral auto index, decltype(index) first, decltype(index) last, template<decltype(index)> typename T>
+	constexpr bool holds_alternative(integral_template_variant<first, last, T> const &variant) noexcept {
+		return std::holds_alternative<T<index>>(variant.to_underlying());
 	}
 
+	template<typename U, std::integral auto first, decltype(first) last, template<decltype(first)> typename T>
+	constexpr bool holds_alternative(integral_template_variant<first, last, T> const &variant) noexcept {
+		return std::holds_alternative<U>(variant.to_underlying());
+	}
 } // namespace dice::template_library
+
+namespace std {
+	template<integral auto first, decltype(first) last, template<decltype(first)> typename T>
+	struct hash<::dice::template_library::integral_template_variant<first, last, T>> {
+		[[nodiscard]] size_t operator()(::dice::template_library::integral_template_variant<first, last, T> const &variant) const noexcept {
+			using underlying_type = typename ::dice::template_library::integral_template_variant<first, last, T>::underlying_type;
+			return hash<underlying_type>{}(variant.to_underlying());
+		}
+	};
+} // namespace std
 
 #endif//DICE_TEMPLATE_LIBRARY_INTEGRAL_TEMPLATE_VARIANT_HPP

--- a/tests/tests_integral_template_tuple.cpp
+++ b/tests/tests_integral_template_tuple.cpp
@@ -108,8 +108,8 @@ namespace dice::template_library {
 														   std::tuple<double, int>,
 														   float>;
 
-			static constexpr example_tuple example_tuple_v{};
-			static constexpr example_struct example_struct_v{};
+			example_tuple example_tuple_v{};
+			example_struct example_struct_v{};
 
 			auto const offset = [](void const *base, void const *member) -> size_t {
 				return reinterpret_cast<std::byte const *>(base) - reinterpret_cast<std::byte const *>(member);

--- a/tests/tests_integral_template_tuple.cpp
+++ b/tests/tests_integral_template_tuple.cpp
@@ -196,7 +196,7 @@ namespace dice::template_library {
 		TEST_CASE("reinterpret_cast counting up") {
 			integral_template_tuple<0, 3, Data> inTuple;
 			// NOLINTNEXTLINE
-			auto &casted = inTuple.template subtuple<1, 2>();
+			integral_template_tuple<1, 2, Data> &casted = inTuple.template subtuple<1, 2>();
 			auto vec = to_int_vector<1, 2>(casted);
 			REQUIRE(is_equal(vec, {1, 2}));
 		}
@@ -204,7 +204,7 @@ namespace dice::template_library {
 		TEST_CASE("reinterpret_cast counting down") {
 			integral_template_tuple<3, 0, Data> inTuple;
 			// NOLINTNEXTLINE
-			auto &casted = inTuple.template subtuple<2, 1>();
+			integral_template_tuple<2, 1, Data> &casted = inTuple.template subtuple<2, 1>();
 			auto vec = to_int_vector<1, 2>(casted);
 			REQUIRE(is_equal(vec, {1, 2}));
 		}
@@ -212,7 +212,7 @@ namespace dice::template_library {
 		TEST_CASE("reinterpret_cast counting up from negative") {
 			integral_template_tuple<-1, 3, Data> inTuple;
 			// NOLINTNEXTLINE
-			auto &casted = inTuple.template subtuple<0, 2>();
+			integral_template_tuple<0, 2, Data> &casted = inTuple.template subtuple<0, 2>();
 			auto vec = to_int_vector<0, 2>(casted);
 			REQUIRE(is_equal(vec, {0, 1, 2}));
 		}
@@ -220,7 +220,7 @@ namespace dice::template_library {
 		TEST_CASE("reinterpret_cast counting down into negative") {
 			integral_template_tuple<3, -2, Data> inTuple;
 			// NOLINTNEXTLINE
-			auto &casted = inTuple.template subtuple<2, -1>();
+			integral_template_tuple<2, -1, Data> &casted = inTuple.template subtuple<2, -1>();
 			auto vec = to_int_vector<-1, 2>(casted);
 			REQUIRE(is_equal(vec, {-1, 0, 1, 2}));
 		}

--- a/tests/tests_integral_template_tuple.cpp
+++ b/tests/tests_integral_template_tuple.cpp
@@ -65,7 +65,9 @@ namespace dice::template_library {
 		explicit Data(int value) : value_{value} {}
 
 		operator int() const { return static_cast<int>(N); }
-		constexpr auto operator<=>(Data const &other) const noexcept = default;
+		auto operator<=>(Data const &other) const noexcept {
+			return value_ <=> other.value_;
+		}
 	};
 
 	TEST_SUITE("checking test utilities") {

--- a/tests/tests_integral_template_variant.cpp
+++ b/tests/tests_integral_template_variant.cpp
@@ -39,115 +39,131 @@ namespace dice::template_library {
 
 	TEST_SUITE("integral_template_variant") {
 		TEST_CASE("asc pos") {
-			integral_template_variant<Data, 2, 7> itv{Data<5>{}};
-			integral_template_variant<Data, 2, 7> lower{Data<2>{}};
-			integral_template_variant<Data, 2, 7> upper{Data<7>{}};
+			integral_template_variant<2, 7, Data> itv{Data<5>{}};
+			integral_template_variant<2, 7, Data> lower{Data<2>{}};
+			integral_template_variant<2, 7, Data> upper{Data<7>{}};
 
-			CHECK(get<5>(itv) == 5);
-			CHECK(get<2>(lower) == 2);
-			CHECK(get<7>(upper) == 7);
+			CHECK(itv.index() == 5);
+			CHECK(lower.index() == 2);
+			CHECK(upper.index() == 7);
 
-			visit([]<auto N>(Data<N> const &) {
+			CHECK(itv.template get<5>() == 5);
+			CHECK(lower.template get<2>() == 2);
+			CHECK(upper.template get<7>() == 7);
+
+			itv.visit([]<auto N>(Data<N> const &) {
 				CHECK(N == 5);
-			}, itv);
+			});
 
-			visit([]<auto N>(Data<N> const &) {
+			lower.visit([]<auto N>(Data<N> const &) {
 				CHECK(N == 2);
-			}, lower);
+			});
 
-			visit([]<auto N>(Data<N> const &) {
+			upper.visit([]<auto N>(Data<N> const &) {
 				CHECK(N == 7);
-			}, upper);
+			});
 		}
 
 		TEST_CASE("desc pos") {
-			integral_template_variant<Data, 5, 1> itv{Data<3>{}};
-			integral_template_variant<Data, 5, 1> lower{Data<5>{}};
-			integral_template_variant<Data, 5, 1> upper{Data<1>{}};
+			integral_template_variant<5, 1, Data> itv{Data<3>{}};
+			integral_template_variant<5, 1, Data> lower{Data<5>{}};
+			integral_template_variant<5, 1, Data> upper{Data<1>{}};
 
-			CHECK(get<3>(itv) == 3);
-			CHECK(get<5>(lower) == 5);
-			CHECK(get<1>(upper) == 1);
+			CHECK(itv.index() == 3);
+			CHECK(lower.index() == 5);
+			CHECK(upper.index() == 1);
 
-			visit([]<auto N>(Data<N> const &) {
+			CHECK(itv.template get<3>() == 3);
+			CHECK(lower.template get<5>() == 5);
+			CHECK(upper.template get<1>() == 1);
+
+			itv.visit([]<auto N>(Data<N> const &) {
 				CHECK(N == 3);
-			}, itv);
+			});
 
-			visit([]<auto N>(Data<N> const &) {
+			lower.visit([]<auto N>(Data<N> const &) {
 				CHECK(N == 5);
-			}, lower);
+			});
 
-			visit([]<auto N>(Data<N> const &) {
+			upper.visit([]<auto N>(Data<N> const &) {
 				CHECK(N == 1);
-			}, upper);
+			});
 		}
 
 		TEST_CASE("asc neg") {
-			integral_template_variant<Data, -6, -1> itv{Data<-3>{}};
-			integral_template_variant<Data, -6, -1> lower{Data<-6>{}};
-			integral_template_variant<Data, -6, -1> upper{Data<-1>{}};
+			integral_template_variant<-6, -1, Data> itv{Data<-3>{}};
+			integral_template_variant<-6, -1, Data> lower{Data<-6>{}};
+			integral_template_variant<-6, -1, Data> upper{Data<-1>{}};
 
-			CHECK(get<-3>(itv) == -3);
-			CHECK(get<-6>(lower) == -6);
-			CHECK(get<-1>(upper) == -1);
+			CHECK(itv.index() == -3);
+			CHECK(lower.index() == -6);
+			CHECK(upper.index() == -1);
 
-			visit([]<auto N>(Data<N> const &) {
+			CHECK(itv.template get<-3>() == -3);
+			CHECK(lower.template get<-6>() == -6);
+			CHECK(upper.template get<-1>() == -1);
+
+			itv.visit([]<auto N>(Data<N> const &) {
 				CHECK(N == -3);
-			}, itv);
+			});
 
-			visit([]<auto N>(Data<N> const &) {
+			lower.visit([]<auto N>(Data<N> const &) {
 				CHECK(N == -6);
-			}, lower);
+			});
 
-			visit([]<auto N>(Data<N> const &) {
+			upper.visit([]<auto N>(Data<N> const &) {
 				CHECK(N == -1);
-			}, upper);
+			});
 		}
 
 		TEST_CASE("desc pos") {
-			integral_template_variant<Data, -2, -8> itv{Data<-5>{}};
-			integral_template_variant<Data, -2, -8> lower{Data<-2>{}};
-			integral_template_variant<Data, -2, -8> upper{Data<-8>{}};
+			integral_template_variant<-2, -8, Data> itv{Data<-5>{}};
+			integral_template_variant<-2, -8, Data> lower{Data<-2>{}};
+			integral_template_variant<-2, -8, Data> upper{Data<-8>{}};
 
-			CHECK(get<-5>(itv) == -5);
-			CHECK(get<-2>(lower) == -2);
-			CHECK(get<-8>(upper) == -8);
+			CHECK(itv.index() == -5);
+			CHECK(lower.index() == -2);
+			CHECK(upper.index() == -8);
 
-			visit([]<auto N>(Data<N> const &) {
+			CHECK(itv.template get<-5>() == -5);
+			CHECK(lower.template get<-2>() == -2);
+			CHECK(upper.template get<-8>() == -8);
+
+			itv.visit([]<auto N>(Data<N> const &) {
 				CHECK(N == -5);
-			}, itv);
+			});
 
-			visit([]<auto N>(Data<N> const &) {
+			lower.visit([]<auto N>(Data<N> const &) {
 				CHECK(N == -2);
-			}, lower);
+			});
 
-			visit([]<auto N>(Data<N> const &) {
+			upper.visit([]<auto N>(Data<N> const &) {
 				CHECK(N == -8);
-			}, upper);
+			});
 		}
 
 		TEST_CASE("single entry") {
-			integral_template_variant<Data, 0, 0> itv{Data<0>{}};
-			CHECK(get<0>(itv) == 0);
+			integral_template_variant<0, 0, Data> itv{Data<0>{}};
+			CHECK(itv.template get<0>() == 0);
 		}
 
 		TEST_CASE("in place construction") {
-			integral_template_variant<CompoundData, 0, 2> itv{std::in_place_type<CompoundData<1>>, 2.0, 3.f, 5};
-			CHECK(get<1>(itv) == 1 + 2 + 3 + 5);
+			integral_template_variant<0, 2, CompoundData> itv{std::in_place_type<CompoundData<1>>, 2.0, 3.f, 5};
+			CHECK(itv.template get<1>() == 1 + 2 + 3 + 5);
 		}
 
 		TEST_CASE("visit forwarding") {
-			integral_template_variant<Data, 1, 1> const copyable{std::in_place_type<Data<1>>};
+			integral_template_variant<1, 1, Data> const copyable{std::in_place_type<Data<1>>};
 
-			visit([](auto &&x) {
+			copyable.visit([](auto &&x) {
 				call_counted(std::forward<decltype(x)>(x));
-			}, copyable);
+			});
 
-			integral_template_variant<Data, 1, 1> movable{std::in_place_type<Data<1>>};
+			integral_template_variant<1, 1, Data> movable{std::in_place_type<Data<1>>};
 
-			visit([](auto &&x) {
+			std::move(movable).visit([](auto &&x) {
 				call_counted(std::forward<decltype(x)>(x));
-			}, std::move(movable));
+			});
 		}
 	}
 


### PR DESCRIPTION
This PR addresses a few problems of the library and adds some missing features.

1. unifies interface of `intergral_template_tuple` and `integral_template_variant`
2. Fixes the weirdness that was specifiying additional constructor arguments in the _type_ of `integral_template_tuple`
3. Fixes some ADL related bugs that made it impossible to call functions of `integral_templated_variant`
4. Fixes the UB source that is relying on `std::tuple`'s being layout equivalent to a struct
5. Adds some missing convenience functionality
6. All functions and structs now instantiate the user's callables and structs with exactly the types they want (and not just always `uintmax_t`/`intmax_t`)
7. moved the `reinterpret_cast`ing of `integral_template_tuple` into a function
8. some general code cleanup

This PR does break existing code:
1. if it relies on the previous behaviour of integer selection
2. the template parameter order of `integral_template_variant` and `integral_template_tuple` changed (because it had to)