### PR TITLE
Feature: `match` convenience function

### DIFF
--- a/include/dice/template-library/overloaded.hpp
+++ b/include/dice/template-library/overloaded.hpp
@@ -1,6 +1,8 @@
 #ifndef DICE_TEMPLATE_LIBRARY_OVERLOADED_HPP
 #define DICE_TEMPLATE_LIBRARY_OVERLOADED_HPP
 
+#include <utility>
+
 namespace dice::template_library {
 
 	/**
@@ -17,6 +19,11 @@ namespace dice::template_library {
 
 	template<typename ...Fs>
 	overloaded(Fs...) -> overloaded<Fs...>;
+
+	template<typename Variant, typename ...Fs>
+	decltype(auto) match(Variant &&variant, Fs &&...visitors) {
+		return visit(overloaded{std::forward<Fs>(visitors)...}, std::forward<Variant>(variant));
+	}
 
 } // namespace dice::template_library
 

--- a/tests/tests_overloaded.cpp
+++ b/tests/tests_overloaded.cpp
@@ -20,5 +20,17 @@ TEST_SUITE("overloaded") {
 				FAIL("not expecting float");
 			}
 		}, v);
+
+		dice::template_library::match(v,
+			[](int x) {
+				CHECK_EQ(x, 5);
+			},
+			[](double d) {
+				FAIL("not expecting double");
+			},
+			[](auto f) {
+				FAIL("not expecting float");
+			}
+		);
 	}
 }


### PR DESCRIPTION
add `match` function as convenience for the common `visit(overloaded{...}, x)` pattern