### PR TITLE
Feature: defer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It contains:
 - `integral_template_variant`: A wrapper type for `std::variant` guarantees to only contain variants of the form `T<ix>` where $\texttt{ix}\in [\texttt{first},\texttt{last}]$ (inclusive).
 - `for_{types,values,range}`: Compile time for loops for types, values or ranges
 - `polymorphic_allocator`: Like `std::pmr::polymorphic_allocator` but with static dispatch
-- `DEFER`/`DEFER_TO_SUCCES`/`DEFER_TO_FAIL`: On-the-fly RAII for types that do not support it natively (similar to go's defer keyword)
+- `DICE_DEFER`/`DICE_DEFER_TO_SUCCES`/`DICE_DEFER_TO_FAIL`: On-the-fly RAII for types that do not support it natively (similar to go's `defer` keyword)
 
 ## Usage
 
@@ -58,7 +58,7 @@ The problem with `mmap` allocations is that they will be placed at an arbitrary 
 therefore absolute pointers will cause segfaults if the segment is reloaded.
 Which means: vtables will not work (because they use absolute pointers) and therefore you cannot use `std::pmr::polymorphic_allocator`.
 
-### `DEFER`/`DEFER_TO_SUCCES`/`DEFER_TO_FAIL`
+### `DICE_DEFER`/`DICE_DEFER_TO_SUCCES`/`DICE_DEFER_TO_FAIL`
 A mechanism similar to go's `defer` keyword, which can be used to defer some action to scope exit.
 The primary use-case for this is on-the-fly RAII-like resource management for types that do not support RAII (for example C types).
 Usage examples can be found [here](examples/examples_defer.cpp).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ It contains:
 - `integral_template_variant`: A wrapper type for `std::variant` guarantees to only contain variants of the form `T<ix>` where $\texttt{ix}\in [\texttt{first},\texttt{last}]$ (inclusive).
 - `for_{types,values,range}`: Compile time for loops for types, values or ranges
 - `polymorphic_allocator`: Like `std::pmr::polymorphic_allocator` but with static dispatch
+- `DEFER`/`DEFER_TO_SUCCES`/`DEFER_TO_FAIL`: On-the-fly RAII for types that do not support it natively (similar to go's defer keyword)
 
 ## Usage
 
@@ -56,6 +57,11 @@ For example, you might have some allocations in persistent or shared memory (or 
 The problem with `mmap` allocations is that they will be placed at an arbitrary position in virtual memory each time they are loaded,
 therefore absolute pointers will cause segfaults if the segment is reloaded.
 Which means: vtables will not work (because they use absolute pointers) and therefore you cannot use `std::pmr::polymorphic_allocator`.
+
+### `DEFER`/`DEFER_TO_SUCCES`/`DEFER_TO_FAIL`
+A mechanism similar to go's `defer` keyword, which can be used to defer some action to scope exit.
+The primary use-case for this is on-the-fly RAII-like resource management for types that do not support RAII (for example C types).
+Usage examples can be found [here](examples/examples_defer.cpp).
 
 
 ### Further Examples

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -37,3 +37,10 @@ target_link_libraries(examples_overloaded
         PRIVATE
         dice-template-library::dice-template-library
 )
+
+add_executable(examples_defer
+        examples_defer.cpp)
+target_link_libraries(examples_defer
+        PRIVATE
+        dice-template-library::dice-template-library
+)

--- a/examples/examples_defer.cpp
+++ b/examples/examples_defer.cpp
@@ -15,7 +15,7 @@ void write_to_file(std::filesystem::path const &p) {
 		return;
 	}
 
-	DEFER {
+	DICE_DEFER {
 		fclose(f);
 	};
 
@@ -31,7 +31,7 @@ void write_to_file(std::filesystem::path const &p) {
  */
 void copy_file_transact(std::filesystem::path const &src, std::filesystem::path const &dst) {
 	std::filesystem::path const dst2 = dst.string() + ".deleteme";
-	DEFER_TO_FAIL {
+	DICE_DEFER_TO_FAIL {
 		std::error_code ec;
 		std::filesystem::remove(dst2, ec);
 	};
@@ -48,7 +48,7 @@ void copy_file_transact(std::filesystem::path const &src, std::filesystem::path 
 int string_to_int(std::string const &integer) {
 	int value = std::stoi(integer);
 
-	DEFER_TO_SUCCESS {
+	DICE_DEFER_TO_SUCCESS {
 		// check postcondition
 		assert(std::to_string(value) == integer);
 	};
@@ -60,7 +60,7 @@ int main() {
 	std::filesystem::path const p = "/tmp/dice-template-lib-defer-example1-" + std::to_string(std::random_device{}());
 	std::filesystem::path const p2 = "/tmp/dice-template-lib-defer-example2-" + std::to_string(std::random_device{}());
 
-	DEFER {
+	DICE_DEFER {
 		std::error_code ec;
 		std::filesystem::remove(p, ec);
 		std::filesystem::remove(p2, ec);

--- a/examples/examples_defer.cpp
+++ b/examples/examples_defer.cpp
@@ -1,0 +1,75 @@
+#include <dice/template-library/defer.hpp>
+
+#include <cassert>
+#include <cstdio>
+#include <filesystem>
+#include <random>
+#include <string>
+
+/**
+ * Some C Api File handling
+ */
+void write_to_file(std::filesystem::path const &p) {
+	FILE *f = fopen(p.c_str(), "w");
+	if (f == nullptr) {
+		return;
+	}
+
+	DEFER {
+		fclose(f);
+	};
+
+	std::string const s = "Spherical Cow";
+	fwrite(s.data(), 1, s.size(), f);
+}
+
+/**
+ * Copies a file from src to dst, will not overwrite dst
+ * if copying does not succeed
+ *
+ * @note Inspired by Andrei Alexandrescu's “Declarative Control Flow" presentation
+ */
+void copy_file_transact(std::filesystem::path const &src, std::filesystem::path const &dst) {
+	std::filesystem::path const dst2 = dst.string() + ".deleteme";
+	DEFER_TO_FAIL {
+		std::error_code ec;
+		std::filesystem::remove(dst2, ec);
+	};
+
+	std::filesystem::copy_file(src, dst2);
+	std::filesystem::rename(dst2, dst);
+}
+
+/**
+ * Converts a string to and int with a postcondition check
+ *
+ * @note Inspired by Andrei Alexandrescu's “Declarative Control Flow" presentation
+ */
+int string_to_int(std::string const &integer) {
+	int value = std::stoi(integer);
+
+	DEFER_TO_SUCCESS {
+		// check postcondition
+		assert(std::to_string(value) == integer);
+	};
+
+	return value;
+}
+
+int main() {
+	std::filesystem::path const p = "/tmp/dice-template-lib-defer-example1-" + std::to_string(std::random_device{}());
+	std::filesystem::path const p2 = "/tmp/dice-template-lib-defer-example2-" + std::to_string(std::random_device{}());
+
+	DEFER {
+		std::error_code ec;
+		std::filesystem::remove(p, ec);
+		std::filesystem::remove(p2, ec);
+	};
+
+	write_to_file(p);
+	copy_file_transact(p, p2);
+
+	std::string const i = "42";
+	int const j = 10 + string_to_int(i);
+	assert(j == 52);
+}

--- a/include/dice/template-library/defer.hpp
+++ b/include/dice/template-library/defer.hpp
@@ -1,0 +1,155 @@
+#ifndef DICE_TEMPLATE_LIBRARY_DEFER_HPP
+#define DICE_TEMPLATE_LIBRARY_DEFER_HPP
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <exception>
+
+namespace dice::template_library {
+	/**
+	 * The policy deciding if the scope exit function should be executed
+	 */
+	enum struct ScopeExitPolicy : uint8_t {
+		Always,    ///< Always execute
+		OnFail,    ///< Only execute if the scope failed (i.e. an exception was thrown)
+		OnSuccess, ///< Only execute if the scope did not fail (i.e. no exception was thrown)
+	};
+
+	/**
+	 * A RAII type that executes a function on scope exit.
+	 * Inspired by Andrei Alexandrescu's “Declarative Control Flow" presentation
+	 *
+	 * @tparam Pol Policy deciding if the function should be executed
+	 * @tparam F type of function to execute
+	 */
+	template<ScopeExitPolicy Pol, typename F>
+	struct ScopeExitGuard {
+	private:
+		std::optional<F> func_;
+		int const uncaught_exceptions_ = std::uncaught_exceptions();
+
+		[[nodiscard]] bool scope_failed() const noexcept {
+			return uncaught_exceptions_ < std::uncaught_exceptions();
+		}
+
+	public:
+		ScopeExitGuard() noexcept = default;
+
+		explicit ScopeExitGuard(F &&func) noexcept(std::is_nothrow_move_constructible_v<F>) : func_{std::move(func)} {
+		}
+
+		explicit ScopeExitGuard(F const &func) noexcept(std::is_nothrow_copy_constructible_v<F>) : func_{std::move(func)} {
+		}
+
+		ScopeExitGuard(ScopeExitGuard const &) = delete;
+		ScopeExitGuard &operator=(ScopeExitGuard const &) = delete;
+
+		~ScopeExitGuard() noexcept(Pol != ScopeExitPolicy::OnSuccess) {
+			if (!func_.has_value()) {
+				return;
+			}
+
+			if constexpr (Pol == ScopeExitPolicy::OnSuccess) {
+				if (!scope_failed()) {
+					std::invoke(*func_);
+				}
+			} else if constexpr (Pol == ScopeExitPolicy::OnFail) {
+				if (scope_failed()) {
+					std::invoke(*func_);
+				}
+			} else /* Pol == ScopeExitPolicy::Always */ {
+				std::invoke(*func_);
+			}
+		}
+	};
+
+	/**
+	 * Constructs a ScopeExitGuard with ScopeExitPolicy::Always and the given function
+	 * @param func function to execute on scope exit
+	 * @return constructed ScopeExitGuard
+	 */
+	template<typename F>
+	auto make_scope_exit_guard(F &&func) {
+		return ScopeExitGuard<ScopeExitPolicy::Always, std::remove_cvref_t<F>>{std::forward<F>(func)};
+	}
+
+	/**
+	 * Constructs a ScopeExitGuard with ScopeExitPolicy::OnFail and the given function
+	 * @param func function to execute on scope exit
+	 * @return constructed ScopeExitGuard
+	 */
+	template<typename F>
+	auto make_scope_fail_guard(F &&func) {
+		return ScopeExitGuard<ScopeExitPolicy::OnFail, std::remove_cvref_t<F>>{std::forward<F>(func)};
+	}
+
+	/**
+	 * Constructs a ScopeExitGuard with ScopeExitPolicy::OnSuccess and the given function
+	 * @param func function to execute on scope exit
+	 * @return constructed ScopeExitGuard
+	 */
+	template<typename F>
+	auto make_scope_success_guard(F &&func) {
+		return ScopeExitGuard<ScopeExitPolicy::OnSuccess, std::remove_cvref_t<F>>{std::forward<F>(func)};
+	}
+
+	namespace detail {
+		struct ScopeGuardOnExit {};
+		struct ScopeGuardOnFail {};
+		struct ScopeGuardOnSuccess {};
+
+		template<typename F>
+		auto operator+(ScopeGuardOnExit, F &&func) {
+			return make_scope_exit_guard(std::forward<F>(func));
+		}
+
+		template<typename F>
+		auto operator+(ScopeGuardOnFail, F &&func) {
+			return make_scope_fail_guard(std::forward<F>(func));
+		}
+
+		template<typename F>
+		auto operator+(ScopeGuardOnSuccess, F &&func) {
+			return make_scope_success_guard(std::forward<F>(func));
+		}
+	} // namespace detail
+
+} // namespace dice::template_library
+
+#define DICE_TEMPLATE_LIBRARY_DETAIL_CONCAT_IMPL(a, b) a ## b
+#define DICE_TEMPLATE_LIBRARY_DETAIL_CONCAT(a, b) DICE_TEMPLATE_LIBRARY_DETAIL_CONCAT_IMPL(a, b)
+#define DICE_TEMPLATE_LIBRARY_DETAIL_SCOPEGUARD_VAR DICE_TEMPLATE_LIBRARY_DETAIL_CONCAT(_scope_guard, __LINE__)
+
+/**
+ * Execute the given expression on scope exit.
+ * Note the evaluated expression is not allowed to throw.
+ * Naming is inspired by GO's defer and C23's defer proposal
+ *
+ * Example:
+ * @code
+ * FILE *f = fopen("path", "r");
+ * DEFER { fclose(f); };
+ *
+ * // do stuff with f
+ * // f closed at end of scope
+ * @endcode
+ */
+#define DEFER \
+	auto DICE_TEMPLATE_LIBRARY_DETAIL_SCOPEGUARD_VAR = ::dice::template_library::detail::ScopeGuardOnExit{} + [&]() noexcept
+
+/**
+ * Similar to DEFER, but it only executes the expression if the scope failed (i.e. the scope threw an exception).
+ * Note the evaluated expression is not allowed to throw.
+ */
+#define DEFER_TO_FAIL \
+	auto DICE_TEMPLATE_LIBRARY_DETAIL_SCOPEGUARD_VAR = ::dice::template_library::detail::ScopeGuardOnFail{} + [&]() noexcept
+
+/**
+ * Similar to DEFER, but it only executes the expression if the scope succeeded (i.e. the scope did not throw an exception).
+ * Note the evaluated expression is allowed to throw.
+ */
+#define DEFER_TO_SUCCESS \
+	auto DICE_TEMPLATE_LIBRARY_DETAIL_SCOPEGUARD_VAR = ::dice::template_library::detail::ScopeGuardOnSuccess{} + [&]()
+
+#endif // DICE_TEMPLATE_LIBRARY_DEFER_HPP

--- a/include/dice/template-library/defer.hpp
+++ b/include/dice/template-library/defer.hpp
@@ -29,10 +29,6 @@ namespace dice::template_library {
 		std::optional<F> func_;
 		int const uncaught_exceptions_ = std::uncaught_exceptions();
 
-		[[nodiscard]] bool scope_failed() const noexcept {
-			return uncaught_exceptions_ < std::uncaught_exceptions();
-		}
-
 	public:
 		ScopeExitGuard() noexcept = default;
 
@@ -49,6 +45,16 @@ namespace dice::template_library {
 			if (!func_.has_value()) {
 				return;
 			}
+
+			/**
+			 * Determines if the scope failed by examining the number of in-flight exceptions.
+			 * The baseline number is captured at construction time and is now compared to the current number.
+			 * If the number of in-flight exceptions increased, this means the scope must have failed.
+			 * Otherwise it must not have failed.
+			 */
+			auto const scope_failed = [this]() noexcept {
+				return uncaught_exceptions_ < std::uncaught_exceptions();
+			};
 
 			if constexpr (Pol == ScopeExitPolicy::OnSuccess) {
 				if (!scope_failed()) {
@@ -95,6 +101,12 @@ namespace dice::template_library {
 	}
 
 	namespace detail {
+		/**
+		 * Helper types and functions whose only purpose it to improve
+		 * the syntax of the provided `DEFER*` macros to make them seem more like actual language
+		 * constructs rather than macros (see macro definitions below).
+		 */
+
 		struct ScopeGuardOnExit {};
 		struct ScopeGuardOnFail {};
 		struct ScopeGuardOnSuccess {};

--- a/include/dice/template-library/defer.hpp
+++ b/include/dice/template-library/defer.hpp
@@ -140,27 +140,27 @@ namespace dice::template_library {
  * Example:
  * @code
  * FILE *f = fopen("path", "r");
- * DEFER { fclose(f); };
+ * DICE_DEFER { fclose(f); };
  *
  * // do stuff with f
  * // f closed at end of scope
  * @endcode
  */
-#define DEFER \
+#define DICE_DEFER \
 	auto DICE_TEMPLATE_LIBRARY_DETAIL_SCOPEGUARD_VAR = ::dice::template_library::defer_detail::ScopeGuardOnExit{} + [&]() noexcept
 
 /**
- * Similar to DEFER, but it only executes the expression if the scope failed (i.e. the scope threw an exception).
+ * Similar to DICE_DEFER, but it only executes the expression if the scope failed (i.e. the scope threw an exception).
  * Note the evaluated expression is not allowed to throw.
  */
-#define DEFER_TO_FAIL \
+#define DICE_DEFER_TO_FAIL \
 	auto DICE_TEMPLATE_LIBRARY_DETAIL_SCOPEGUARD_VAR = ::dice::template_library::defer_detail::ScopeGuardOnFail{} + [&]() noexcept
 
 /**
- * Similar to DEFER, but it only executes the expression if the scope succeeded (i.e. the scope did not throw an exception).
+ * Similar to DICE_DEFER, but it only executes the expression if the scope succeeded (i.e. the scope did not throw an exception).
  * Note the evaluated expression is allowed to throw.
  */
-#define DEFER_TO_SUCCESS \
+#define DICE_DEFER_TO_SUCCESS \
 	auto DICE_TEMPLATE_LIBRARY_DETAIL_SCOPEGUARD_VAR = ::dice::template_library::defer_detail::ScopeGuardOnSuccess{} + [&]()
 
 #endif // DICE_TEMPLATE_LIBRARY_DEFER_HPP

--- a/include/dice/template-library/defer.hpp
+++ b/include/dice/template-library/defer.hpp
@@ -100,13 +100,12 @@ namespace dice::template_library {
 		return ScopeExitGuard<ScopeExitPolicy::OnSuccess, std::remove_cvref_t<F>>{std::forward<F>(func)};
 	}
 
-	namespace detail {
-		/**
-		 * Helper types and functions whose only purpose it to improve
-		 * the syntax of the provided `DEFER*` macros to make them seem more like actual language
-		 * constructs rather than macros (see macro definitions below).
-		 */
-
+	/**
+	 * Helper types and functions whose only purpose it to improve
+	 * the syntax of the provided `DEFER*` macros to make them seem more like actual language
+	 * constructs rather than macros (see macro definitions below).
+	 */
+	namespace defer_detail {
 		struct ScopeGuardOnExit {};
 		struct ScopeGuardOnFail {};
 		struct ScopeGuardOnSuccess {};
@@ -125,7 +124,7 @@ namespace dice::template_library {
 		auto operator+(ScopeGuardOnSuccess, F &&func) {
 			return make_scope_success_guard(std::forward<F>(func));
 		}
-	} // namespace detail
+	} // namespace defer_detail
 
 } // namespace dice::template_library
 
@@ -148,20 +147,20 @@ namespace dice::template_library {
  * @endcode
  */
 #define DEFER \
-	auto DICE_TEMPLATE_LIBRARY_DETAIL_SCOPEGUARD_VAR = ::dice::template_library::detail::ScopeGuardOnExit{} + [&]() noexcept
+	auto DICE_TEMPLATE_LIBRARY_DETAIL_SCOPEGUARD_VAR = ::dice::template_library::defer_detail::ScopeGuardOnExit{} + [&]() noexcept
 
 /**
  * Similar to DEFER, but it only executes the expression if the scope failed (i.e. the scope threw an exception).
  * Note the evaluated expression is not allowed to throw.
  */
 #define DEFER_TO_FAIL \
-	auto DICE_TEMPLATE_LIBRARY_DETAIL_SCOPEGUARD_VAR = ::dice::template_library::detail::ScopeGuardOnFail{} + [&]() noexcept
+	auto DICE_TEMPLATE_LIBRARY_DETAIL_SCOPEGUARD_VAR = ::dice::template_library::defer_detail::ScopeGuardOnFail{} + [&]() noexcept
 
 /**
  * Similar to DEFER, but it only executes the expression if the scope succeeded (i.e. the scope did not throw an exception).
  * Note the evaluated expression is allowed to throw.
  */
 #define DEFER_TO_SUCCESS \
-	auto DICE_TEMPLATE_LIBRARY_DETAIL_SCOPEGUARD_VAR = ::dice::template_library::detail::ScopeGuardOnSuccess{} + [&]()
+	auto DICE_TEMPLATE_LIBRARY_DETAIL_SCOPEGUARD_VAR = ::dice::template_library::defer_detail::ScopeGuardOnSuccess{} + [&]()
 
 #endif // DICE_TEMPLATE_LIBRARY_DEFER_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,3 +49,6 @@ custom_add_test(tests_polymorphic_allocator)
 
 add_executable(tests_overloaded tests_overloaded.cpp)
 custom_add_test(tests_overloaded)
+
+add_executable(tests_defer tests_defer.cpp)
+custom_add_test(tests_defer)

--- a/tests/tests_defer.cpp
+++ b/tests/tests_defer.cpp
@@ -11,14 +11,14 @@ namespace dice::template_library {
 
 			SUBCASE("success") {
 				{
-					DEFER { executed = true; };
+					DICE_DEFER { executed = true; };
 				}
 				CHECK(executed);
 			}
 
 			SUBCASE("fail") {
 				try {
-					DEFER { executed = true; };
+					DICE_DEFER { executed = true; };
 					throw std::runtime_error{""};
 				} catch (...) {
 					// expecting excetpion
@@ -33,14 +33,14 @@ namespace dice::template_library {
 
 			SUBCASE("success") {
 				{
-					DEFER_TO_FAIL { executed = true; };
+					DICE_DEFER_TO_FAIL { executed = true; };
 				}
 				CHECK_FALSE(executed);
 			}
 
 			SUBCASE("fail") {
 				try {
-					DEFER_TO_FAIL { executed = true; };
+					DICE_DEFER_TO_FAIL { executed = true; };
 					throw std::runtime_error{""};
 				} catch (...) {
 					// expecting excetpion
@@ -55,14 +55,14 @@ namespace dice::template_library {
 
 			SUBCASE("success") {
 				{
-					DEFER_TO_SUCCESS { executed = true; };
+					DICE_DEFER_TO_SUCCESS { executed = true; };
 				}
 				CHECK(executed);
 			}
 
 			SUBCASE("fail") {
 				try {
-					DEFER_TO_SUCCESS { executed = true; };
+					DICE_DEFER_TO_SUCCESS { executed = true; };
 					throw std::runtime_error{""};
 				} catch (...) {
 					// expecting excetpion
@@ -74,12 +74,12 @@ namespace dice::template_library {
 
 		TEST_CASE("multiple in same scope") {
 			// only checking if it compiles
-			DEFER {};
-			DEFER {};
-			DEFER_TO_FAIL {};
-			DEFER_TO_FAIL {};
-			DEFER_TO_SUCCESS {};
-			DEFER_TO_SUCCESS {};
+			DICE_DEFER {};
+			DICE_DEFER {};
+			DICE_DEFER_TO_FAIL {};
+			DICE_DEFER_TO_FAIL {};
+			DICE_DEFER_TO_SUCCESS {};
+			DICE_DEFER_TO_SUCCESS {};
 		}
 	}
 } // namespace dice::template_library

--- a/tests/tests_defer.cpp
+++ b/tests/tests_defer.cpp
@@ -1,0 +1,85 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include <dice/template-library/defer.hpp>
+
+#include <doctest/doctest.h>
+
+namespace dice::template_library {
+	TEST_SUITE("defer") {
+		TEST_CASE("always") {
+			bool executed = false;
+
+			SUBCASE("success") {
+				{
+					DEFER { executed = true; };
+				}
+				CHECK(executed);
+			}
+
+			SUBCASE("fail") {
+				try {
+					DEFER { executed = true; };
+					throw std::runtime_error{""};
+				} catch (...) {
+					// expecting excetpion
+				}
+
+				CHECK(executed);
+			}
+		}
+
+		TEST_CASE("fail") {
+			bool executed = false;
+
+			SUBCASE("success") {
+				{
+					DEFER_TO_FAIL { executed = true; };
+				}
+				CHECK_FALSE(executed);
+			}
+
+			SUBCASE("fail") {
+				try {
+					DEFER_TO_FAIL { executed = true; };
+					throw std::runtime_error{""};
+				} catch (...) {
+					// expecting excetpion
+				}
+
+				CHECK(executed);
+			}
+		}
+
+		TEST_CASE("success") {
+			bool executed = false;
+
+			SUBCASE("success") {
+				{
+					DEFER_TO_SUCCESS { executed = true; };
+				}
+				CHECK(executed);
+			}
+
+			SUBCASE("fail") {
+				try {
+					DEFER_TO_SUCCESS { executed = true; };
+					throw std::runtime_error{""};
+				} catch (...) {
+					// expecting excetpion
+				}
+
+				CHECK_FALSE(executed);
+			}
+		}
+
+		TEST_CASE("multiple in same scope") {
+			// only checking if it compiles
+			DEFER {};
+			DEFER {};
+			DEFER_TO_FAIL {};
+			DEFER_TO_FAIL {};
+			DEFER_TO_SUCCESS {};
+			DEFER_TO_SUCCESS {};
+		}
+	}
+} // namespace dice::template_library


### PR DESCRIPTION
Implements a mechanism like GO's `defer` or C23's `defer` proposal or Andrei Alexandrescu's `SCOPE_EXIT` mechanism.

Open question:
- Do we want to keep the macro naming as is or do we name them `DICE_DEFER` to avoid conflicts?
  - Pro keeping names: short, readable
  - Pro changing names: more unlikely to conflict with macros from other people