### PR TITLE
More features for `type_list`

### DIFF
--- a/include/dice/template-library/type_list.hpp
+++ b/include/dice/template-library/type_list.hpp
@@ -284,7 +284,7 @@ namespace dice::template_library::type_list {
     } // namespace detail_position
 
     /**
-     * Searches for an element in the type list, returning its position.
+     * Searches for an element in the type list, returning the first position where the predicate returns true.
      */
     template<typename TL, auto pred>
     using position = detail_position::position<TL, pred, 0>;
@@ -418,19 +418,21 @@ namespace dice::template_library::type_list {
      */
     template<typename T>
     struct opt {
-        static constexpr auto value = nullopt{};
         using type = nullopt;
+        static constexpr auto value = nullopt{};
     };
 
     template<typename T>
     requires (detail_opt::type_present<T> && !detail_opt::value_present<T>)
     struct opt<T> {
         using type = typename T::type;
+        static constexpr auto value = nullopt{};
     };
 
     template<typename T>
     requires (!detail_opt::type_present<T> && detail_opt::value_present<T>)
     struct opt<T> {
+        using type = nullopt;
         static constexpr auto value = T::value;
     };
 

--- a/tests/tests_type_list.cpp
+++ b/tests/tests_type_list.cpp
@@ -168,6 +168,9 @@ TEST_SUITE("type_list") {
 		static_assert(tl::opt_v<tl::position<t2, pred1>> == tl::nullopt{});
 		static_assert(tl::opt_v<tl::position<t2, pred2>> == tl::nullopt{});
 		static_assert(tl::opt_v<tl::position<t2, pred3>> == tl::nullopt{});
+
+		using t3 = tl::type_list<int, int>;
+		static_assert(tl::position_v<t3, pred2> == 0);
 	}
 
 	TEST_CASE("contains") {


### PR DESCRIPTION
Adds:
- `position`
- `opt_v`
- remove `void_t` trick for `opt` (idk why I did not use a `requires` clause in the first place)

These were required in rdf4cpp (I previously overlooked them)