### PR TITLE
Run workflows on PR instead of push

### DIFF
--- a/.github/workflows/code_testing.yaml
+++ b/.github/workflows/code_testing.yaml
@@ -1,6 +1,6 @@
 name: Build and run Tests
 
-on: [ push ]
+on: [ pull_request ]
 
 concurrency:
   group: build-and-run-tests-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/publish-conan-branch-package.yml
+++ b/.github/workflows/publish-conan-branch-package.yml
@@ -1,6 +1,6 @@
 name: Publish Conan branch package
 
-on: [ push ]
+on: [ pull_request ]
 
 concurrency:
   group: publish-conan-branch-package-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
should fix CI for PRs from forks