### PR TITLE
Fix: DICE_IGNORE_LEAK

### DIFF
--- a/include/dice/template-library/macro_util.hpp
+++ b/include/dice/template-library/macro_util.hpp
@@ -41,15 +41,45 @@
 #endif // __FILE_NAME__
 
 
-#if defined(__has_include) && __has_include(<sanitizer/lsan_interface.h>) && (defined(__SANITIZE_ADDRESS__) || __has_feature(address_sanitizer) || __has_feature(leak_sanitizer))
-#include <sanitizer/lsan_interface.h>
-/**
- * Tell the leak sanitizer to ignore that the given object is leaked.
- */
-#define DICE_IGNORE_LEAK(ptr) __lsan_ignore_object(ptr)
+#if defined(__has_attribute) && __has_attribute(weak)
+#define DICE_WEAK __attribute__((weak))
+#define DICE_HAS_WEAK 1
 #else
-#define DICE_IGNORE_LEAK(ptr)
+#define DICE_WEAK
+#define DICE_HAS_WEAK 0
 #endif
 
+#if DICE_HAS_WEAK
+// forward declaration for __lsan_ignore_object from <sanitizer/lsan_interface.h> as a weak symbol.
+// If the sanitizer is linked this it set to the correct value by the linker, if not this is set to nullptr by the linker.
+extern "C" DICE_WEAK void __lsan_ignore_object(void const *ptr); // NOLINT(bugprone-reserved-identifier)
+#endif
+
+namespace dice::template_library {
+    /**
+     * Tell the leak sanitizer to ignore that the given object is leaked.
+     */
+    inline void ignore_leak(void const *ptr) noexcept {
+#if DICE_HAS_WEAK
+        if (__lsan_ignore_object) {
+            __lsan_ignore_object(ptr);
+        }
+#endif
+
+        (void) ptr;
+    }
+
+    namespace detail_ignore_leak {
+        [[deprecated("DICE_IGNORE_LEAK is deprecated. Use dice::template_library::ignore_leak() instead.")]]
+        inline void deprecated_macro_use() {
+        }
+    }  // namespace detail_ignore_leak
+}  // namespace dice::template_library
+
+/**
+ * Tell the leak sanitizer to ignore that the given object is leaked.
+ * This macro is deprecated, use dice::template_library::ignore_leak instead.
+ */
+#define DICE_IGNORE_LEAK(ptr) (::dice::template_library::detail_ignore_leak::deprecated_macro_use(), ::dice::template_library::ignore_leak(ptr))
 
 #endif // DICE_TEMPLATELIBRARY_MACROUTIL_HPP

--- a/tests/tests_macro_util.cpp
+++ b/tests/tests_macro_util.cpp
@@ -21,6 +21,15 @@ TEST_SUITE("macro_util") {
 
     TEST_CASE("ignore leak") {
 	    auto *my_obj = new int{42};
+	    dice::template_library::ignore_leak(my_obj);
+	}
+
+    TEST_CASE("ignore leak, deprecated macro") {
+	    auto *my_obj = new int{42};
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	    DICE_IGNORE_LEAK(my_obj);
+#pragma GCC diagnostic pop
 	}
 }


### PR DESCRIPTION
Issue that this addresses: 

When dependencies are compiled without sanitizers but the main library/binary is compiles with sanitizers, it caused the `DICE_IGNORE_LEAK` used in cpp files of dependencies to expand to nothing and therefore triggered a sanitizer warning for the main library/binary.

This PR fixes this issue by checking in the final build product if the symbol exists (i.e. if sanitizers are enabled). This works by the linker filling in the address for `__lsan_ignore_object` if it exists, otherwise nullptr (weak symbol, like malloc).
