### PR TITLE
Feature/poly alloc cmake version fix

### DIFF
--- a/.github/workflows/code_testing.yaml
+++ b/.github/workflows/code_testing.yaml
@@ -43,9 +43,9 @@ jobs:
           sudo apt-get update -y
 
       - name: Install CMake
-        uses: lukka/get-cmake@v3.24.3
+        uses: lukka/get-cmake@v3.27
         with:
-          cmakeVersion: 3.16.9
+          cmakeVersion: 3.25.3
 
       - name: Install compiler
         id: install_cc

--- a/.github/workflows/code_testing.yaml
+++ b/.github/workflows/code_testing.yaml
@@ -43,7 +43,7 @@ jobs:
           sudo apt-get update -y
 
       - name: Install CMake
-        uses: lukka/get-cmake@v3.27
+        uses: lukka/get-cmake@vv3.27.0
         with:
           cmakeVersion: 3.25.3
 

--- a/.github/workflows/code_testing.yaml
+++ b/.github/workflows/code_testing.yaml
@@ -43,7 +43,7 @@ jobs:
           sudo apt-get update -y
 
       - name: Install CMake
-        uses: lukka/get-cmake@vv3.27.0
+        uses: lukka/get-cmake@v3.27.0
         with:
           cmakeVersion: 3.25.3
 

--- a/.github/workflows/publish-conan-branch-package.yml
+++ b/.github/workflows/publish-conan-branch-package.yml
@@ -13,7 +13,7 @@ jobs:
       public_artifactory: true
       os: ubuntu-22.04
       compiler: clang-14
-      cmake-version: 3.22.6
+      cmake-version: 3.25.3
       conan-version: 1.59
     secrets:
       CONAN_USER: ${{ secrets.CONAN_USER }}

--- a/.github/workflows/publish-conan-branch-package.yml
+++ b/.github/workflows/publish-conan-branch-package.yml
@@ -14,7 +14,7 @@ jobs:
       os: ubuntu-22.04
       compiler: clang-14
       cmake-version: 3.25.3
-      conan-version: 1.59
+      conan-version: 1.60.1
     secrets:
       CONAN_USER: ${{ secrets.CONAN_USER }}
       CONAN_PW: ${{ secrets.CONAN_PW }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,7 +18,7 @@ jobs:
       public_artifactory: true
       os: ubuntu-22.04
       compiler: clang-14
-      cmake-version: 3.22.6
+      cmake-version: 3.25.3
       conan-version: 1.59
     secrets:
       CONAN_USER: ${{ secrets.CONAN_USER }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.25)
 
 project(
   dice-template-library

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.25)
 project(test_package)
 
 find_package(dice-template-library REQUIRED)


### PR DESCRIPTION
updating the cmake version should help finding the updated boost package v1.81

see: https://stackoverflow.com/questions/42123509/cmake-finds-boost-but-the-imported-targets-not-available-for-boost-version