### PR TITLE
Feature: support any allocator in `offset_ptr_stl_allocator`

### DIFF
--- a/include/dice/template-library/polymorphic_allocator.hpp
+++ b/include/dice/template-library/polymorphic_allocator.hpp
@@ -387,6 +387,9 @@ namespace dice::template_library {
 		[[nodiscard]] upstream_allocator_type &upstream_allocator() noexcept {
 			return inner_;
 		}
+
+		constexpr bool operator==(offset_ptr_stl_allocator const &other) const noexcept = default;
+		constexpr bool operator!=(offset_ptr_stl_allocator const &other) const noexcept = default;
 	};
 #endif // __has_include(<boost/interprocess/offset_ptr.hpp>)
 

--- a/include/dice/template-library/polymorphic_allocator.hpp
+++ b/include/dice/template-library/polymorphic_allocator.hpp
@@ -388,8 +388,13 @@ namespace dice::template_library {
 			return inner_;
 		}
 
-		constexpr bool operator==(offset_ptr_stl_allocator const &other) const noexcept = default;
-		constexpr bool operator!=(offset_ptr_stl_allocator const &other) const noexcept = default;
+		friend constexpr void swap(offset_ptr_stl_allocator &a, offset_ptr_stl_allocator &b) noexcept(std::is_nothrow_swappable_v<upstream_allocator_type>) {
+			using std::swap;
+			swap(a.inner_, b.inner_);
+		}
+
+		bool operator==(offset_ptr_stl_allocator const &other) const noexcept = default;
+		bool operator!=(offset_ptr_stl_allocator const &other) const noexcept = default;
 	};
 #endif // __has_include(<boost/interprocess/offset_ptr.hpp>)
 

--- a/include/dice/template-library/polymorphic_allocator.hpp
+++ b/include/dice/template-library/polymorphic_allocator.hpp
@@ -345,13 +345,14 @@ namespace dice::template_library {
 
 	public:
 		constexpr offset_ptr_stl_allocator() noexcept(std::is_nothrow_default_constructible_v<upstream_allocator_type>) = default;
-		constexpr offset_ptr_stl_allocator(offset_ptr_stl_allocator const &other) noexcept = default;
-		constexpr offset_ptr_stl_allocator(offset_ptr_stl_allocator &&other) noexcept = default;
+		constexpr offset_ptr_stl_allocator(offset_ptr_stl_allocator const &other) noexcept(std::is_nothrow_move_constructible_v<upstream_allocator_type>) = default;
+		constexpr offset_ptr_stl_allocator(offset_ptr_stl_allocator &&other) noexcept(std::is_nothrow_copy_constructible_v<upstream_allocator_type>) = default;
 		constexpr offset_ptr_stl_allocator &operator=(offset_ptr_stl_allocator const &other) noexcept(std::is_nothrow_copy_assignable_v<upstream_allocator_type>) = default;
 		constexpr offset_ptr_stl_allocator &operator=(offset_ptr_stl_allocator &&other) noexcept(std::is_nothrow_move_assignable_v<upstream_allocator_type>) = default;
 
 		template<typename U>
-		constexpr offset_ptr_stl_allocator(offset_ptr_stl_allocator<U, Allocator> const &other) noexcept
+		constexpr offset_ptr_stl_allocator(offset_ptr_stl_allocator<U, Allocator> const &other)
+		noexcept(std::is_nothrow_constructible_v<upstream_allocator_type, typename offset_ptr_stl_allocator<U, Allocator>::upstream_allocator_type const &>)
 			: inner_{other.inner_} {
 		}
 

--- a/include/dice/template-library/polymorphic_allocator.hpp
+++ b/include/dice/template-library/polymorphic_allocator.hpp
@@ -388,7 +388,8 @@ namespace dice::template_library {
 			return inner_;
 		}
 
-		friend constexpr void swap(offset_ptr_stl_allocator &a, offset_ptr_stl_allocator &b) noexcept(std::is_nothrow_swappable_v<upstream_allocator_type>) {
+		friend constexpr void swap(offset_ptr_stl_allocator &a, offset_ptr_stl_allocator &b) noexcept(std::is_nothrow_swappable_v<upstream_allocator_type>)
+		requires(std::is_swappable_v<upstream_allocator_type>) {
 			using std::swap;
 			swap(a.inner_, b.inner_);
 		}

--- a/include/dice/template-library/polymorphic_allocator.hpp
+++ b/include/dice/template-library/polymorphic_allocator.hpp
@@ -188,8 +188,10 @@ namespace dice::template_library {
 		constexpr bool operator==(polymorphic_allocator const &other) const noexcept = default;
 		constexpr bool operator!=(polymorphic_allocator const &other) const noexcept = default;
 
-		friend constexpr void swap(polymorphic_allocator &lhs, polymorphic_allocator &rhs) noexcept(noexcept(std::swap(lhs.alloc_, rhs.alloc_))) {
-			std::swap(lhs.alloc_, rhs.alloc_);
+		friend constexpr void swap(polymorphic_allocator &lhs, polymorphic_allocator &rhs) noexcept(std::is_nothrow_swappable_v<inner_variant_t>)
+		requires (std::is_swappable_v<inner_variant_t>) {
+			using std::swap;
+			swap(lhs.alloc_, rhs.alloc_);
 		}
 
 		constexpr polymorphic_allocator select_on_container_copy_construction() const {
@@ -287,8 +289,10 @@ namespace dice::template_library {
 		constexpr bool operator==(polymorphic_allocator const &other) const noexcept = default;
 		constexpr bool operator!=(polymorphic_allocator const &other) const noexcept = default;
 
-		friend constexpr void swap(polymorphic_allocator &lhs, polymorphic_allocator &rhs) noexcept(noexcept(std::swap(lhs.alloc_, rhs.alloc_))) {
-			std::swap(lhs.alloc_, rhs.alloc_);
+		friend constexpr void swap(polymorphic_allocator &lhs, polymorphic_allocator &rhs) noexcept(std::is_nothrow_swappable_v<inner_type>)
+		requires (std::is_swappable_v<inner_type>) {
+			using std::swap;
+			swap(lhs.alloc_, rhs.alloc_);
 		}
 
 		constexpr polymorphic_allocator select_on_container_copy_construction() const {

--- a/include/dice/template-library/polymorphic_allocator.hpp
+++ b/include/dice/template-library/polymorphic_allocator.hpp
@@ -359,7 +359,7 @@ namespace dice::template_library {
 		}
 
 		template<typename ...Args>
-		constexpr offset_ptr_stl_allocator(std::in_place_t, Args &&...args) noexcept(std::is_nothrow_constructible_v<upstream_allocator_type, decltype(std::forward<Args>(args))...>)
+		explicit constexpr offset_ptr_stl_allocator(std::in_place_t, Args &&...args) noexcept(std::is_nothrow_constructible_v<upstream_allocator_type, decltype(std::forward<Args>(args))...>)
 			: inner_{std::forward<Args>(args)...} {
 		}
 

--- a/include/dice/template-library/polymorphic_allocator.hpp
+++ b/include/dice/template-library/polymorphic_allocator.hpp
@@ -345,22 +345,15 @@ namespace dice::template_library {
 
 	public:
 		constexpr offset_ptr_stl_allocator() noexcept(std::is_nothrow_default_constructible_v<upstream_allocator_type>) = default;
-
-		constexpr offset_ptr_stl_allocator(offset_ptr_stl_allocator const &other) noexcept(std::is_nothrow_copy_constructible_v<upstream_allocator_type>)
-			: inner_{other.inner_} {
-		}
-
-		constexpr offset_ptr_stl_allocator(offset_ptr_stl_allocator &&other) noexcept(std::is_nothrow_move_constructible_v<upstream_allocator_type>)
-			: inner_{other.inner_} {
-		}
+		constexpr offset_ptr_stl_allocator(offset_ptr_stl_allocator const &other) noexcept = default;
+		constexpr offset_ptr_stl_allocator(offset_ptr_stl_allocator &&other) noexcept = default;
+		constexpr offset_ptr_stl_allocator &operator=(offset_ptr_stl_allocator const &other) noexcept(std::is_nothrow_copy_assignable_v<upstream_allocator_type>) = default;
+		constexpr offset_ptr_stl_allocator &operator=(offset_ptr_stl_allocator &&other) noexcept(std::is_nothrow_move_assignable_v<upstream_allocator_type>) = default;
 
 		template<typename U>
 		constexpr offset_ptr_stl_allocator(offset_ptr_stl_allocator<U, Allocator> const &other) noexcept
 			: inner_{other.inner_} {
 		}
-
-		constexpr offset_ptr_stl_allocator &operator=(offset_ptr_stl_allocator const &other) noexcept(std::is_nothrow_copy_assignable_v<upstream_allocator_type>) = default;
-		constexpr offset_ptr_stl_allocator &operator=(offset_ptr_stl_allocator &&other) noexcept(std::is_nothrow_move_assignable_v<upstream_allocator_type>) = default;
 
 		explicit constexpr offset_ptr_stl_allocator(upstream_allocator_type const &upstream) noexcept(std::is_nothrow_copy_constructible_v<upstream_allocator_type>)
 			: inner_{upstream} {

--- a/include/dice/template-library/polymorphic_allocator.hpp
+++ b/include/dice/template-library/polymorphic_allocator.hpp
@@ -118,9 +118,9 @@ namespace dice::template_library {
 		using void_pointer = typename detail_pmr::same_type<typename std::allocator_traits<Allocators<T>>::void_pointer...>::type;
 		using const_void_pointer = typename detail_pmr::same_type<typename std::allocator_traits<Allocators<T>>::const_void_pointer...>::type;
 
-		using propagate_on_container_copy_assignment = std::bool_constant<(std::allocator_traits<Allocators<T>>::propagate_on_container_copy_assignment::value || ...)>;
-		using propagate_on_container_move_assignment = std::bool_constant<(std::allocator_traits<Allocators<T>>::propagate_on_container_move_assignment::value || ...)>;
-		using propagate_on_container_swap = std::bool_constant<(std::allocator_traits<Allocators<T>>::propagate_on_container_swap::value || ...)>;
+		using propagate_on_container_copy_assignment = std::bool_constant<(std::allocator_traits<Allocators<T>>::propagate_on_container_copy_assignment::value && ...)>;
+		using propagate_on_container_move_assignment = std::bool_constant<(std::allocator_traits<Allocators<T>>::propagate_on_container_move_assignment::value && ...)>;
+		using propagate_on_container_swap = std::bool_constant<(std::allocator_traits<Allocators<T>>::propagate_on_container_swap::value && ...)>;
 		using is_always_equal = std::bool_constant<sizeof...(Allocators) == 1 && std::allocator_traits<typename detail_pmr::first_type<Allocators<T>...>::type>::is_always_equal::value>;
 
 		template<typename U>

--- a/include/dice/template-library/polymorphic_allocator.hpp
+++ b/include/dice/template-library/polymorphic_allocator.hpp
@@ -347,6 +347,11 @@ namespace dice::template_library {
 			: inner_{other.inner_} {
 		}
 
+		template<typename U>
+		constexpr offset_ptr_stl_allocator(offset_ptr_stl_allocator<U, Allocator> const &other) noexcept
+			: inner_{other.inner_} {
+		}
+
 		constexpr offset_ptr_stl_allocator &operator=(offset_ptr_stl_allocator const &other) noexcept(std::is_nothrow_copy_assignable_v<upstream_allocator_type>) = default;
 		constexpr offset_ptr_stl_allocator &operator=(offset_ptr_stl_allocator &&other) noexcept(std::is_nothrow_move_assignable_v<upstream_allocator_type>) = default;
 
@@ -361,11 +366,6 @@ namespace dice::template_library {
 		template<typename ...Args>
 		explicit constexpr offset_ptr_stl_allocator(std::in_place_t, Args &&...args) noexcept(std::is_nothrow_constructible_v<upstream_allocator_type, decltype(std::forward<Args>(args))...>)
 			: inner_{std::forward<Args>(args)...} {
-		}
-
-		template<typename U>
-		constexpr offset_ptr_stl_allocator(offset_ptr_stl_allocator<U> const &other) noexcept
-			: inner_{other.inner_} {
 		}
 
 		constexpr pointer allocate(size_t n) {

--- a/include/dice/template-library/polymorphic_allocator.hpp
+++ b/include/dice/template-library/polymorphic_allocator.hpp
@@ -325,20 +325,23 @@ namespace dice::template_library {
 	struct offset_ptr_stl_allocator {
 		using value_type = T;
 		using pointer = boost::interprocess::offset_ptr<T>;
+		using const_pointer = boost::interprocess::offset_ptr<T const>;
+		using void_pointer = boost::interprocess::offset_ptr<void>;
+		using const_void_pointer = boost::interprocess::offset_ptr<void const>;
 		using size_type = size_t;
 		using difference_type = std::ptrdiff_t;
 		using upstream_allocator_type = Allocator<T>;
 
-		using propagate_on_container_copy_assignment = typename std::allocator_traits<Allocator<T>>::propagate_on_container_copy_assignment;
-		using propagate_on_container_move_assignment = typename std::allocator_traits<Allocator<T>>::propagate_on_container_move_assignment;
-		using propagate_on_container_swap = typename std::allocator_traits<Allocator<T>>::propagate_on_container_swap;
-		using is_always_equal = typename std::allocator_traits<Allocator<T>>::is_always_equal;
+		using propagate_on_container_copy_assignment = typename std::allocator_traits<upstream_allocator_type>::propagate_on_container_copy_assignment;
+		using propagate_on_container_move_assignment = typename std::allocator_traits<upstream_allocator_type>::propagate_on_container_move_assignment;
+		using propagate_on_container_swap = typename std::allocator_traits<upstream_allocator_type>::propagate_on_container_swap;
+		using is_always_equal = typename std::allocator_traits<upstream_allocator_type>::is_always_equal;
 
 	private:
 		template<typename, template<typename> typename>
 		friend struct offset_ptr_stl_allocator;
 
-		[[no_unique_address]] Allocator<T> inner_;
+		[[no_unique_address]] upstream_allocator_type inner_;
 
 	public:
 		constexpr offset_ptr_stl_allocator() noexcept(std::is_nothrow_default_constructible_v<upstream_allocator_type>) = default;

--- a/include/dice/template-library/polymorphic_allocator.hpp
+++ b/include/dice/template-library/polymorphic_allocator.hpp
@@ -350,11 +350,11 @@ namespace dice::template_library {
 		constexpr offset_ptr_stl_allocator &operator=(offset_ptr_stl_allocator const &other) noexcept(std::is_nothrow_copy_assignable_v<upstream_allocator_type>) = default;
 		constexpr offset_ptr_stl_allocator &operator=(offset_ptr_stl_allocator &&other) noexcept(std::is_nothrow_move_assignable_v<upstream_allocator_type>) = default;
 
-		constexpr offset_ptr_stl_allocator(upstream_allocator_type const &upstream) noexcept(std::is_nothrow_copy_constructible_v<upstream_allocator_type>)
+		explicit constexpr offset_ptr_stl_allocator(upstream_allocator_type const &upstream) noexcept(std::is_nothrow_copy_constructible_v<upstream_allocator_type>)
 			: inner_{upstream} {
 		}
 
-		constexpr offset_ptr_stl_allocator(upstream_allocator_type &&upstream) noexcept(std::is_nothrow_move_constructible_v<upstream_allocator_type>)
+		explicit constexpr offset_ptr_stl_allocator(upstream_allocator_type &&upstream) noexcept(std::is_nothrow_move_constructible_v<upstream_allocator_type>)
 			: inner_{std::move(upstream)} {
 		}
 

--- a/tests/tests_polymorphic_allocator.cpp
+++ b/tests/tests_polymorphic_allocator.cpp
@@ -83,6 +83,18 @@ TEST_SUITE("polymorphic_allocator") {
 		CHECK(*ptr == 5);
 		std::allocator_traits<alloc_t>::deallocate(alloc, ptr, 1);
 	}
+
+	TEST_CASE("offset_ptr_stl_allocator with std::pmr") {
+		using alloc_t = dice::template_library::offset_ptr_stl_allocator<int, std::pmr::polymorphic_allocator>;
+
+		std::pmr::monotonic_buffer_resource rc;
+		alloc_t alloc{&rc};
+
+		auto ptr = std::allocator_traits<alloc_t>::allocate(alloc, 1);
+		*ptr = 5;
+		CHECK(*ptr == 5);
+		std::allocator_traits<alloc_t>::deallocate(alloc, ptr, 1);
+	}
 #endif // __has_include
 
 	template<typename T>


### PR DESCRIPTION
Support any `stl`-like allocator in `offset_ptr_stl_allocator` not just `std::allocator`