### PR TITLE
Feature: copy qualifier type traits

### DIFF
--- a/include/dice/template-library/type_traits.hpp
+++ b/include/dice/template-library/type_traits.hpp
@@ -31,6 +31,64 @@ namespace dice::template_library {
 	template<typename T>
 	inline constexpr bool is_zst_v = is_zst<T>::value;
 
+	/**
+	 * If From is const make To const as well
+	 */
+	template<typename From, typename To>
+	struct copy_const {
+		using type = To;
+	};
+
+	template<typename From, typename To>
+	struct copy_const<From const, To> {
+		using type = To const;
+	};
+
+	template<typename From, typename To>
+	using copy_const_t = typename copy_const<From, To>::type;
+
+	/**
+	 * If From is volatile make To volatile as well
+	 */
+	template<typename From, typename To>
+	struct copy_volatile {
+		using type = To;
+	};
+
+	template<typename From, typename To>
+	struct copy_volatile<From volatile, To> {
+		using type = To volatile;
+	};
+
+	template<typename From, typename To>
+	using copy_volatile_t = typename copy_volatile<From, To>::type;
+
+	/**
+	 * If From is const and/or volatile make To const and/or volatile as well
+	 */
+	template<typename From, typename To>
+	struct copy_cv {
+		using type = To;
+	};
+
+	template<typename From, typename To>
+	struct copy_cv<From const, To> {
+		using type = To const;
+	};
+
+	template<typename From, typename To>
+	struct copy_cv<From volatile, To> {
+		using type = To volatile;
+	};
+
+	template<typename From, typename To>
+	struct copy_cv<From const volatile, To> {
+		using type = To const volatile;
+	};
+
+	template<typename From, typename To>
+	using copy_cv_t = typename copy_cv<From, To>::type;
+
 } // namespace dice::template_library
 
 #endif // DICE_TEMPLATELIBRARY_ZST_HPP

--- a/tests/tests_type_traits.cpp
+++ b/tests/tests_type_traits.cpp
@@ -2,8 +2,10 @@
 #include <doctest/doctest.h>
 
 #include <dice/template-library/type_traits.hpp>
+#include <type_traits>
 
 TEST_SUITE("type_traits") {
+	using namespace dice::template_library;
 
 	TEST_CASE("is_zst") {
 		struct zst {};
@@ -11,13 +13,48 @@ TEST_SUITE("type_traits") {
 			int x;
 		};
 
-		static_assert(dice::template_library::is_zst<zst>::value);
-		static_assert(dice::template_library::is_zst_v<zst>);
+		static_assert(is_zst<zst>::value);
+		static_assert(is_zst_v<zst>);
 
-		static_assert(!dice::template_library::is_zst<non_zst>::value);
-		static_assert(!dice::template_library::is_zst_v<non_zst>);
+		static_assert(!is_zst<non_zst>::value);
+		static_assert(!is_zst_v<non_zst>);
 
-		static_assert(!dice::template_library::is_zst<void>::value);
-		static_assert(!dice::template_library::is_zst_v<void>);
+		static_assert(!is_zst<void>::value);
+		static_assert(!is_zst_v<void>);
+	}
+
+	TEST_CASE("copy_const") {
+		static_assert(std::is_same_v<copy_const_t<int, double>, double>);
+		static_assert(std::is_same_v<copy_const_t<int const, double>, double const>);
+		static_assert(std::is_same_v<copy_const_t<int const &, double>, double>);
+		static_assert(std::is_same_v<copy_const_t<int &, double>, double>);
+		static_assert(std::is_same_v<copy_const_t<int volatile, double>, double>);
+		static_assert(std::is_same_v<copy_const_t<int const, double const>, double const>);
+		static_assert(std::is_same_v<copy_const_t<int const volatile, double const>, double const>);
+	}
+
+	TEST_CASE("copy_volatile") {
+		static_assert(std::is_same_v<copy_volatile_t<int, double>, double>);
+		static_assert(std::is_same_v<copy_volatile_t<int volatile, double>, double volatile>);
+		static_assert(std::is_same_v<copy_volatile_t<int volatile &, double>, double>);
+		static_assert(std::is_same_v<copy_volatile_t<int &, double>, double>);
+		static_assert(std::is_same_v<copy_volatile_t<int const, double>, double>);
+		static_assert(std::is_same_v<copy_volatile_t<int volatile, double volatile>, double volatile>);
+		static_assert(std::is_same_v<copy_volatile_t<int const volatile, double volatile>, double volatile>);
+	}
+
+	TEST_CASE("copy_cv") {
+		static_assert(std::is_same_v<copy_cv_t<int, double>, double>);
+		static_assert(std::is_same_v<copy_cv_t<int const, double>, double const>);
+		static_assert(std::is_same_v<copy_cv_t<int const &, double>, double>);
+		static_assert(std::is_same_v<copy_cv_t<int &, double>, double>);
+		static_assert(std::is_same_v<copy_cv_t<int, double>, double>);
+		static_assert(std::is_same_v<copy_cv_t<int volatile, double>, double volatile>);
+		static_assert(std::is_same_v<copy_cv_t<int volatile &, double>, double>);
+		static_assert(std::is_same_v<copy_cv_t<int &, double>, double>);
+		static_assert(std::is_same_v<copy_cv_t<int const volatile, double>, double const volatile>);
+		static_assert(std::is_same_v<copy_cv_t<int const volatile, double const>, double const volatile>);
+		static_assert(std::is_same_v<copy_cv_t<int const volatile, double volatile>, double const volatile>);
+		static_assert(std::is_same_v<copy_cv_t<int const volatile, double const volatile>, double const volatile>);
 	}
 }


### PR DESCRIPTION
Adds type traits that copy qualifiers from one type to another:
- `copy_const`
- `copy_volatile`
- `copy_cv`

I needed those a few times already so I thought this is a good time to put them in this library.