### PR TITLE
Feature: `next_to_range` & `next_to_iter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It contains:
 - `mutex`/`shared_mutex`: Rust inspired mutex interfaces that hold their data instead of living next to it
 - `static_string`: A string type that is smaller than `std::string` for use cases where you do not need to resize the string
 - `ranges`: Additional range algorithms and adaptors that are missing from the standard library.  
-- `iter_to_range`: Eliminate the boilerplate required to write C++ iterators and ranges.
+- `next_to_range`/`next_to_iter`: Eliminate the boilerplate required to write C++ iterators and ranges.
 
 ## Usage
 
@@ -137,7 +137,7 @@ It also supports allocators with "fancy" pointers.
 Additional range algorithms (e.g. `unique_view`) and adaptors (e.g., a pipeable `all_of`)
 that are missing from the standard library.
 
-### `iter_to_range`
+### `next_to_range`/`next_to_iter`
 Eliminate the boilerplate required to write C++ iterators and ranges.
 To get a fully functional range, the only thing that is required is
 implementing a minimal, rust-style iterator interface.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -137,9 +137,9 @@ target_link_libraries(example_static_string
 )
 
 
-add_executable(example_iter_to_range
-        example_iter_to_range.cpp)
-target_link_libraries(example_iter_to_range
+add_executable(example_next_to_range
+        example_next_to_range.cpp)
+target_link_libraries(example_next_to_range
         PRIVATE
         dice-template-library::dice-template-library
 )

--- a/examples/example_next_to_range.cpp
+++ b/examples/example_next_to_range.cpp
@@ -1,4 +1,4 @@
-#include <dice/template-library/iter_to_range.hpp>
+#include <dice/template-library/next_to_range.hpp>
 
 #include <cstddef>
 #include <iostream>
@@ -25,11 +25,11 @@ protected:
 };
 
 // Create just a C++-style iterator
-using iota_iter = dtl::iter_to_iter<iota_iter_impl>;
+using iota_iter = dtl::next_to_iter<iota_iter_impl>;
 static_assert(std::input_iterator<iota_iter>);
 
 // Create a C++-style range
-using iota = dtl::iter_to_range<iota_iter>;
+using iota = dtl::next_to_range<iota_iter>;
 static_assert(std::ranges::range<iota>);
 
 

--- a/include/dice/template-library/next_to_range.hpp
+++ b/include/dice/template-library/next_to_range.hpp
@@ -1,5 +1,5 @@
-#ifndef DICE_TEMPLATELIBRARY_ITERTORANGE_HPP
-#define DICE_TEMPLATELIBRARY_ITERTORANGE_HPP
+#ifndef DICE_TEMPLATELIBRARY_NEXTTORANGE_HPP
+#define DICE_TEMPLATELIBRARY_NEXTTORANGE_HPP
 
 #include <cassert>
 #include <cstddef>
@@ -23,7 +23,7 @@ namespace dice::template_library {
 	 * We are not using a concept here, because concepts require things to be public
 	 */
 	template<typename Iter>
-	struct iter_to_iter : Iter {
+	struct next_to_iter : Iter {
 		using base_iterator = Iter;
 		using sentinel = std::default_sentinel_t;
 		using value_type = typename Iter::value_type;
@@ -47,7 +47,7 @@ namespace dice::template_library {
 
 	public:
 		template<typename ...Args>
-		explicit iter_to_iter(Args &&...args) : Iter{std::forward<Args>(args)...},
+		explicit next_to_iter(Args &&...args) : Iter{std::forward<Args>(args)...},
 												cur_{this->next()} {
 		}
 
@@ -78,12 +78,12 @@ namespace dice::template_library {
 			return *cur_;
 		}
 
-		iter_to_iter &operator++() {
+		next_to_iter &operator++() {
 			advance();
 			return *this;
 		}
 
-		std::conditional_t<std::is_copy_constructible_v<base_iterator>, iter_to_iter, void> operator++(int) {
+		std::conditional_t<std::is_copy_constructible_v<base_iterator>, next_to_iter, void> operator++(int) {
 			if constexpr (std::is_copy_constructible_v<base_iterator>) {
 				auto cpy = *this;
 				advance();
@@ -107,11 +107,11 @@ namespace dice::template_library {
 			return peeked_;
 		}
 
-		friend bool operator==(iter_to_iter const &self, sentinel) noexcept {
+		friend bool operator==(next_to_iter const &self, sentinel) noexcept {
 			return !self.cur_.has_value();
 		}
 
-		friend bool operator==(sentinel, iter_to_iter const &self) noexcept {
+		friend bool operator==(sentinel, next_to_iter const &self) noexcept {
 			return !self.cur_.has_value();
 		}
 	};
@@ -129,8 +129,8 @@ namespace dice::template_library {
 	 * We are not using a concept here, because concepts require things to be public
 	 */
 	template<typename Iter>
-	struct iter_to_range {
-		using iterator = iter_to_iter<Iter>;
+	struct next_to_range {
+		using iterator = next_to_iter<Iter>;
 		using sentinel = typename iterator::sentinel;
 		using value_type = typename iterator::value_type;
 
@@ -143,12 +143,12 @@ namespace dice::template_library {
 
 	public:
 		template<typename ...Args> requires (!std::is_copy_constructible_v<Iter>)
-		explicit iter_to_range(Args &&...args)
+		explicit next_to_range(Args &&...args)
 			: make_iter_{[...args = std::forward<Args>(args)] { return iterator{args...}; }} {
 		}
 
 		template<typename ...Args> requires (std::is_copy_constructible_v<Iter>)
-		explicit iter_to_range(Args &&...args)
+		explicit next_to_range(Args &&...args)
 			: make_iter_{std::forward<Args>(args)...} {
 		}
 
@@ -172,4 +172,4 @@ namespace dice::template_library {
 } // namespace dice::template_library
 
 
-#endif // DICE_TEMPLATELIBRARY_ITERTORANGE_HPP
+#endif // DICE_TEMPLATELIBRARY_NEXTTORANGE_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,5 +88,5 @@ custom_add_test(tests_shared_mutex)
 add_executable(tests_static_string tests_static_string.cpp)
 custom_add_test(tests_static_string)
 
-add_executable(tests_iter_to_range tests_iter_to_range.cpp)
-custom_add_test(tests_iter_to_range)
+add_executable(tests_next_to_range tests_next_to_range.cpp)
+custom_add_test(tests_next_to_range)

--- a/tests/tests_next_to_range.cpp
+++ b/tests/tests_next_to_range.cpp
@@ -1,7 +1,7 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 
-#include <dice/template-library/iter_to_range.hpp>
+#include <dice/template-library/next_to_range.hpp>
 
 
 #include <algorithm>
@@ -13,7 +13,7 @@
 
 namespace dtl = dice::template_library;
 
-TEST_SUITE("iter_to_range") {
+TEST_SUITE("next_to_range") {
 	struct non_copy_iota_iter {
 		using value_type = int;
 
@@ -36,7 +36,7 @@ TEST_SUITE("iter_to_range") {
 		}
 	};
 
-	using non_copy_iota = dtl::iter_to_range<non_copy_iota_iter>;
+	using non_copy_iota = dtl::next_to_range<non_copy_iota_iter>;
 	static_assert(std::ranges::range<non_copy_iota>);
 
 	struct values_yielder_iter {
@@ -60,7 +60,7 @@ TEST_SUITE("iter_to_range") {
 		}
 	};
 
-	using values_yielder = dtl::iter_to_range<values_yielder_iter>;
+	using values_yielder = dtl::next_to_range<values_yielder_iter>;
 	static_assert(std::ranges::range<values_yielder>);
 
 


### PR DESCRIPTION
Make a C++-style range (or iterator) out of a rust-style iterator.

For the review: start with the example, that should make everything clear.