### PR TITLE
Fix: generation of version file by removing header-only

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -13,7 +13,6 @@ class DiceTemplateLibrary(ConanFile):
     url = "https://github.com/dice-group/dice-template-library.git"
     license = "MIT"
     topics = "template", "template-library", "compile-time", "switch", "integral-tuple"
-    package_type = "header-library"
     generators = "CMakeDeps", "CMakeToolchain"
     settings = "os", "compiler", "build_type", "arch"
     exports_sources = "include/*", "CMakeLists.txt", "cmake/*", "LICENSE"

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,9 +14,7 @@ class DiceTemplateLibrary(ConanFile):
     license = "MIT"
     topics = "template", "template-library", "compile-time", "switch", "integral-tuple"
     generators = "CMakeDeps", "CMakeToolchain"
-    settings = "os", "compiler", "build_type", "arch"
     exports_sources = "include/*", "CMakeLists.txt", "cmake/*", "LICENSE"
-    no_copy_source = True
     options = {
         "with_test_deps": [True, False],
         "with_svector": [True, False],

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,6 +13,7 @@ class DiceTemplateLibrary(ConanFile):
     url = "https://github.com/dice-group/dice-template-library.git"
     license = "MIT"
     topics = "template", "template-library", "compile-time", "switch", "integral-tuple"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain"
     exports_sources = "include/*", "CMakeLists.txt", "cmake/*", "LICENSE"
     options = {


### PR DESCRIPTION
If `package_type = "header-library"` the `build()` function is not executed.