### PR TITLE
Feature: more flexy `flex_array`

### DIFF
--- a/.github/workflows/code_testing.yaml
+++ b/.github/workflows/code_testing.yaml
@@ -66,7 +66,7 @@ jobs:
         uses: dice-group/cpp-conan-release-reusable-workflow/.github/actions/add_conan_provider@main
 
       - name: Configure CMake
-        run: cmake -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined" -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=On -DBUILD_EXAMPLES=On -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -G Ninja -B build .
+        run: cmake -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined" -DCMAKE_BUILD_TYPE=Debug -DWITH_SVECTOR=ON -DBUILD_TESTING=On -DBUILD_EXAMPLES=On -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -G Ninja -B build .
         env:
           CC: ${{ steps.install_cc.outputs.cc }}
           CXX: ${{ steps.install_cc.outputs.cxx }}

--- a/.github/workflows/code_testing.yaml
+++ b/.github/workflows/code_testing.yaml
@@ -66,7 +66,7 @@ jobs:
         uses: dice-group/cpp-conan-release-reusable-workflow/.github/actions/add_conan_provider@main
 
       - name: Configure CMake
-        run: cmake -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined" -DCMAKE_BUILD_TYPE=Debug -DWITH_SVECTOR=ON -DBUILD_TESTING=On -DBUILD_EXAMPLES=On -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -G Ninja -B build .
+        run: cmake -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined" -DCMAKE_BUILD_TYPE=Debug -DWITH_SVECTOR=ON -DWITH_BOOST=ON -DBUILD_TESTING=On -DBUILD_EXAMPLES=On -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=conan_provider.cmake -G Ninja -B build .
         env:
           CC: ${{ steps.install_cc.outputs.cc }}
           CXX: ${{ steps.install_cc.outputs.cxx }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ project(
   HOMEPAGE_URL "https://dice-research.org/")
 set(POBR_VERSION 1)  # Persisted Object Binary Representation
 
+find_package(svector REQUIRED)
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.hpp.in ${CMAKE_CURRENT_SOURCE_DIR}/include/dice/template-library/version.hpp)
 
 option(BUILD_TESTING "build tests" OFF)
@@ -33,6 +35,10 @@ add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        )
+
+target_link_libraries(${PROJECT_NAME} INTERFACE
+        svector::svector
         )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,15 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.hpp.in ${CMAKE_CURRENT_
 
 option(BUILD_TESTING "build tests" OFF)
 option(BUILD_EXAMPLES "build examples" OFF)
-option(WITH_SVECTOR "use ankerl/svector to provide flex_array with flex_array_implementation::sbo_vector" OFF)
+option(WITH_SVECTOR "use ankerl/svector to provide flex_array with flex_array_implementation::sbo_vector" ON)
+option(WITH_BOOST "use boost to provide offset_ptr_stl_allocator in polymorphic_allocator.hpp" ON)
 
 if (WITH_SVECTOR)
     set(CONAN_INSTALL_ARGS "${CONAN_INSTALL_ARGS};-o=&:with_svector=True")
+endif ()
+
+if (WITH_BOOST)
+    set(CONAN_INSTALL_ARGS "${CONAN_INSTALL_ARGS};-o=&:with_boost=True")
 endif ()
 
 if (PROJECT_IS_TOP_LEVEL)
@@ -33,8 +38,6 @@ if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CMakeCache.txt)
   endif ()
 endif ()
 
-find_package(svector QUIET)
-
 add_library(${PROJECT_NAME} INTERFACE)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
@@ -42,9 +45,19 @@ target_include_directories(${PROJECT_NAME} INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         )
 
-if (svector_FOUND)
+if (WITH_SVECTOR)
+    find_package(svector REQUIRED)
+
     target_link_libraries(${PROJECT_NAME} INTERFACE
             svector::svector
+            )
+endif ()
+
+if (WITH_BOOST)
+    find_package(Boost REQUIRED COMPONENTS)
+
+    target_link_libraries(${PROJECT_NAME} INTERFACE
+            Boost::headers
             )
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(BUILD_EXAMPLES "build examples" OFF)
 if (PROJECT_IS_TOP_LEVEL)
     set(CONAN_INSTALL_ARGS "${CONAN_INSTALL_ARGS};-o=boost/*:header_only=True")
 
-    if (BUILD_TESTING)
+    if (BUILD_TESTING OR BUILD_EXAMPLES)
         set(CONAN_INSTALL_ARGS "${CONAN_INSTALL_ARGS};-o=&:with_test_deps=True")
     endif ()
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.hpp.in ${CMAKE_CURRENT_
 
 option(BUILD_TESTING "build tests" OFF)
 option(BUILD_EXAMPLES "build examples" OFF)
-option(WITH_SVECTOR "use ankerl/svector to provide flex_array with flex_array_implementation::sbo_vector" ON)
-option(WITH_BOOST "use boost to provide offset_ptr_stl_allocator in polymorphic_allocator.hpp" ON)
+option(WITH_SVECTOR "use ankerl/svector to provide flex_array with flex_array_implementation::sbo_vector" OFF)
+option(WITH_BOOST "use boost to provide offset_ptr_stl_allocator in polymorphic_allocator.hpp" OFF)
 
 if (PROJECT_IS_TOP_LEVEL)
     if (BUILD_TESTING OR BUILD_EXAMPLES)
@@ -25,7 +25,7 @@ if (PROJECT_IS_TOP_LEVEL)
     endif ()
 
     if (WITH_BOOST)
-        set(CONAN_INSTALL_ARGS "${CONAN_INSTALL_ARGS};-o=&:with_boost=True;o=boost/*:header_only=True")
+        set(CONAN_INSTALL_ARGS "${CONAN_INSTALL_ARGS};-o=&:with_boost=True;-o=boost/*:header_only=True")
     endif ()
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.hpp.in ${CMAKE_CURRENT_
 
 option(BUILD_TESTING "build tests" OFF)
 option(BUILD_EXAMPLES "build examples" OFF)
+option(WITH_SVECTOR "use ankerl/svector to provide flex_array with flex_array_implementation::sbo_vector" OFF)
+
+if (WITH_SVECTOR)
+    set(CONAN_INSTALL_ARGS "${CONAN_INSTALL_ARGS};-o=&:with_svector=True")
+endif ()
 
 if (PROJECT_IS_TOP_LEVEL)
     set(CONAN_INSTALL_ARGS "${CONAN_INSTALL_ARGS};-o=boost/*:header_only=True")
@@ -28,7 +33,7 @@ if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CMakeCache.txt)
   endif ()
 endif ()
 
-find_package(svector REQUIRED)
+find_package(svector QUIET)
 
 add_library(${PROJECT_NAME} INTERFACE)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
@@ -37,9 +42,11 @@ target_include_directories(${PROJECT_NAME} INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         )
 
-target_link_libraries(${PROJECT_NAME} INTERFACE
-        svector::svector
-        )
+if (svector_FOUND)
+    target_link_libraries(${PROJECT_NAME} INTERFACE
+            svector::svector
+            )
+endif ()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
         CXX_STANDARD 20

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,19 +15,17 @@ option(BUILD_EXAMPLES "build examples" OFF)
 option(WITH_SVECTOR "use ankerl/svector to provide flex_array with flex_array_implementation::sbo_vector" ON)
 option(WITH_BOOST "use boost to provide offset_ptr_stl_allocator in polymorphic_allocator.hpp" ON)
 
-if (WITH_SVECTOR)
-    set(CONAN_INSTALL_ARGS "${CONAN_INSTALL_ARGS};-o=&:with_svector=True")
-endif ()
-
-if (WITH_BOOST)
-    set(CONAN_INSTALL_ARGS "${CONAN_INSTALL_ARGS};-o=&:with_boost=True")
-endif ()
-
 if (PROJECT_IS_TOP_LEVEL)
-    set(CONAN_INSTALL_ARGS "${CONAN_INSTALL_ARGS};-o=boost/*:header_only=True")
-
     if (BUILD_TESTING OR BUILD_EXAMPLES)
         set(CONAN_INSTALL_ARGS "${CONAN_INSTALL_ARGS};-o=&:with_test_deps=True")
+    endif ()
+
+    if (WITH_SVECTOR)
+        set(CONAN_INSTALL_ARGS "${CONAN_INSTALL_ARGS};-o=&:with_svector=True")
+    endif ()
+
+    if (WITH_BOOST)
+        set(CONAN_INSTALL_ARGS "${CONAN_INSTALL_ARGS};-o=&:with_boost=True;o=boost/*:header_only=True")
     endif ()
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ project(
   HOMEPAGE_URL "https://dice-research.org/")
 set(POBR_VERSION 1)  # Persisted Object Binary Representation
 
-find_package(svector REQUIRED)
-
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.hpp.in ${CMAKE_CURRENT_SOURCE_DIR}/include/dice/template-library/version.hpp)
 
 option(BUILD_TESTING "build tests" OFF)
@@ -29,6 +27,8 @@ if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/CMakeCache.txt)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
   endif ()
 endif ()
+
+find_package(svector REQUIRED)
 
 add_library(${PROJECT_NAME} INTERFACE)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
@@ -50,12 +50,12 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 include(cmake/install_interface_library.cmake)
 install_interface_library(${PROJECT_NAME} ${PROJECT_NAME} ${PROJECT_NAME} "include")
 
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
+if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
   include(CTest)
   enable_testing()
   add_subdirectory(tests)
 endif()
 
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_EXAMPLES)
+if(PROJECT_IS_TOP_LEVEL AND BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It contains:
 - `polymorphic_allocator`: Like `std::pmr::polymorphic_allocator` but with static dispatch
 - `DICE_DEFER`/`DICE_DEFER_TO_SUCCES`/`DICE_DEFER_TO_FAIL`: On-the-fly RAII for types that do not support it natively (similar to go's `defer` keyword)
 - `overloaded`: Composition for `std::variant` visitor lambdas
-- `flex_array`: A combination of `std::array` and `std::span`
+- `flex_array`: A combination of `std::array`, `std::span` and a `vector` with small buffer optimization
 - `tuple_algorithms`: Some algorithms for iterating tuples
 - `generator`: The reference implementation of `std::generator` from [P2502R2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2502r2.pdf)
 - `channel`: A single producer, single consumer queue
@@ -73,8 +73,8 @@ Usage examples can be found [here](examples/examples_defer.cpp).
 Some algorithms for iterating tuples, for example `tuple_fold` a fold/reduce implementation for tuples.
 
 ### `flex_array`
-A combination of `std::array` and `std::span` where the size is either statically known or a runtime variable
-depending on the `extent` template parameter
+A combination of `std::array`, `std::span` and a `vector` with small buffer optimization where the size is either
+statically known or a runtime variable depending on the `extent`/`max_extent` template parameters
 
 ### `generator`
 The reference implementation of `std::generator` from [P2502R2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2502r2.pdf).

--- a/conanfile.py
+++ b/conanfile.py
@@ -26,6 +26,8 @@ class DiceTemplateLibrary(ConanFile):
     }
 
     def requirements(self):
+        self.requires("svector/1.0.3", transitive_headers=True)
+        
         if self.options.with_test_deps:
             self.test_requires("boost/1.83.0")
             self.test_requires("doctest/2.4.11")
@@ -67,6 +69,7 @@ class DiceTemplateLibrary(ConanFile):
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
+        self.cpp_info.requires = ("svector::svector", )
 
         self.cpp_info.set_property("cmake_find_mode", "both")
         self.cpp_info.set_property("cmake_target_name", f"{self.name}::{self.name}")

--- a/conanfile.py
+++ b/conanfile.py
@@ -72,7 +72,9 @@ class DiceTemplateLibrary(ConanFile):
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
-        self.cpp_info.requires = ("svector::svector", )
+
+        if self.options.with_svector:
+            self.cpp_info.requires = ("svector::svector", )
 
         self.cpp_info.set_property("cmake_find_mode", "both")
         self.cpp_info.set_property("cmake_target_name", f"{self.name}::{self.name}")

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,8 +25,8 @@ class DiceTemplateLibrary(ConanFile):
     }
     default_options = {
         "with_test_deps": False,
-        "with_svector": True,
-        "with_boost": True,
+        "with_svector": False,
+        "with_boost": False,
     }
 
     def requirements(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -20,13 +20,16 @@ class DiceTemplateLibrary(ConanFile):
     no_copy_source = True
     options = {
         "with_test_deps": [True, False],
+        "with_svector": [True, False],
     }
     default_options = {
         "with_test_deps": False,
+        "with_svector": False,
     }
 
     def requirements(self):
-        self.requires("svector/1.0.3", transitive_headers=True)
+        if self.options.with_svector:
+            self.requires("svector/1.0.3", transitive_headers=True)
 
         if self.options.with_test_deps:
             self.test_requires("boost/1.83.0")

--- a/conanfile.py
+++ b/conanfile.py
@@ -27,7 +27,7 @@ class DiceTemplateLibrary(ConanFile):
 
     def requirements(self):
         self.requires("svector/1.0.3", transitive_headers=True)
-        
+
         if self.options.with_test_deps:
             self.test_requires("boost/1.83.0")
             self.test_requires("doctest/2.4.11")

--- a/conanfile.py
+++ b/conanfile.py
@@ -21,18 +21,22 @@ class DiceTemplateLibrary(ConanFile):
     options = {
         "with_test_deps": [True, False],
         "with_svector": [True, False],
+        "with_boost": [True, False],
     }
     default_options = {
         "with_test_deps": False,
-        "with_svector": False,
+        "with_svector": True,
+        "with_boost": True,
     }
 
     def requirements(self):
         if self.options.with_svector:
             self.requires("svector/1.0.3", transitive_headers=True)
 
+        if self.options.with_boost:
+            self.requires("boost/1.84.0", transitive_headers=True)
+
         if self.options.with_test_deps:
-            self.test_requires("boost/1.83.0")
             self.test_requires("doctest/2.4.11")
 
     def layout(self):
@@ -41,7 +45,7 @@ class DiceTemplateLibrary(ConanFile):
     def build(self):
         if not self.conf.get("tools.build:skip_test", default=False):
             cmake = CMake(self)
-            cmake.configure()
+            cmake.configure(variables={"WITH_SVECTOR": self.options.with_svector, "WITH_BOOST": self.options.with_boost})
             cmake.build()
 
     def package_id(self):
@@ -72,9 +76,13 @@ class DiceTemplateLibrary(ConanFile):
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
+        self.cpp_info.requires = []
 
         if self.options.with_svector:
-            self.cpp_info.requires = ("svector::svector", )
+            self.cpp_info.requires += ["svector::svector"]
+
+        if self.options.with_boost:
+            self.cpp_info.requires += ["boost::headers"]
 
         self.cpp_info.set_property("cmake_find_mode", "both")
         self.cpp_info.set_property("cmake_target_name", f"{self.name}::{self.name}")

--- a/examples/example_flex_array.cpp
+++ b/examples/example_flex_array.cpp
@@ -35,9 +35,11 @@ struct square {
 	}
 };
 
+#if __has_include(<ankerl/svector.h>)
 struct arbitrary_high_dimensional_thing {
 	flex_array<size_t, 2, dynamic_extent> extents;
 };
+#endif // __has_include
 
 struct shape {
 	std::variant<point, line, square> shape_;
@@ -72,8 +74,10 @@ int main() {
 	print_extents(line1);
 	print_extents(square1);
 
+#if __has_include(<ankerl/svector.h>)
 	arbitrary_high_dimensional_thing thing{.extents = {1, 2, 3, 4, 5, 6, 7, 8}};
 	for (auto const ext : thing.extents) {
 		std::cout << ext << " ";
 	}
+#endif // __has_include
 }

--- a/examples/example_flex_array.cpp
+++ b/examples/example_flex_array.cpp
@@ -35,6 +35,10 @@ struct square {
 	}
 };
 
+struct arbitrary_high_dimensional_thing {
+	flex_array<size_t, 2, dynamic_extent> extents;
+};
+
 struct shape {
 	std::variant<point, line, square> shape_;
 
@@ -67,4 +71,9 @@ int main() {
 	print_extents(point1);
 	print_extents(line1);
 	print_extents(square1);
+
+	arbitrary_high_dimensional_thing thing{.extents = {1, 2, 3, 4, 5, 6, 7, 8}};
+	for (auto const ext : thing.extents) {
+		std::cout << ext << " ";
+	}
 }

--- a/include/dice/template-library/flex_array.hpp
+++ b/include/dice/template-library/flex_array.hpp
@@ -19,9 +19,9 @@ namespace dice::template_library {
 	 * The underlying implementation of a flex array
 	 */
 	enum struct flex_array_mode {
-		direct_static_sized, ///< size is static and flex array is stack allocated
-		direct_dynamic_limited_sized, ///< size is dynamic but limited by max_size, flex array is stack allocated and has at most max_size elements
-		sbo_dynamic_sized, ///< small buffer optimized vector
+		direct_static_size, ///< size is static and flex array is stack allocated
+		direct_dynamic_limited_size, ///< size is dynamic but limited by max_size, flex array is stack allocated and has at most max_size elements
+		sbo_dynamic_size, ///< small buffer optimized vector
 	};
 
 	namespace detail_flex_array {
@@ -32,7 +32,7 @@ namespace dice::template_library {
 		template<typename T, size_t extent> requires (extent != dynamic_extent)
 		struct flex_array_inner<T, extent, extent> {
 			// fully fixed size
-			static constexpr flex_array_mode mode = flex_array_mode::direct_static_sized;
+			static constexpr flex_array_mode mode = flex_array_mode::direct_static_size;
 
 			static constexpr size_t size_ = extent;
 			std::array<T, extent> data_;
@@ -55,7 +55,7 @@ namespace dice::template_library {
 		template<typename T, size_t max_extent>
 		struct flex_array_inner<T, dynamic_extent, max_extent> {
 			// fixed max size, dynamic actual size
-			static constexpr flex_array_mode mode = flex_array_mode::direct_dynamic_limited_sized;
+			static constexpr flex_array_mode mode = flex_array_mode::direct_dynamic_limited_size;
 
 			size_t size_ = 0;
 			std::array<T, max_extent> data_;
@@ -129,7 +129,7 @@ namespace dice::template_library {
 		template<typename T, size_t extent> requires (extent != dynamic_extent)
 		struct flex_array_inner<T, extent, dynamic_extent> {
 			// dynamic max size, fixed small buffer size
-			static constexpr flex_array_mode mode = flex_array_mode::sbo_dynamic_sized;
+			static constexpr flex_array_mode mode = flex_array_mode::sbo_dynamic_size;
 
 			::ankerl::svector<T, extent> data_;
 

--- a/include/dice/template-library/flex_array.hpp
+++ b/include/dice/template-library/flex_array.hpp
@@ -298,11 +298,20 @@ namespace dice::template_library {
 		 */
 		template<std::input_iterator Iter, std::sentinel_for<Iter> Sent>
 		constexpr flex_array(Iter first, Sent last) {
+			if constexpr (has_max_extent && std::random_access_iterator<Iter>) {
+				auto const range_size = std::distance(first, last);
+				if (static_cast<size_t>(range_size) > max_size()) [[unlikely]] {
+					throw std::length_error{"flex_array::flex_array: maximum size exceeded"};
+				}
+			}
+
 			size_t ix = 0;
 			while (first != last) {
 				if constexpr (has_max_extent) {
-					if (ix >= max_size()) [[unlikely]] {
-						throw std::length_error{"flex_array::flex_array: maximum size exceeded"};
+					if constexpr (!std::random_access_iterator<Iter>) {
+						if (ix >= max_size()) [[unlikely]] {
+							throw std::length_error{"flex_array::flex_array: maximum size exceeded"};
+						}
 					}
 
 					inner_.data_[ix++] = *first++;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(Boost REQUIRED COMPONENTS)
-
 find_package(DocTest REQUIRED)
 
 add_custom_target(build_tests)

--- a/tests/tests_flex_array.cpp
+++ b/tests/tests_flex_array.cpp
@@ -75,7 +75,7 @@ TEST_SUITE("flex_array") {
 	TEST_CASE("static size") {
 		static_assert(sizeof(flex_array<int, 1>) == sizeof(int));
 		static_assert(alignof(flex_array<int, 1>) == alignof(int));
-		static_assert(flex_array<int, 1>::implementation == flex_array_implementation::array);
+		static_assert(flex_array<int, 1>::mode == flex_array_mode::direct_static_sized);
 
 		SUBCASE("default ctor") {
 			flex_array<int, 5> f;
@@ -129,7 +129,7 @@ TEST_SUITE("flex_array") {
 	TEST_CASE("dynamic size but bounded") {
 		static_assert(sizeof(flex_array<int, dynamic_extent, 2>) == 2*sizeof(int) + sizeof(size_t));
 		static_assert(alignof(flex_array<int, dynamic_extent, 2>) == alignof(size_t));
-		static_assert(flex_array<int, dynamic_extent, 1>::implementation == flex_array_implementation::array_and_size);
+		static_assert(flex_array<int, dynamic_extent, 1>::mode == flex_array_mode::direct_dynamic_limited_sized);
 
 		SUBCASE("default ctor") {
 			flex_array<int, dynamic_extent, 5> f;
@@ -186,7 +186,7 @@ TEST_SUITE("flex_array") {
 	TEST_CASE("dynamic size not bounded") {
 		static_assert(sizeof(flex_array<int, 2, dynamic_extent>) == 2*sizeof(int) + sizeof(size_t));
 		static_assert(alignof(flex_array<int, 2, dynamic_extent>) == alignof(size_t));
-		static_assert(flex_array<int, 1, dynamic_extent>::implementation == flex_array_implementation::sbo_vector);
+		static_assert(flex_array<int, 1, dynamic_extent>::mode == flex_array_mode::sbo_dynamic_sized);
 
 		using farray = flex_array<int, 4, dynamic_extent>;
 

--- a/tests/tests_flex_array.cpp
+++ b/tests/tests_flex_array.cpp
@@ -75,7 +75,7 @@ TEST_SUITE("flex_array") {
 	TEST_CASE("static size") {
 		static_assert(sizeof(flex_array<int, 1>) == sizeof(int));
 		static_assert(alignof(flex_array<int, 1>) == alignof(int));
-		static_assert(flex_array<int, 1>::mode == flex_array_mode::direct_static_sized);
+		static_assert(flex_array<int, 1>::mode == flex_array_mode::direct_static_size);
 
 		SUBCASE("default ctor") {
 			flex_array<int, 5> f;
@@ -129,7 +129,7 @@ TEST_SUITE("flex_array") {
 	TEST_CASE("dynamic size but bounded") {
 		static_assert(sizeof(flex_array<int, dynamic_extent, 2>) == 2*sizeof(int) + sizeof(size_t));
 		static_assert(alignof(flex_array<int, dynamic_extent, 2>) == alignof(size_t));
-		static_assert(flex_array<int, dynamic_extent, 1>::mode == flex_array_mode::direct_dynamic_limited_sized);
+		static_assert(flex_array<int, dynamic_extent, 1>::mode == flex_array_mode::direct_dynamic_limited_size);
 
 		SUBCASE("default ctor") {
 			flex_array<int, dynamic_extent, 5> f;
@@ -186,7 +186,7 @@ TEST_SUITE("flex_array") {
 	TEST_CASE("dynamic size not bounded") {
 		static_assert(sizeof(flex_array<int, 2, dynamic_extent>) == 2*sizeof(int) + sizeof(size_t));
 		static_assert(alignof(flex_array<int, 2, dynamic_extent>) == alignof(size_t));
-		static_assert(flex_array<int, 1, dynamic_extent>::mode == flex_array_mode::sbo_dynamic_sized);
+		static_assert(flex_array<int, 1, dynamic_extent>::mode == flex_array_mode::sbo_dynamic_size);
 
 		using farray = flex_array<int, 4, dynamic_extent>;
 

--- a/tests/tests_flex_array.cpp
+++ b/tests/tests_flex_array.cpp
@@ -75,6 +75,7 @@ TEST_SUITE("flex_array") {
 	TEST_CASE("static size") {
 		static_assert(sizeof(flex_array<int, 1>) == sizeof(int));
 		static_assert(alignof(flex_array<int, 1>) == alignof(int));
+		static_assert(flex_array<int, 1>::implementation == flex_array_implementation::array);
 
 		SUBCASE("default ctor") {
 			flex_array<int, 5> f;
@@ -128,6 +129,7 @@ TEST_SUITE("flex_array") {
 	TEST_CASE("dynamic size but bounded") {
 		static_assert(sizeof(flex_array<int, dynamic_extent, 2>) == 2*sizeof(int) + sizeof(size_t));
 		static_assert(alignof(flex_array<int, dynamic_extent, 2>) == alignof(size_t));
+		static_assert(flex_array<int, dynamic_extent, 1>::implementation == flex_array_implementation::array_and_size);
 
 		SUBCASE("default ctor") {
 			flex_array<int, dynamic_extent, 5> f;
@@ -180,9 +182,11 @@ TEST_SUITE("flex_array") {
 		}
 	}
 
+#if __has_include(<ankerl/svector.h>)
 	TEST_CASE("dynamic size not bounded") {
 		static_assert(sizeof(flex_array<int, 2, dynamic_extent>) == 2*sizeof(int) + sizeof(size_t));
 		static_assert(alignof(flex_array<int, 2, dynamic_extent>) == alignof(size_t));
+		static_assert(flex_array<int, 1, dynamic_extent>::implementation == flex_array_implementation::sbo_vector);
 
 		using farray = flex_array<int, 4, dynamic_extent>;
 
@@ -267,4 +271,5 @@ TEST_SUITE("flex_array") {
 			CHECK_THROWS_AS((flex_array<int, 4>{d2}), std::length_error);
 		}
 	}
+#endif // __has_include
 }

--- a/tests/tests_polymorphic_allocator.cpp
+++ b/tests/tests_polymorphic_allocator.cpp
@@ -72,6 +72,8 @@ struct mallocator2 {
 };
 
 TEST_SUITE("polymorphic_allocator") {
+
+#if __has_include(<boost/interprocess/offset_ptr.hpp>)
 	TEST_CASE("offset_ptr_stl_allocator") {
 		using alloc_t = dice::template_library::offset_ptr_stl_allocator<int>;
 
@@ -81,6 +83,7 @@ TEST_SUITE("polymorphic_allocator") {
 		CHECK(*ptr == 5);
 		std::allocator_traits<alloc_t>::deallocate(alloc, ptr, 1);
 	}
+#endif // __has_include
 
 	template<typename T>
 	using poly_alloc2_t = dice::template_library::polymorphic_allocator<T, std::allocator, mallocator>;


### PR DESCRIPTION
Implements a third variant of `flex_array` (that behaves like a vector with small buffer optimization).

Variants (let `CONSTANT` be some integer constant):
- `flex_array<T, CONSTANT, CONSTANT>` (preexisting) ~ std::array
- `flex_array<T, dynamic_depth, CONSTANT>` (preexisting) ~ vector but maximum size of CONSTANT, all stack allocated
- `flex_array<T, CONSTANT, dynamic_depth>` (new) ~ vector with small buffer optimization (`small buffer size == CONSTANT`)

NOT a POBR breaking change because the preexisting configs have the same layout as before

TODO:
- [x] update example
- [x] update readme