### PR TITLE
Feature: flex array mode without SBO

### DIFF
--- a/include/dice/template-library/flex_array.hpp
+++ b/include/dice/template-library/flex_array.hpp
@@ -7,6 +7,7 @@
 #include <concepts>
 #include <span>
 #include <stdexcept>
+#include <vector>
 
 #if __has_include(<ankerl/svector.h>)
 #include <ankerl/svector.h>
@@ -22,6 +23,7 @@ namespace dice::template_library {
 		direct_static_size, ///< size is static and flex array is stack allocated
 		direct_dynamic_limited_size, ///< size is dynamic but limited by max_size, flex array is stack allocated and has at most max_size elements
 		sbo_dynamic_size, ///< small buffer optimized vector
+		dynamic_size, ///< regular vector
 	};
 
 	namespace detail_flex_array {
@@ -125,6 +127,32 @@ namespace dice::template_library {
 			}
 		};
 
+		template<typename T>
+		struct flex_array_inner<T, dynamic_extent, dynamic_extent> {
+			static constexpr flex_array_mode mode = flex_array_mode::dynamic_size;
+
+			std::vector<T> data_;
+
+			[[nodiscard]] size_t size() const noexcept {
+				return data_.size();
+			}
+
+			operator std::span<T>() noexcept {
+				return data_;
+			}
+
+			operator std::span<T const>() const noexcept {
+				return data_;
+			}
+
+			void set_size(size_t size) {
+				data_.resize(size);
+			}
+
+			bool operator==(flex_array_inner const &other) const noexcept = default;
+			auto operator<=>(flex_array_inner const &other) const noexcept = default;
+		};
+
 #if __has_include(<ankerl/svector.h>)
 		template<typename T, size_t extent> requires (extent != dynamic_extent)
 		struct flex_array_inner<T, extent, dynamic_extent> {
@@ -205,7 +233,7 @@ namespace dice::template_library {
 				return false;
 			}
 
-			static_assert(always_false<flex_array_inner>(), "Could not find <ankerl/svector.h>, flex_array_implementation::sbo_vector mode is not available.");
+			static_assert(always_false<flex_array_inner>(), "Could not find <ankerl/svector.h>, flex_array_implementation::sbo_dynamic_size mode is not available.");
 		};
 #endif // __has_include
 	} // namespace detail_flex_array
@@ -227,14 +255,6 @@ namespace dice::template_library {
 		using inner_type = detail_flex_array::flex_array_inner<T, extent_, max_extent_>;
 
 	public:
-		// extent_ == dynamic_extent -> max_extent_ != dynamic_extent
-		static_assert(extent_ != dynamic_extent || max_extent_ != dynamic_extent,
-					  "If extent is not dynamic_extent, extent must be equal to max_extent");
-
-		// max_extent_ == dynamic_extent -> extent_ != dynamic_extent
-		static_assert(max_extent_ != dynamic_extent || extent_ != dynamic_extent,
-					  "If extent is dynamic_extent, max_extent must not be dynamic_extent");
-
 		static constexpr size_t extent = extent_;
 		static constexpr size_t max_extent = max_extent_;
 
@@ -376,11 +396,11 @@ namespace dice::template_library {
 		[[nodiscard]] constexpr pointer data() noexcept { return inner_.data_.data(); }
 		[[nodiscard]] constexpr const_pointer data() const noexcept { return inner_.data_.data(); }
 
-		constexpr iterator begin() noexcept { return inner_.data_.begin(); }
+		constexpr iterator begin() noexcept { return inner_.data_.data(); }
 		constexpr iterator end() noexcept { return std::next(begin(), size()); }
-		constexpr const_iterator begin() const noexcept { return inner_.data_.begin(); }
+		constexpr const_iterator begin() const noexcept { return inner_.data_.data(); }
 		constexpr const_iterator end() const noexcept { return std::next(begin(), size()); }
-		constexpr const_iterator cbegin() const noexcept { return inner_.data_.cbegin(); }
+		constexpr const_iterator cbegin() const noexcept { return inner_.data_.data(); }
 		constexpr const_iterator cend() const noexcept { return std::next(cbegin(), size()); }
 		constexpr reverse_iterator rbegin() noexcept { return reverse_iterator{end()}; }
 		constexpr reverse_iterator rend() noexcept { return reverse_iterator{begin()}; }

--- a/tests/tests_flex_array.cpp
+++ b/tests/tests_flex_array.cpp
@@ -245,26 +245,31 @@ TEST_SUITE("flex_array") {
 			REQUIRE_EQ(f <=> f, std::strong_ordering::equal);
 			REQUIRE_EQ(f3 <=> f, std::strong_ordering::greater);
 		}
+#if __has_include(<ankerl/svector.h>)
+	    SUBCASE("no-cmp") {
+		    struct uncomparable {};
+		    flex_array<uncomparable, 5, dynamic_extent> f; // checking if this compiles
+	    }
+#endif
 
-		SUBCASE("no-cmp") {
-			struct uncomparable {};
-			flex_array<uncomparable, 5, dynamic_extent> f; // checking if this compiles
-		}
 	}
 
 	TEST_CASE("converting ctors") {
 		SUBCASE("static -> dynamic") {
 			flex_array<int, 5> s{1, 2, 3, 4, 5};
 			flex_array<int, dynamic_extent, 6> d{s};
-			flex_array<int, 5, dynamic_extent> d2{s};
 
 			REQUIRE_EQ(d.size(), 5);
 			REQUIRE_EQ(d.max_size(), 6);
 			REQUIRE(std::ranges::equal(s, d));
-			REQUIRE(std::ranges::equal(s, d2));
 
 			d = s; // checking if this compiles
-			d2 = s;
+
+#if __has_include(<ankerl/svector.h>)
+		    flex_array<int, 5, dynamic_extent> d2{s};
+		    REQUIRE(std::ranges::equal(s, d2));
+		    d2 = s;
+#endif
 		}
 
 	    SUBCASE("dynamic -> static") {

--- a/tests/tests_flex_array.cpp
+++ b/tests/tests_flex_array.cpp
@@ -190,12 +190,17 @@ TEST_SUITE("flex_array") {
 	}
 
 #if __has_include(<ankerl/svector.h>)
-	TEST_CASE("dynamic size not bounded") {
-		static_assert(sizeof(flex_array<int, 2, dynamic_extent>) == 2*sizeof(int) + sizeof(size_t));
-		static_assert(alignof(flex_array<int, 2, dynamic_extent>) == alignof(size_t));
-		static_assert(flex_array<int, 1, dynamic_extent>::mode == flex_array_mode::sbo_dynamic_size);
+#define EXTS std::integral_constant<size_t, dynamic_extent>, std::integral_constant<size_t, 4>
+#else
+#define EXTS std::integral_constant<size_t, dynamic_extent>
+#endif
 
-		using farray = flex_array<int, 4, dynamic_extent>;
+    TEST_CASE_TEMPLATE("dynamic size not bounded", Ext, EXTS) {
+		static_assert(sizeof(flex_array<int, Ext::value, dynamic_extent>) == sizeof(void *) + 2*sizeof(size_t));
+		static_assert(alignof(flex_array<int, Ext::value, dynamic_extent>) == alignof(size_t));
+        static_assert(flex_array<int, Ext::value, dynamic_extent>::mode == (Ext::value == dynamic_extent ? flex_array_mode::dynamic_size : flex_array_mode::sbo_dynamic_size));
+
+		using farray = flex_array<int, Ext::value, dynamic_extent>;
 
 		SUBCASE("default ctor") {
 			farray f;
@@ -262,7 +267,24 @@ TEST_SUITE("flex_array") {
 			d2 = s;
 		}
 
-		SUBCASE("dynamic -> static") {
+	    SUBCASE("dynamic -> static") {
+		    flex_array<int, dynamic_extent, 5> d{1, 2, 3};
+		    flex_array<int, dynamic_extent> d2{1, 2, 3};
+
+		    flex_array<int, 3> s{d};
+		    flex_array<int, 3> s2{d2};
+
+		    REQUIRE(std::ranges::equal(s, d));
+		    REQUIRE(std::ranges::equal(s2, d2));
+
+		    REQUIRE_THROWS_AS((flex_array<int, 2>{d}), std::length_error);
+		    REQUIRE_THROWS_AS((flex_array<int, 4>{d}), std::length_error);
+		    REQUIRE_THROWS_AS((flex_array<int, 2>{d2}), std::length_error);
+		    REQUIRE_THROWS_AS((flex_array<int, 4>{d2}), std::length_error);
+		}
+
+#if __has_include(<ankerl/svector.h>)
+		SUBCASE("sbo dynamic -> static") {
 			flex_array<int, dynamic_extent, 5> d{1, 2, 3};
 			flex_array<int, 3, dynamic_extent> d2{1, 2, 3};
 
@@ -277,6 +299,6 @@ TEST_SUITE("flex_array") {
 			REQUIRE_THROWS_AS((flex_array<int, 2>{d2}), std::length_error);
 			REQUIRE_THROWS_AS((flex_array<int, 4>{d2}), std::length_error);
 		}
+#endif //__has_include(<ankerl/svector.h>)
 	}
-#endif // __has_include
 }


### PR DESCRIPTION
Add support for the missing combination `dynamic_extend, dynamic_extend`.

Not POBR breaking because this was not supported before.