### PR TITLE
Fix: packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,50 +79,11 @@ environment_run.sh.env
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
-# User-specific stuff
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
-.idea/**/dictionaries
-.idea/**/shelf
-
-# AWS User-specific
-.idea/**/aws.xml
-
-# Generated files
-.idea/**/contentModel.xml
-
-# Sensitive or high-churn files
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-.idea/**/dbnavigator.xml
-
-# Gradle
-.idea/**/gradle.xml
-.idea/**/libraries
-
-# Gradle and Maven with auto-import
-# When using Gradle or Maven with auto-import, you should exclude module files,
-# since they will be recreated, and may cause churn.  Uncomment if using
-# auto-import.
-# .idea/artifacts
-# .idea/compiler.xml
-# .idea/jarRepositories.xml
-# .idea/modules.xml
-# .idea/*.iml
-# .idea/modules
-# *.iml
-# *.ipr
+.idea/
 
 # CMake
 cmake-build-*/
 
-# Mongo Explorer plugin
-.idea/**/mongoSettings.xml
 
 # File-based project format
 *.iws
@@ -136,32 +97,11 @@ out/
 # JIRA plugin
 atlassian-ide-plugin.xml
 
-# Cursive Clojure plugin
-.idea/replstate.xml
-
-# SonarLint plugin
-.idea/sonarlint/
-
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
-
-# Editor-based Rest Client
-.idea/httpRequests
-
-# Android studio 3.1+ serialized cache file
-.idea/caches/build_file_checksums.ser
-
-### Intellij+all Patch ###
-# Ignore everything but code style settings and run configurations
-# that are supposed to be shared within teams.
-
-.idea/*
-
-!.idea/codeStyles
-!.idea/runConfigurations
 
 ### Ninja ###
 .ninja_deps

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,13 +26,8 @@ if (PROJECT_IS_TOP_LEVEL AND USE_CONAN)
       set(DICE_TEMPLATE_LIB_CONAN_WITH_BOOST "False")
   endif ()
 
-  set(CONAN_OPTIONS "with_boost=${DICE_TEMPLATE_LIB_CONAN_WITH_BOOST}")
+  set(CONAN_OPTIONS "with_boost=${DICE_TEMPLATE_LIB_CONAN_WITH_BOOST};boost:header_only=True")
   install_packages_via_conan("${CMAKE_SOURCE_DIR}/conanfile.py" "${CONAN_OPTIONS}")
-endif ()
-
-if (WITH_BOOST)
-  find_package(Boost REQUIRED COMPONENTS)
-  set(DICE_TEMPLATE_LIB_BOOST_DEP "Boost::headers")
 endif ()
 
 add_library(${PROJECT_NAME} INTERFACE)
@@ -42,19 +37,18 @@ target_include_directories(${PROJECT_NAME} INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         )
 
-target_link_libraries(${PROJECT_NAME} INTERFACE
-        ${DICE_TEMPLATE_LIB_BOOST_DEP}
-        )
+if (WITH_BOOST)
+    find_package(Boost REQUIRED COMPONENTS)
+    target_link_libraries(${PROJECT_NAME} INTERFACE
+            Boost::headers
+            )
+endif ()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
         CXX_STANDARD 20
         CXX_EXTENSIONS OFF
         CXX_STANDARD_REQUIRED ON
         )
-
-if (WITH_BOOST)
-  target_compile_definitions(${PROJECT_NAME} INTERFACE DICE_TEMPLATE_LIBRARY_WITH_BOOST=1)
-endif ()
 
 include(cmake/install_interface_library.cmake)
 install_interface_library(${PROJECT_NAME} ${PROJECT_NAME} ${PROJECT_NAME} "include")

--- a/examples/examples_polymorphic_allocator.cpp
+++ b/examples/examples_polymorphic_allocator.cpp
@@ -1,4 +1,5 @@
 #include <dice/template-library/polymorphic_allocator.hpp>
+#include <dice/template-library/offset_ptr_stl_allocator.hpp>
 
 #include <boost/interprocess/allocators/allocator.hpp>
 #include <boost/interprocess/containers/vector.hpp>

--- a/include/dice/template-library/offset_ptr_stl_allocator.hpp
+++ b/include/dice/template-library/offset_ptr_stl_allocator.hpp
@@ -1,6 +1,7 @@
 #ifndef DICE_TEMPLATE_LIBRARY_OFFSETPTRSTLALLOCATOR_HPP
 #define DICE_TEMPLATE_LIBRARY_OFFSETPTRSTLALLOCATOR_HPP
 
+#include <memory>
 #include <boost/interprocess/offset_ptr.hpp>
 
 namespace dice::template_library {

--- a/include/dice/template-library/offset_ptr_stl_allocator.hpp
+++ b/include/dice/template-library/offset_ptr_stl_allocator.hpp
@@ -1,0 +1,40 @@
+#ifndef DICE_TEMPLATE_LIBRARY_OFFSETPTRSTLALLOCATOR_HPP
+#define DICE_TEMPLATE_LIBRARY_OFFSETPTRSTLALLOCATOR_HPP
+
+#include <boost/interprocess/offset_ptr.hpp>
+
+namespace dice::template_library {
+
+	/**
+	 * @brief Basically std::allocator but returning boost::interprocess::offset_ptr
+	 * @tparam T type to allocate
+	 */
+	template<typename T>
+	struct offset_ptr_stl_allocator : std::allocator<T> {
+		using value_type = T;
+		using pointer = boost::interprocess::offset_ptr<T>;
+		using size_type = size_t;
+		using difference_type = std::ptrdiff_t;
+
+		using propagate_on_container_copy_assignment = typename std::allocator_traits<std::allocator<T>>::propagate_on_container_copy_assignment;
+		using propagate_on_container_move_assignment = typename std::allocator_traits<std::allocator<T>>::propagate_on_container_move_assignment;
+		using propagate_on_container_swap = typename std::allocator_traits<std::allocator<T>>::propagate_on_container_swap;
+		using is_always_equal = typename std::allocator_traits<std::allocator<T>>::is_always_equal;
+
+		constexpr offset_ptr_stl_allocator() noexcept = default;
+
+		template<typename U>
+		constexpr offset_ptr_stl_allocator(offset_ptr_stl_allocator<U> const &) noexcept {}
+
+		constexpr pointer allocate(size_t n) {
+			return pointer{std::allocator<T>::allocate(n)};
+		}
+
+		constexpr void deallocate(pointer ptr, size_t n) {
+			return std::allocator<T>::deallocate(std::to_address(ptr), n);
+		}
+	};
+
+} // namespace dice::template_library
+
+#endif//DICE_TEMPLATE_LIBRARY_OFFSETPTRSTLALLOCATOR_HPP

--- a/include/dice/template-library/polymorphic_allocator.hpp
+++ b/include/dice/template-library/polymorphic_allocator.hpp
@@ -2,6 +2,7 @@
 #define DICE_TEMPLATE_LIBRARY_POLYMORPHICALLOCATOR_HPP
 
 #include <cstddef>
+#include <memory>
 #include <utility>
 #include <variant>
 

--- a/include/dice/template-library/polymorphic_allocator.hpp
+++ b/include/dice/template-library/polymorphic_allocator.hpp
@@ -5,10 +5,6 @@
 #include <utility>
 #include <variant>
 
-#ifdef DICE_TEMPLATE_LIBRARY_WITH_BOOST
-#include <boost/interprocess/offset_ptr.hpp>
-#endif//DICE_TEMPLATE_LIBRARY_WITH_BOOST
-
 namespace dice::template_library {
 	namespace detail_pmr {
 		/**
@@ -195,39 +191,7 @@ namespace dice::template_library {
 			return std::holds_alternative<UAllocator<T>>(alloc_);
 		}
 	};
-
-#ifdef DICE_TEMPLATE_LIBRARY_WITH_BOOST
-	/**
-	 * @brief Basically std::allocator but returning boost::interprocess::offset_ptr
-	 * @tparam T type to allocate
-	 */
-	template<typename T>
-	struct offset_ptr_stl_allocator : std::allocator<T> {
-		using value_type = T;
-		using pointer = boost::interprocess::offset_ptr<T>;
-		using size_type = size_t;
-		using difference_type = std::ptrdiff_t;
-
-		using propagate_on_container_copy_assignment = typename std::allocator_traits<std::allocator<T>>::propagate_on_container_copy_assignment;
-		using propagate_on_container_move_assignment = typename std::allocator_traits<std::allocator<T>>::propagate_on_container_move_assignment;
-		using propagate_on_container_swap = typename std::allocator_traits<std::allocator<T>>::propagate_on_container_swap;
-		using is_always_equal = typename std::allocator_traits<std::allocator<T>>::is_always_equal;
-
-		constexpr offset_ptr_stl_allocator() noexcept = default;
-
-		template<typename U>
-		constexpr offset_ptr_stl_allocator(offset_ptr_stl_allocator<U> const &) noexcept {}
-
-		constexpr pointer allocate(size_t n) {
-			return pointer{std::allocator<T>::allocate(n)};
-		}
-
-		constexpr void deallocate(pointer ptr, size_t n) {
-			return std::allocator<T>::deallocate(std::to_address(ptr), n);
-		}
-	};
-#endif//DICE_TEMPLATE_LIBRARY_WITH_BOOST
-
+	
 }// namespace dice::template_library
 
 #endif//DICE_TEMPLATE_LIBRARY_POLYMORPHICALLOCATOR_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,9 +41,9 @@ add_executable(tests_for tests_for.cpp)
 custom_add_test(tests_for)
 
 add_executable(tests_polymorphic_allocator tests_polymorphic_allocator.cpp)
+custom_add_test(tests_polymorphic_allocator)
 
 if (WITH_BOOST)
-  target_compile_definitions(tests_polymorphic_allocator PRIVATE DICE_TEMPLATE_LIBRARY_WITH_BOOST=1)
+  add_executable(tests_offset_ptr_stl_allocator tests_offset_ptr_stl_allocator.cpp)
+  custom_add_test(tests_offset_ptr_stl_allocator)
 endif ()
-
-custom_add_test(tests_polymorphic_allocator)

--- a/tests/tests_offset_ptr_stl_allocator.cpp
+++ b/tests/tests_offset_ptr_stl_allocator.cpp
@@ -1,0 +1,16 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <dice/template-library/offset_ptr_stl_allocator.hpp>
+
+TEST_SUITE("offset_ptr_stl_allocator") {
+	TEST_CASE("sanity check") {
+		using alloc_t = dice::template_library::offset_ptr_stl_allocator<int>;
+
+		alloc_t alloc;
+		auto ptr = std::allocator_traits<alloc_t>::allocate(alloc, 1);
+		*ptr = 5;
+		CHECK(*ptr == 5);
+		std::allocator_traits<alloc_t>::deallocate(alloc, ptr, 1);
+	}
+}

--- a/tests/tests_polymorphic_allocator.cpp
+++ b/tests/tests_polymorphic_allocator.cpp
@@ -10,18 +10,6 @@ TEST_SUITE("polymorphic_allocator") {
 	template<typename T>
 	using poly_alloc_t = dice::template_library::polymorphic_allocator<T, std::allocator, std::pmr::polymorphic_allocator>;
 
-#ifdef DICE_TEMPLATE_LIBRARY_WITH_BOOST
-	TEST_CASE("offset_ptr_stl_allocator") {
-		using alloc_t = dice::template_library::offset_ptr_stl_allocator<int>;
-
-		alloc_t alloc;
-		auto ptr = std::allocator_traits<alloc_t>::allocate(alloc, 1);
-		*ptr = 5;
-		CHECK(*ptr == 5);
-		std::allocator_traits<alloc_t>::deallocate(alloc, ptr, 1);
-	}
-#endif//DICE_TEMPLATE_LIBRARY_WITH_BOOST
-
 	TEST_CASE("polymorphic alloc") {
 		SUBCASE("with default alloc") {
 			poly_alloc_t<int> alloc{};


### PR DESCRIPTION
Currently when using dice-template-library either as header only (by copying the sources) or through conan one needs
to manually define `#define DICE_TEMPLATE_LIBRARY_WITH_BOOST 1` if they want to be able to use `offset_ptr_stl_allocator` this is not ideal.

Moving it to a seperate file this fixes both of these use-cases.

This is technically a major version bump, I think, but the interface didn't change it just moved to a different file.