### PR TITLE
Implementation of bitset based on flex_array

### DIFF
--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -493,15 +493,12 @@ namespace dice::template_library {
                 return std::countr_zero(~segment);
             }
 
-            auto [word, end] = segment_slots(segment);
-
-            for (auto c{0uz}; word != end; ++word, ++c) {
-                if (auto const segment_free = static_cast<const storage_word>(~(*word)); segment_free != 0) {
-                    return (sizeof(storage_word) * 8) * c + std::countr_zero(segment_free);
-                }
-            }
-
-            return segment_size_in_bits;
+            return slot_handler(segment, [](storage_word word) -> size_t {
+                auto const segment_free = static_cast<const storage_word>(~(*word));
+                return std::countr_zero(segment_free);
+            }, [](size_t const val) {
+                return val != 0;
+            }, merge_functor<size_t>{}, 0uz);
         }
 
         [[nodiscard]] size_t segment_countl_zero(storage::const_reference segment) const noexcept {
@@ -511,6 +508,8 @@ namespace dice::template_library {
 
             return slot_handler(segment, [](storage_word word) -> size_t {
                 return std::countl_zero(word);
+            }, [](size_t const val) {
+                return val == sizeof(storage_word);
             }, merge_functor<size_t>{}, 0uz);
         }
 
@@ -521,6 +520,8 @@ namespace dice::template_library {
 
             return slot_handler(segment, [](storage_word word) -> size_t {
                 return std::countr_zero(word);
+            }, [](size_t const val) {
+                return val == sizeof(storage_word);
             }, merge_functor<size_t>{}, 0uz);
         }
 
@@ -531,6 +532,8 @@ namespace dice::template_library {
 
             return slot_handler(segment, [](storage_word word) -> size_t {
                 return std::countl_one(word);
+            }, [](size_t const val) {
+                return val == sizeof(storage_word);
             }, merge_functor<size_t>{}, 0uz);
         }
 
@@ -541,6 +544,8 @@ namespace dice::template_library {
 
             return slot_handler(segment, [](storage_word word) -> size_t {
                 return std::countr_one(word);
+            }, [](size_t const val) {
+                return val == sizeof(storage_word);
             }, merge_functor<size_t>{}, 0uz);
         }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -45,6 +45,8 @@ namespace dice::template_library {
 
         using storage_word = std::conditional_t<segment_align >= alignof(std::uint64_t), std::uint64_t,
             std::conditional_t<segment_align >= alignof(std::uint32_t), std::uint32_t, std::uint8_t>>;
+        using storage_word_pointer = storage_word *;
+        using storage_word_const_pointer = storage_word const *;
 
     private:
         struct bitset_iterator {
@@ -316,8 +318,8 @@ namespace dice::template_library {
         }
 #endif
 
-        [[nodiscard]] std::pair<storage_word*, storage_word*> segment_slots(storage::const_reference segment) {
-            auto word = reinterpret_cast<const storage_word*>(&segment);
+        [[nodiscard]] std::pair<storage_word_const_pointer, storage_word_const_pointer> segment_slots(storage::const_reference segment) {
+            auto word = reinterpret_cast<storage_word_const_pointer>(&segment);
             auto const end = word + segment_steps;
 
             return std::pair{word, end};
@@ -329,7 +331,7 @@ namespace dice::template_library {
             auto [word, end] = segment_slots(segment);
 
             for (; word != end; ++word) {
-                std::invoke(std::forward<M>(m),merge_val, std::invoke<F>(std::forward<F>(f), *word));
+                merge_val = std::invoke(std::forward<M>(m),merge_val, std::invoke(std::forward<F>(f), *word));
             }
 
             return merge_val;
@@ -356,7 +358,7 @@ namespace dice::template_library {
                 return std::countl_zero(segment);
             }
 
-            return slot_handler(segment, [](storage_word* word) -> size_t {
+            return slot_handler(segment, [](storage_word_const_pointer word) -> size_t {
                 return std::countl_zero(*word);
             }, MergeFunctor<size_t>{}, 0uz);
         }
@@ -366,7 +368,7 @@ namespace dice::template_library {
                 return std::countr_zero(segment);
             }
 
-            return slot_handler(segment, [](storage_word* word) -> size_t {
+            return slot_handler(segment, [](storage_word_const_pointer word) -> size_t {
                 return std::countr_zero(*word);
             }, MergeFunctor<size_t>{}, 0uz);
         }
@@ -376,7 +378,7 @@ namespace dice::template_library {
                 return std::countr_zero(segment);
             }
 
-            return slot_handler(segment, [](storage_word* word) -> size_t {
+            return slot_handler(segment, [](storage_word_const_pointer word) -> size_t {
                 return std::countl_one(*word);
             }, MergeFunctor<size_t>{}, 0uz);
         }
@@ -386,7 +388,7 @@ namespace dice::template_library {
                 return std::countr_zero(segment);
             }
 
-            return slot_handler(segment, [](storage_word* word) -> size_t {
+            return slot_handler(segment, [](storage_word_const_pointer word) -> size_t {
                 return std::countr_one(*word);
             }, MergeFunctor<size_t>{}, 0uz);
         }

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -106,26 +106,26 @@ namespace dice::template_library {
 
         public:
             ///> proxy for the current bit position
-            struct bit_ref {
+            struct reference {
             private:
                 bitset_pointer backing_bitset_;
             public:
                 segment seg;
                 offset  off;
 
-                bit_ref(bit_ref const&) = default;
-                bit_ref const& operator=(bit_ref const& other) const noexcept {
+                reference(reference const&) = default;
+                reference const& operator=(reference const& other) const noexcept {
                     return *this = static_cast<bool>(other);
                 }
 
-                bit_ref(bitset_pointer backing_bitset, segment const seg, offset const off) noexcept
+                reference(bitset_pointer backing_bitset, segment const seg, offset const off) noexcept
                     : backing_bitset_{backing_bitset}, seg{seg}, off{off} {}
 
                 explicit operator bool() const noexcept {
                     return backing_bitset_->test(calc_global_idx(seg, off));
                 }
 
-                bit_ref const& operator=(bool const b) const noexcept {
+                reference const& operator=(bool const b) const noexcept {
                     if (b) {
                         backing_bitset_->set(calc_global_idx(seg, off));
                     }
@@ -139,7 +139,6 @@ namespace dice::template_library {
             using iterator_category = std::random_access_iterator_tag;
             using iterator_concept  = std::random_access_iterator_tag;
             using value_type        = bool;
-            using reference         = bit_ref;
             using pointer           = void;
             using difference_type   = ptrdiff_t;
 
@@ -176,8 +175,8 @@ namespace dice::template_library {
                 backing_bitset_->unset(calc_global_idx(cur_segment_, cur_offset_));
             }
 
-            bit_ref operator*() const noexcept {
-                return bit_ref {backing_bitset_, cur_segment_, cur_offset_};
+            reference operator*() const noexcept {
+                return reference {backing_bitset_, cur_segment_, cur_offset_};
             }
 
             // shared iterator for mode=0 (bits) mode>=1 (segments)
@@ -377,6 +376,10 @@ namespace dice::template_library {
 
         [[nodiscard]] static constexpr global_ix calc_global_idx(segment const s, offset const o) noexcept {
             return s * segment_size_in_bits + o;
+        }
+
+        [[nodiscard]] constexpr size_t size() const noexcept {
+            return inner_.size();
         }
 
         [[nodiscard]] static constexpr size_t inner_size() noexcept {
@@ -1033,10 +1036,6 @@ namespace dice::template_library {
 
         constexpr std::default_sentinel_t end() const noexcept {
             return std::default_sentinel;
-        }
-
-        constexpr size_t size() const noexcept {
-            return inner_.size();
         }
 
         /**

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -300,6 +300,10 @@ namespace dice::template_library {
                 return tmp;
             }
 
+            difference_type operator-(bitset_iterator const& other) const noexcept {
+                return (**this).ix() - (*other).ix();
+            }
+
             [[nodiscard]] T const& get() const noexcept {
                 return *(backing_bitset_->inner_.data() + cur_segment_);
             }

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -55,14 +55,17 @@ namespace dice::template_library {
         using storage_word_const_pointer = storage_word const *;
 
     private:
+        template<bool is_const>
         struct bitset_iterator {
         private:
+            using bitset_pointer = std::conditional_t<is_const, bitset const*, bitset*>;
+
             segment       cur_segment_{};
             offset        cur_offset_{};
-            bitset *const backing_bitset_;
+            bitset_pointer const backing_bitset_;
 
         public:
-            explicit bitset_iterator(bitset &bitset) noexcept :
+            explicit bitset_iterator(std::conditional_t<is_const,bitset const&, bitset&> bitset) noexcept :
                 backing_bitset_{&bitset} {}
 
             explicit bitset_iterator(bitset &bitset, offset const& o) :
@@ -87,7 +90,7 @@ namespace dice::template_library {
                 cur_segment_ = s;
             }
 
-            void operator=(bool const b) const noexcept {
+            void operator=(bool const b) const noexcept requires(!is_const) {
                 if (b) {
                     backing_bitset_->set(calc_global_idx(cur_segment_, cur_offset_));
                     return;
@@ -341,7 +344,7 @@ namespace dice::template_library {
             }
         }
 
-        [[nodiscard]] bool segment_test(segment const s, offset const o) noexcept {
+        [[nodiscard]] bool segment_test(segment const s, offset const o) const noexcept {
             if constexpr (std::is_integral_v<T>) {
                 return *(inner_.data() + s) & 1uz << o;
             }
@@ -562,7 +565,8 @@ namespace dice::template_library {
         }
 
     public:
-        using iterator = bitset_iterator;
+        using iterator = bitset_iterator<false>;
+        using const_iterator = bitset_iterator<true>;
         static constexpr Set mode_set = Set{};
         static constexpr Unset mode_unset = Unset{};
 
@@ -611,8 +615,14 @@ namespace dice::template_library {
             bitset_mod_cntl(AutoModeTag{}, &bitset::segment_unset, ix);
         }
 
-        [[nodiscard]] bool test(global_ix const ix) {
-            return bitset_mod_cntl(DefaultModeTag{}, &bitset::segment_test, ix);
+        [[nodiscard]] bool test(global_ix const ix) const {
+            if (!fits_in_storage(ix)) {
+                throw std::out_of_range{"bitset::set: ix out of range"};
+            }
+
+            auto const segment = calc_which_segment(ix);
+            auto const offset  = calc_which_offset(ix);
+            return segment_test(segment, offset);
         }
 
         [[nodiscard]] size_t count() const {
@@ -652,6 +662,10 @@ namespace dice::template_library {
 
             return storage_size_in_bits;
         }
+
+        /* TODO: countl_zero & countl_one are currently walking the segments in the wrong directon
+                the same also applies for the inner slot handling
+                use a backward iterator + modes for traversing backwards*/
 
         [[nodiscard]] size_t countr_zero() const {
             return segment_handler([this](typename storage::const_reference segment) {
@@ -709,6 +723,10 @@ namespace dice::template_library {
 
         constexpr iterator begin() noexcept {
             return iterator{*this};
+        }
+
+        constexpr const_iterator begin() const noexcept {
+            return const_iterator{*this};
         }
 
         constexpr std::default_sentinel_t end() const noexcept {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -95,7 +95,6 @@ namespace dice::template_library {
     private:
         template<bool is_const>
         struct bitset_iterator {
-            using iterator_category = std::random_access_iterator_tag;
         private:
             using bitset_pointer = std::conditional_t<is_const, bitset const*, bitset*>;
 
@@ -126,6 +125,13 @@ namespace dice::template_library {
                     return *this;
                 }
             };
+
+            using iterator_category = std::random_access_iterator_tag;
+            using iterator_concept  = std::random_access_iterator_tag;
+            using value_type        = bool;
+            using reference         = bit_ref;
+            using pointer           = void;
+            using difference_type   = ptrdiff_t;
 
             explicit bitset_iterator(std::conditional_t<is_const,bitset const&, bitset&> bitset) noexcept :
                 backing_bitset_{&bitset} {}

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -356,25 +356,39 @@ namespace dice::template_library {
                 return std::countl_zero(segment);
             }
 
-
+            return slot_handler(segment, [](storage_word* word) -> size_t {
+                return std::countl_zero(*word);
+            }, MergeFunctor<size_t>{}, 0uz);
         }
 
         [[nodiscard]] size_t countr_zero(storage::const_reference segment) const noexcept {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::countr_zero(segment);
             }
+
+            return slot_handler(segment, [](storage_word* word) -> size_t {
+                return std::countr_zero(*word);
+            }, MergeFunctor<size_t>{}, 0uz);
         }
 
         [[nodiscard]] size_t countl_one(storage::const_reference segment) const noexcept {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::countr_zero(segment);
             }
+
+            return slot_handler(segment, [](storage_word* word) -> size_t {
+                return std::countl_one(*word);
+            }, MergeFunctor<size_t>{}, 0uz);
         }
 
         [[nodiscard]] size_t countr_one(storage::const_reference segment) const noexcept {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::countr_zero(segment);
             }
+
+            return slot_handler(segment, [](storage_word* word) -> size_t {
+                return std::countr_one(*word);
+            }, MergeFunctor<size_t>{}, 0uz);
         }
 
         [[nodiscard]] bool all_set(storage::const_reference segment) const noexcept {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -123,7 +123,7 @@ namespace dice::template_library {
 
             template<size_t mode=bitset_const::bit_mode>
             bitset_iterator& operator+=(size_t const skip) noexcept {
-                auto skip_handler = [this](size_t skip_size) {
+                auto skip_handler = [this](size_t const skip_size) {
                     auto global_ix = calc_global_idx(cur_segment_, cur_offset_) + skip_size;
 
                     if (global_ix >= storage_size_in_bits) {
@@ -149,7 +149,7 @@ namespace dice::template_library {
                 return *this;
             }
 
-            bitset_iterator operator+(size_t rh_add) {
+            bitset_iterator operator+(size_t rh_add) const noexcept {
                 bitset_iterator tmp = *this;
                 tmp += rh_add;
                 return tmp;
@@ -300,11 +300,11 @@ namespace dice::template_library {
         }
 
         [[nodiscard]] static size_t offset_in_chunk(offset const o) noexcept {
-            return o % segment_align;
+            return o % segment_align * 8;
         }
 
         [[nodiscard]] static size_t which_chunk(offset const o) noexcept {
-            return o / segment_align;
+            return o / segment_align * 8;
         }
 
         storage_word_pointer get_chunk_raw(segment const s, offset const o) const noexcept {
@@ -370,13 +370,13 @@ namespace dice::template_library {
         }
 #endif
 
-        template<typename F, typename M, typename Tp, typename Ops=add_op>
+        template<typename F, typename M, typename Tp, typename Ops>
         requires std::is_same_v<std::invoke_result_t<F, typename storage::const_reference>, Tp> &&
-            std::invocable<M, Tp, Tp>
-        [[nodiscard]] Tp segment_handler(F &&handler, M &&merge, Tp initial) const {
+            std::invocable<M, Ops, Tp, Tp>
+        [[nodiscard]] Tp segment_handler(F &&handler, M &&merge, Tp initial, Ops ops=add_op{}) const {
             Tp merge_val{initial};
             for (auto const &segment : inner_) {
-                merge_val = std::invoke(std::forward<M>(merge), Ops{}, merge_val,
+                merge_val = std::invoke(std::forward<M>(merge), ops, merge_val,
                     std::invoke(std::forward<F>(handler), segment));
             }
 
@@ -418,8 +418,8 @@ namespace dice::template_library {
             return true;
         }
 
-        template<typename F, typename Pr, typename M, typename Tp, typename Ops=add_op>
-        Tp segment_handler(F &&handler, Pr &&pred, M &&merge, Tp initial) const {
+        template<typename F, typename Pr, typename M, typename Tp, typename Ops>
+        Tp segment_handler(F &&handler, Pr &&pred, M &&merge, Tp initial, Ops ops=add_op{}) const {
             auto self_it = begin();
             auto end_sentinel = end();
 
@@ -427,7 +427,7 @@ namespace dice::template_library {
 
             while (self_it != end_sentinel) {
                 Tp const val = std::invoke(std::forward<F>(handler), self_it.get());
-                merge_val = std::invoke(std::forward<M>(merge), Ops{}, merge_val, val);
+                merge_val = std::invoke(std::forward<M>(merge), ops, merge_val, val);
                 if (!std::invoke(std::forward<Pr>(pred), val)) {
                     return merge_val;
                 }
@@ -436,26 +436,26 @@ namespace dice::template_library {
             return merge_val;
         }
 
-        template<typename F, typename M, typename Tp, typename Ops=add_op>
-        [[nodiscard]] Tp slot_handler(storage::const_reference segment, F &&f, M&& m, Tp initial) const {
+        template<typename F, typename M, typename Tp, typename Ops>
+        [[nodiscard]] Tp slot_handler(storage::const_reference segment, F &&f, M&& m, Tp initial, Ops ops=add_op{}) const {
             Tp merge_val{initial};
             auto [word, end] = segment_slots(segment);
 
             for (; word != end; ++word) {
-                merge_val = std::invoke(std::forward<M>(m), Ops{}, merge_val, std::invoke(std::forward<F>(f), *word));
+                merge_val = std::invoke(std::forward<M>(m), ops, merge_val, std::invoke(std::forward<F>(f), *word));
             }
 
             return merge_val;
         }
 
-        template<typename F, typename Pr, typename M, typename Tp, typename Ops=add_op>
-        [[nodiscard]] Tp slot_handler(storage::const_reference segment, F &&f, Pr &&pred, M&& m, Tp initial) const {
+        template<typename F, typename Pr, typename M, typename Tp, typename Ops>
+        [[nodiscard]] Tp slot_handler(storage::const_reference segment, F &&f, Pr &&pred, M&& m, Tp initial, Ops ops=add_op{}) const {
             Tp merge_val{initial};
             auto [word, end] = segment_slots(segment);
 
             for (; word != end; ++word) {
                 Tp const val = std::invoke(std::forward<F>(f), *word);
-                merge_val = std::invoke(std::forward<M>(m), Ops{}, merge_val, val);
+                merge_val = std::invoke(std::forward<M>(m), ops, merge_val, val);
                 if (!std::invoke(std::forward<Pr>(pred), val)) {
                     return merge_val;
                 }
@@ -498,7 +498,7 @@ namespace dice::template_library {
                 return std::countr_zero(segment_free);
             }, [](size_t const val) {
                 return val == sizeof(storage_word) * 8;
-            }, merge_functor<size_t>{}, 0uz);
+            }, merge_functor<size_t>{}, 0uz, add_op{});
         }
 
         [[nodiscard]] size_t segment_countl_zero(storage::const_reference segment) const noexcept {
@@ -510,7 +510,7 @@ namespace dice::template_library {
                 return std::countl_zero(word);
             }, [](size_t const val) {
                 return val == sizeof(storage_word) * 8;
-            }, merge_functor<size_t>{}, 0uz);
+            }, merge_functor<size_t>{}, 0uz, add_op{});
         }
 
         [[nodiscard]] size_t segment_countr_zero(storage::const_reference segment) const noexcept {
@@ -522,7 +522,7 @@ namespace dice::template_library {
                 return std::countr_zero(word);
             }, [](size_t const val) {
                 return val == sizeof(storage_word) * 8;
-            }, merge_functor<size_t>{}, 0uz);
+            }, merge_functor<size_t>{}, 0uz, add_op{});
         }
 
         [[nodiscard]] size_t segment_countl_one(storage::const_reference segment) const noexcept {
@@ -534,7 +534,7 @@ namespace dice::template_library {
                 return std::countl_one(word);
             }, [](size_t const val) {
                 return val == sizeof(storage_word) * 8;
-            }, merge_functor<size_t>{}, 0uz);
+            }, merge_functor<size_t>{}, 0uz, add_op{});
         }
 
         [[nodiscard]] size_t segment_countr_one(storage::const_reference segment) const noexcept {
@@ -546,7 +546,7 @@ namespace dice::template_library {
                 return std::countr_one(word);
             }, [](size_t const val) {
                 return val == sizeof(storage_word) * 8;
-            }, merge_functor<size_t>{}, 0uz);
+            }, merge_functor<size_t>{}, 0uz, add_op{});
         }
 
         [[nodiscard]] bool segment_all_set(storage::const_reference segment) const noexcept {
@@ -554,9 +554,7 @@ namespace dice::template_library {
         }
 
         [[nodiscard]] bool segment_any_set(storage::const_reference segment) const noexcept {
-            auto const free = segment_free(segment);
-
-            return free > 0 && free < segment_size_in_bits;
+            return segment_count(segment) != 0;
         }
 
         [[nodiscard]] bool segment_none_set(storage::const_reference segment) const noexcept {
@@ -620,7 +618,7 @@ namespace dice::template_library {
         [[nodiscard]] size_t count() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_count, segment);
-            }, merge_functor<size_t>{}, 0);
+            }, merge_functor<size_t>{}, 0uz, add_op{});
         }
 
         [[nodiscard]] size_t set_first_free() {
@@ -639,7 +637,7 @@ namespace dice::template_library {
                     inner_.resize(inner_.size() + 1);
                     *reinterpret_cast<storage_word_pointer>(inner_.end() - 1) = 0x01;
 
-                    return calc_global_idx(std::distance(inner_.data(), inner_.end()), 0);
+                    return calc_global_idx(std::distance(inner_.data(), inner_.data() + size()), 0);
                 }
                 else {
                     if (inner_.size() == inner_.max_size()) {
@@ -648,7 +646,7 @@ namespace dice::template_library {
                     inner_.resize(inner_.size() + 1);
                     *reinterpret_cast<storage_word_pointer>(inner_.end() - 1) = 0x01;
 
-                    return calc_global_idx(std::distance(inner_.data(), inner_.end()), 0);
+                    return calc_global_idx(std::distance(inner_.data(), inner_.data() + size()), 0);
                 }
             }
 
@@ -660,7 +658,7 @@ namespace dice::template_library {
                 return bitset_op_cntl(&bitset::segment_countr_zero, segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;
-            }, merge_functor<size_t>{}, 0);
+            }, merge_functor<size_t>{}, 0, add_op{});
         }
 
         [[nodiscard]] size_t countl_zero() const {
@@ -668,7 +666,7 @@ namespace dice::template_library {
                 return bitset_op_cntl(&bitset::segment_countl_zero, segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;
-            }, merge_functor<size_t>{}, 0);
+            }, merge_functor<size_t>{}, 0, add_op{});
         }
 
         [[nodiscard]] size_t countr_one() const {
@@ -676,7 +674,7 @@ namespace dice::template_library {
                 return bitset_op_cntl(&bitset::segment_countr_one, segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;
-            }, merge_functor<size_t>{}, 0);
+            }, merge_functor<size_t>{}, 0, add_op{});
         }
 
         [[nodiscard]] size_t countl_one() const {
@@ -684,7 +682,7 @@ namespace dice::template_library {
                 return bitset_op_cntl(&bitset::segment_countl_one, segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;
-            }, merge_functor<size_t>{}, 0);
+            }, merge_functor<size_t>{}, 0, add_op{});
         }
 
         [[nodiscard]] bool all_set() const {
@@ -692,15 +690,13 @@ namespace dice::template_library {
                 return bitset_op_cntl(&bitset::segment_all_set, segment);
             }, [](bool const val) {
                 return val;
-            },merge_functor<bool>{}, true);
+            });
         }
 
         [[nodiscard]] bool any_set() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_any_set, segment);
-            }, [](bool const val) {
-                return val;
-            }, merge_functor<bool>{}, true);
+            }, merge_functor<bool>{}, false, bit_or_op{});
         }
 
         [[nodiscard]] bool none_set() const {
@@ -708,7 +704,7 @@ namespace dice::template_library {
                 return bitset_op_cntl(&bitset::segment_none_set, segment);
             }, [](bool const val) {
                 return val;
-            }, merge_functor<bool>{}, true);
+            }, merge_functor<bool>{}, true, bit_and_op{});
         }
 
         constexpr iterator begin() noexcept {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -18,8 +18,7 @@ namespace dice::template_library {
     template<>
     struct MergeFunctor<bool> {
         bool operator()(bool const v1, bool const v2) const {
-            assert(v1 == v2);
-            return v1;
+            return v1 & v2;
         }
     };
 
@@ -297,6 +296,19 @@ namespace dice::template_library {
             }
         }
 
+        [[nodiscard]] bool all_set(storage::const_reference segment) const noexcept {
+            return segment_free(segment) == segment_size_in_bits;
+        }
+
+        [[nodiscard]] bool any_set(storage::const_reference segment) const noexcept {
+            auto const free = segment_free(segment);
+
+            return free > 0 && free < segment_size_in_bits;
+        }
+
+        [[nodiscard]] bool none_set(storage::const_reference segment) const noexcept {
+            return segment_free(segment) == 0x00;
+        }
 
     public:
         using iterator = bitset_iterator;
@@ -328,7 +340,7 @@ namespace dice::template_library {
 
         [[nodiscard]] size_t set_first_free() {
             for (auto const &segment : inner_) {
-                auto offset = bitset_op_cntl(&bitset::set_first_free, segment);
+                auto offset = bitset_op_cntl(&bitset::segment_free, segment);
 
                 if (offset != segment_size_in_bits) {
                     auto seg = std::distance(inner_.data(), &segment);
@@ -340,7 +352,7 @@ namespace dice::template_library {
             if constexpr (storage::has_dynamic_extent) {
                 if constexpr (!has_storage_limit) {
                     inner_.resize(inner_.size() + 1);
-                    *(inner_.end() - 1) = 0x01;
+                    *static_cast<uint8_t*>(inner_.end() - 1) = 0x01;
 
                     return calc_global_idx(std::distance(inner_.end(), inner_.data(), 0));
                 }
@@ -348,7 +360,7 @@ namespace dice::template_library {
                     if (inner_.size() == inner_.max_size()) {
                         return storage_size_in_bits;
                     }
-                    *inner_.end() = 0x01;
+                    *static_cast<uint8_t*>(inner_.end()) = 0x01;
                     inner_.resize(inner_.size() + 1);
 
                     return calc_global_idx(std::distance(inner_.end(), inner_.data()), 0);
@@ -361,8 +373,8 @@ namespace dice::template_library {
         template<typename F, typename M, typename Tp>
         requires std::is_same_v<std::invoke_result_t<F, typename storage::const_reference>, Tp> &&
             std::invocable<M, Tp, Tp>
-        Tp segment_handler(F &&handler, M &&merge) {
-            Tp merge_val{};
+        Tp segment_handler(F &&handler, M &&merge, Tp initial) {
+            Tp merge_val{initial};
             for (auto const &segment : inner_) {
                 std::invoke(std::forward<M>(merge)(
                     merge_val,
@@ -375,25 +387,43 @@ namespace dice::template_library {
         [[nodiscard]] size_t countr_zero() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::countr_zero, segment);
-            }, MergeFunctor<size_t>{});
+            }, MergeFunctor<size_t>{}, 0);
         }
 
         [[nodiscard]] size_t countl_zero() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::countl_zero, segment);
-            }, MergeFunctor<size_t>{});
+            }, MergeFunctor<size_t>{}, 0);
         }
 
         [[nodiscard]] size_t countr_one() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::countr_one, segment);
-            }, MergeFunctor<size_t>{});
+            }, MergeFunctor<size_t>{}, 0);
         }
 
         [[nodiscard]] size_t countl_one() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::countl_one, segment);
-            }, MergeFunctor<size_t>{});
+            }, MergeFunctor<size_t>{}, 0);
+        }
+
+        [[nodiscard]] bool all_set() const {
+            return segment_handler([this](typename storage::const_reference segment) {
+                return bitset_op_cntl(&bitset::all_set, segment);
+            }, MergeFunctor<bool>{}, true);
+        }
+
+        [[nodiscard]] bool any_set() const {
+            return segment_handler([this](typename storage::const_reference segment) {
+                return bitset_op_cntl(&bitset::any_set, segment);
+            }, MergeFunctor<bool>{}, true);
+        }
+
+        [[nodiscard]] bool none_set() const {
+            return segment_handler([this](typename storage::const_reference segment) {
+                return bitset_op_cntl(&bitset::none_set, segment);
+            }, MergeFunctor<bool>{}, true);
         }
 
         constexpr iterator begin() {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -285,13 +285,13 @@ namespace dice::template_library {
             return segment_size_in_bits;
         }
 
-        [[nodiscard]] size_t segment_countl_zero(storage::const_reference segment) {
+        [[nodiscard]] size_t segment_countl_zero(storage::const_reference segment) const noexcept {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::countl_zero(segment);
             }
         }
 
-        [[nodiscard]] size_t segment_countr_zero(storage::const_reference segment) {
+        [[nodiscard]] size_t segment_countr_zero(storage::const_reference segment) const noexcept {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::countr_zero(segment);
             }
@@ -373,25 +373,25 @@ namespace dice::template_library {
         }
 
         [[nodiscard]] size_t countr_zero() const {
-            return segment_handler([this](T const& segment) {
+            return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::countr_zero, segment);
             }, MergeFunctor<size_t>{});
         }
 
         [[nodiscard]] size_t countl_zero() const {
-            return segment_handler([this](T const& segment) {
+            return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::countl_zero, segment);
             }, MergeFunctor<size_t>{});
         }
 
         [[nodiscard]] size_t countr_one() const {
-            return segment_handler([this](T const& segment) {
+            return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::countr_one, segment);
             }, MergeFunctor<size_t>{});
         }
 
         [[nodiscard]] size_t countl_one() const {
-            return segment_handler([this](T const& segment) {
+            return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::countl_one, segment);
             }, MergeFunctor<size_t>{});
         }

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -175,7 +175,7 @@ namespace dice::template_library {
                 return 0;
             }
 
-            auto const bit_off = bit_pos - ix;
+            auto const bit_off = ix - bit_pos;
 
             return [bit_off] {
                 if constexpr (std::has_single_bit(segment_size_in_bits)) {
@@ -392,7 +392,7 @@ namespace dice::template_library {
 
         [[nodiscard]] size_t segment_countl_one(storage::const_reference segment) const noexcept {
             if constexpr (std::integral<typename storage::value_type>) {
-                return std::countr_zero(segment);
+                return std::countl_one(segment);
             }
 
             return slot_handler(segment, [](storage_word_const_pointer word) -> size_t {
@@ -402,7 +402,7 @@ namespace dice::template_library {
 
         [[nodiscard]] size_t segment_countr_one(storage::const_reference segment) const noexcept {
             if constexpr (std::integral<typename storage::value_type>) {
-                return std::countr_zero(segment);
+                return std::countr_one(segment);
             }
 
             return slot_handler(segment, [](storage_word_const_pointer word) -> size_t {
@@ -498,7 +498,7 @@ namespace dice::template_library {
             if constexpr (storage::has_dynamic_extent) {
                 if constexpr (!has_storage_limit) {
                     inner_.resize(inner_.size() + 1);
-                    *static_cast<uint8_t*>(inner_.end() - 1) = 0x01;
+                    *static_cast<storage_word_const_pointer>(inner_.end() - 1) = 0x01;
 
                     return calc_global_idx(std::distance(inner_.data(), inner_.end()), 0);
                 }
@@ -506,10 +506,10 @@ namespace dice::template_library {
                     if (inner_.size() == inner_.max_size()) {
                         return storage_size_in_bits;
                     }
-                    *static_cast<uint8_t*>(inner_.end()) = 0x01;
+                    *static_cast<storage_word_const_pointer>(inner_.end()) = 0x01;
                     inner_.resize(inner_.size() + 1);
 
-                    return calc_global_idx(std::distance(inner_.end(), inner_.data()), 0);
+                    return calc_global_idx(std::distance(inner_.data(), inner_.end()), 0);
                 }
             }
 
@@ -620,10 +620,10 @@ struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
                 debug = true;
             }
 
-            if (*it == 'b') {
+            if (*it == 'x') {
                 hex = true;
             }
-            else {
+            else if (*it == 'b'){
                 binary = true;
             }
             ++it;
@@ -634,7 +634,8 @@ struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
         auto it = storage.begin();
         auto end = storage.end();
         auto segments = storage.size();
-        auto segment_size = storage.inner_size();
+        auto segment_size = storage.inner();
+        auto segment_size_in_bits = storage.inner_size_in_bits();
 
         auto out = ctx.out();
         *out++ = '[';
@@ -670,11 +671,12 @@ struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
                 it.template operator++<dice::template_library::bitset_const::segment_mode>();
             }
             else if (binary) {
-                for (auto segment_bit{0uz}; segment_bit < segment_size; ++segment_bit) {
+                for (auto segment_bit{0uz}; segment_bit < segment_size_in_bits; ++segment_bit) {
                     *out++ = *it++ ? '1' : '0';
                 }
             }
             else {
+                // if no mode is supported and somehow it goes throught consider just to step through, for compatible
                 ++it;
             }
             *out++ = ']';

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -727,7 +727,6 @@ namespace dice::template_library {
             }
         }
 
-        template<typename F>
         void slot_handler(reference segment, storage_word val) {
             auto [word, end] = segment_slots(segment);
 
@@ -954,6 +953,42 @@ namespace dice::template_library {
             auto const segment = calc_which_segment(ix);
             auto const offset  = calc_which_offset(ix);
             return segment_test(segment, offset);
+        }
+
+        void shrink_to_fit() requires (has_dynamic_extent){
+            auto it = begin() + size_in_bits();
+            auto end = begin();
+
+            auto perform_shrink = [this](auto const& segment) {
+                auto ptr_dist = std::distance(inner_.data(), &segment);
+                if constexpr (!has_max_extent) {
+                    inner_ = storage(inner_.data(), inner_.data() + ptr_dist);
+                }
+                else {
+                    inner_.resize(std::distance(inner_.data(), &segment));
+                }
+            };
+
+            while (it != end) {
+                auto segment = (it - 1).get();
+                if constexpr (std::integral<value_type>) {
+                    if (static_cast<value_type>(~segment) != 0x00) {
+                        perform_shrink(segment);
+                        return;
+                    }
+                }
+                else {
+                    auto has_bit = slot_handler(segment, [](storage_word word) {
+                        return static_cast<storage_word>(~word) != 0x00;
+                    }, merge_functor<bool>{}, false, bit_or_op{});
+
+                    if (has_bit) {
+                        perform_shrink(segment);
+                        return;
+                    }
+                }
+                it.template operator--<bitset_mode::SegmentMode>();
+            }
         }
 
         /**

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -38,10 +38,6 @@ namespace dice::template_library {
      * The underlying mode to iterate over the storage
      * Used within the **bitset_iterator**
      */
-    enum class bitset_mode : uint8_t {
-        BitMode = 0x00,
-        SegmentMode = 0x01,
-    };
 
     /**
      * A multi-type bitset supporting both dynamic and static growth.
@@ -100,6 +96,11 @@ namespace dice::template_library {
             std::conditional_t<segment_align >= alignof(std::uint16_t), std::uint16_t, std::uint8_t>>>;
         using storage_word_pointer = storage_word *;
         using storage_word_const_pointer = storage_word const *;
+
+        enum class bitset_mode : uint8_t {
+            BitMode = 0x00,
+            SegmentMode = 0x01,
+        };
 
         template<bool is_const>
         struct bitset_iterator {
@@ -1165,22 +1166,22 @@ namespace dice::template_library {
             });
         }
 
-        static iterator advance_segment(iterator& it) {
+        static iterator advance_segment(iterator it) {
             return it.template operator++<bitset_mode::SegmentMode>();
         }
 
-        static iterator advance_segment(iterator& it, size_t const skip) {
+        static iterator advance_segment(iterator it, size_t const skip) {
             return it.template operator+=<bitset_mode::SegmentMode>(skip);
         }
 
-        static iterator advance_segment_backwards(iterator& it) {
+        static iterator advance_segment_backwards(iterator it) {
             return it.template operator--<bitset_mode::SegmentMode>();
         }
 
-        static iterator advance_segment_backwards(iterator& it, size_t const skip) {
+        static iterator advance_segment_backwards(iterator it, size_t const skip) {
             return it.template operator-=<bitset_mode::SegmentMode>(skip);
         }
-        
+
         constexpr iterator begin() noexcept {
             return iterator{*this};
         }
@@ -1358,7 +1359,7 @@ struct std::formatter<dice::template_library::bitset<extent, max_extent, T>> {
                         out = std::format_to(out, "{:#0{}x}", *word, (storage.segment_align * 8) / 4);
                     }
                 }
-                it.template operator++<dice::template_library::bitset_mode::SegmentMode>();
+                it = storage.advance_segment(it);
             }
             else if (binary) {
                 for (auto segment_bit{0uz}; segment_bit < segment_size_in_bits; ++segment_bit) {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -44,7 +44,8 @@ namespace dice::template_library {
         using offset    = size_t;
 
         using storage_word = std::conditional_t<segment_align >= alignof(std::uint64_t), std::uint64_t,
-            std::conditional_t<segment_align >= alignof(std::uint32_t), std::uint32_t, std::uint8_t>>;
+            std::conditional_t<segment_align >= alignof(std::uint32_t), std::uint32_t,
+            std::conditional_t<segment_align >= alignof(std::uint16_t), std::uint16_t, std::uint8_t>>>;
         using storage_word_pointer = storage_word *;
         using storage_word_const_pointer = storage_word const *;
 
@@ -61,7 +62,7 @@ namespace dice::template_library {
 
             explicit bitset_iterator(storage &bitset, offset const& o) :
                 cur_segment_{bitset.data()}, backing_bitset_{&bitset}{
-                if constexpr (o >= segment_size) {
+                if (o >= segment_size) {
                     throw std::out_of_range{"bitset_iterator: o >= segment_size"};
                 }
                 cur_offset_ = o;
@@ -69,11 +70,11 @@ namespace dice::template_library {
 
             explicit bitset_iterator(storage &bitset, offset const& o, segment const& s) :
                 backing_bitset_{&bitset}{
-                if constexpr (o >= segment_size) {
+                if (o >= segment_size) {
                     throw std::out_of_range{"bitset_iterator: o >= segment_size"};
                 }
 
-                if constexpr (cur_segment_ + s >= bitset.size()) {
+                if (bitset.data() + s >= bitset.size()) {
                     throw std::out_of_range{"bitset_iterator: segment out of bounds"};
                 }
 
@@ -275,35 +276,35 @@ namespace dice::template_library {
         }
 
         template<typename F>
-        auto bitset_op_cntl(F &&ops) -> std::invoke_result_t<F, typename storage::const_reference> {
-            using result_t = std::invoke_result_t<F, bitset*>;
+        auto bitset_op_cntl(F &&ops, storage::const_reference segment) -> std::invoke_result_t<F, typename storage::const_reference> {
+            using result_t = std::invoke_result_t<F, bitset*, typename storage::const_reference>;
 
             if constexpr (std::is_void_v<result_t>) {
-                std::invoke(std::forward<F>(ops), this);
+                std::invoke(std::forward<F>(ops), this, segment);
                 return;
             }
             else {
-                return std::invoke(std::forward<F>(ops), this);
+                return std::invoke(std::forward<F>(ops), this, segment);
             }
         }
 
-        void set(segment const s, offset const o) {
+        void segment_set(segment const s, offset const o) {
             *(inner_.data() + s) |= 1uz << o;
         }
 
-        void flip(segment const s, offset const o) {
+        void segment_flip(segment const s, offset const o) {
             *(inner_.data() + s) ^= 1uz << o;
         }
 
-        void unset(segment const s, offset const o) {
+        void segment_unset(segment const s, offset const o) {
             *(inner_.data() + s) &= ~(1uz << o);
         }
 
-        [[nodiscard]] bool test(segment const s, offset const o) {
+        [[nodiscard]] bool segment_test(segment const s, offset const o) {
             return *(inner_.data() + s) & 1uz << o;
         }
 
-        [[nodiscard]] size_t count(storage::const_reference segment) {
+        [[nodiscard]] size_t segment_count(storage::const_reference segment) {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::popcount(segment);
             }
@@ -320,7 +321,7 @@ namespace dice::template_library {
         }
 
 #ifdef __SIZEOF_INT128__
-        size_t count(__uint128_t const& segment) {
+        size_t segment_count(__uint128_t const& segment) {
             uint64_t const lo = static_cast<uint64_t>(segment);
             uint64_t const hi = static_cast<uint64_t>(segment >> 64);
 
@@ -328,11 +329,17 @@ namespace dice::template_library {
         }
 #endif
 
-        [[nodiscard]] std::pair<storage_word_const_pointer, storage_word_const_pointer> segment_slots(storage::const_reference segment) {
-            auto word = reinterpret_cast<storage_word_const_pointer>(&segment);
-            auto const end = word + segment_steps;
+        template<typename F, typename M, typename Tp>
+        requires std::is_same_v<std::invoke_result_t<F, typename storage::const_reference>, Tp> &&
+            std::invocable<M, Tp, Tp>
+        Tp segment_handler(F &&handler, M &&merge, Tp initial) {
+            Tp merge_val{initial};
+            for (auto const &segment : inner_) {
+                merge_val = std::invoke(std::forward<M>(merge), merge_val,
+                    std::invoke(std::forward<F>(handler), segment));
+            }
 
-            return std::pair{word, end};
+            return merge_val;
         }
 
         template<typename F, typename M, typename Tp>
@@ -363,7 +370,7 @@ namespace dice::template_library {
             return segment_size_in_bits;
         }
 
-        [[nodiscard]] size_t countl_zero(storage::const_reference segment) const noexcept {
+        [[nodiscard]] size_t segment_countl_zero(storage::const_reference segment) const noexcept {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::countl_zero(segment);
             }
@@ -373,7 +380,7 @@ namespace dice::template_library {
             }, merge_functor<size_t>{}, 0uz);
         }
 
-        [[nodiscard]] size_t countr_zero(storage::const_reference segment) const noexcept {
+        [[nodiscard]] size_t segment_countr_zero(storage::const_reference segment) const noexcept {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::countr_zero(segment);
             }
@@ -383,7 +390,7 @@ namespace dice::template_library {
             }, merge_functor<size_t>{}, 0uz);
         }
 
-        [[nodiscard]] size_t countl_one(storage::const_reference segment) const noexcept {
+        [[nodiscard]] size_t segment_countl_one(storage::const_reference segment) const noexcept {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::countr_zero(segment);
             }
@@ -393,7 +400,7 @@ namespace dice::template_library {
             }, merge_functor<size_t>{}, 0uz);
         }
 
-        [[nodiscard]] size_t countr_one(storage::const_reference segment) const noexcept {
+        [[nodiscard]] size_t segment_countr_one(storage::const_reference segment) const noexcept {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::countr_zero(segment);
             }
@@ -403,17 +410,17 @@ namespace dice::template_library {
             }, merge_functor<size_t>{}, 0uz);
         }
 
-        [[nodiscard]] bool all_set(storage::const_reference segment) const noexcept {
+        [[nodiscard]] bool segment_all_set(storage::const_reference segment) const noexcept {
             return segment_free(segment) == segment_size_in_bits;
         }
 
-        [[nodiscard]] bool any_set(storage::const_reference segment) const noexcept {
+        [[nodiscard]] bool segment_any_set(storage::const_reference segment) const noexcept {
             auto const free = segment_free(segment);
 
             return free > 0 && free < segment_size_in_bits;
         }
 
-        [[nodiscard]] bool none_set(storage::const_reference segment) const noexcept {
+        [[nodiscard]] bool segment_none_set(storage::const_reference segment) const noexcept {
             return segment_free(segment) == 0x00;
         }
 
@@ -448,29 +455,33 @@ namespace dice::template_library {
         constexpr bitset &operator=(bitset &&) = default;
         constexpr ~bitset() = default;
 
+        [[nodiscard]] std::pair<storage_word_const_pointer, storage_word_const_pointer> segment_slots(storage::const_reference segment) {
+            auto word = reinterpret_cast<storage_word_const_pointer>(&segment);
+            auto const end = word + segment_steps;
+
+            return std::pair{word, end};
+        }
+
         void set(global_ix const ix) {
-            bitset_mod_cntl(AutoModeTag{}, &bitset::set, ix);
+            bitset_mod_cntl(AutoModeTag{}, &bitset::segment_set, ix);
         }
 
         void flip(global_ix const ix) {
-            bitset_mod_cntl(AutoModeTag{}, &bitset::flip, ix);
+            bitset_mod_cntl(AutoModeTag{}, &bitset::segment_flip, ix);
         }
 
         void unset(global_ix const ix) {
-            bitset_mod_cntl(AutoModeTag{}, &bitset::unset, ix);
+            bitset_mod_cntl(AutoModeTag{}, &bitset::segment_unset, ix);
         }
 
         [[nodiscard]] bool test(global_ix const ix) {
-            return bitset_mod_cntl(DefaultModeTag{}, &bitset::test, ix);
+            return bitset_mod_cntl(DefaultModeTag{}, &bitset::segment_test, ix);
         }
 
         [[nodiscard]] size_t count() {
-            size_t accumulated{0};
-            for (auto const &segment : inner_) {
-                accumulated += bitset_op_cntl(&bitset::count, segment);
-            }
-
-            return accumulated;
+            return segment_handler([this](typename storage::const_reference segment) {
+                return bitset_op_cntl(&bitset::segment_count, segment);
+            }, merge_functor<size_t>{}, 0);
         }
 
         [[nodiscard]] size_t set_first_free() {
@@ -489,7 +500,7 @@ namespace dice::template_library {
                     inner_.resize(inner_.size() + 1);
                     *static_cast<uint8_t*>(inner_.end() - 1) = 0x01;
 
-                    return calc_global_idx(std::distance(inner_.end(), inner_.data(), 0));
+                    return calc_global_idx(std::distance(inner_.data(), inner_.end()), 0);
                 }
                 else {
                     if (inner_.size() == inner_.max_size()) {
@@ -503,20 +514,6 @@ namespace dice::template_library {
             }
 
             return storage_size_in_bits;
-        }
-
-        template<typename F, typename M, typename Tp>
-        requires std::is_same_v<std::invoke_result_t<F, typename storage::const_reference>, Tp> &&
-            std::invocable<M, Tp, Tp>
-        Tp segment_handler(F &&handler, M &&merge, Tp initial) {
-            Tp merge_val{initial};
-            for (auto const &segment : inner_) {
-                merge_val = std::invoke(std::forward<M>(merge)(
-                    merge_val,
-                    std::invoke(std::forward<F>(handler), segment)));
-            }
-
-            return merge_val;
         }
 
         [[nodiscard]] size_t countr_zero() const {
@@ -570,7 +567,7 @@ namespace dice::template_library {
         }
 
         constexpr size_t size() const noexcept {
-            return inner_.size() * 8;
+            return inner_.size();
         }
 
         constexpr size_t size_in_bits() const noexcept {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -136,6 +136,10 @@ namespace dice::template_library {
                     backing_bitset_->set(calc_global_idx(seg, off), b);
                     return *this;
                 }
+
+                [[nodiscard]] size_t ix() const noexcept {
+                    return calc_global_idx(seg, off);
+                }
             };
 
             using iterator_category = std::random_access_iterator_tag;
@@ -317,6 +321,7 @@ namespace dice::template_library {
             bitset_iterator<is_const> it_;
             bitset_pointer backing_bitset_ = nullptr;
 
+            ///> add bool to allow setting a start point, without skipping the initial offset
             void seek(bool include_current) noexcept {
                 auto offset  = (*it_).off;
                 auto segment = it_.get();

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -65,11 +65,16 @@ namespace dice::template_library {
      *
      * @tparam T value type : any type is allowed as representation of the segment itself
      * @tparam extent extent of the bitset
-     * @tparam segments max segments for the underlying bitset : use dynamic_extent to uncap limit
+     * @tparam bits minimal bits for the underlying bitset : use dynamic_extent to uncap limit
      */
-    template<size_t extent, size_t segments, typename T = uint64_t>
+    template<size_t extent, size_t bits, typename T = uint64_t>
     struct bitset {
     private:
+        static constexpr size_t segment_size = sizeof(T);
+        static constexpr size_t segment_size_in_bits = segment_size * 8;
+
+        static constexpr size_t segments = bits != dynamic_extent ? (bits + segment_size_in_bits - 1) / segment_size_in_bits : dynamic_extent;
+
         using storage   = flex_array<T, extent, segments>;
         using global_ix = size_t;
         using segment   = size_t;
@@ -83,10 +88,9 @@ namespace dice::template_library {
     private:
         static constexpr bool   has_max_extent = storage::has_max_extent;
         static constexpr bool   has_dynamic_extent = storage::has_dynamic_extent;
-        static constexpr size_t segment_size = sizeof(T);
         static constexpr size_t segment_align = alignof(T);
         static constexpr size_t segment_steps = segment_size / segment_align; ///> how many chunks fit within one segment
-        static constexpr size_t segment_size_in_bits = segment_size * 8;
+
         static constexpr size_t storage_size = !has_max_extent ? dynamic_extent : segment_size * segments;
         static constexpr size_t storage_size_in_bits = !has_max_extent ? dynamic_extent : storage_size * 8;
         

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -109,7 +109,7 @@ namespace dice::template_library {
 
             segment       cur_segment_{};
             offset        cur_offset_{};
-            bitset_pointer backing_bitset_;
+            bitset_pointer backing_bitset_ = nullptr;
 
         public:
             ///> proxy for the current bit position
@@ -128,7 +128,7 @@ namespace dice::template_library {
                 reference(bitset_pointer backing_bitset, segment const seg, offset const off) noexcept
                     : backing_bitset_{backing_bitset}, seg{seg}, off{off} {}
 
-                explicit operator bool() const noexcept {
+                operator bool() const noexcept {
                     return backing_bitset_->test(calc_global_idx(seg, off));
                 }
 
@@ -315,23 +315,29 @@ namespace dice::template_library {
             using reference = bitset_iterator<is_const>::reference;
 
             bitset_iterator<is_const> it_;
-            bitset_pointer const backing_bitset_;
+            bitset_pointer backing_bitset_ = nullptr;
 
         public:
-            explicit position_iterator(std::conditional_t<is_const, bitset const&, bitset&> bitset) noexcept
-                : it_{&bitset}, backing_bitset_{&bitset} {}
+            using iterator_category = std::input_iterator_tag;
+            using iterator_concept  = std::input_iterator_tag;
+            using value_type        = bool;
+            using pointer           = void;
+            using difference_type   = ptrdiff_t;
 
-            position_iterator operator++() noexcept {
+            explicit position_iterator(std::conditional_t<is_const, bitset const&, bitset&> bitset) noexcept
+                : it_{bitset}, backing_bitset_{&bitset} {}
+
+            position_iterator& operator++() noexcept {
                 auto offset  = (*it_).off;
                 auto segment = it_.get();
 
-                if constexpr (std::integral<value_type>) {
+                if constexpr (std::integral<T>) {
                     auto skip = offset + 1;
 
                     while (true) {
-                        value_type const shifted = (skip >= inner_size_in_bits())
-                            ? value_type{0}
-                            : static_cast<value_type>(segment >> skip);
+                        T const shifted = (skip >= inner_size_in_bits())
+                            ? T{}
+                            : static_cast<T>(segment >> skip);
 
                         if (shifted != 0x00) {
                             it_ += (skip + std::countr_zero(shifted)) - offset;
@@ -795,7 +801,7 @@ namespace dice::template_library {
 
         [[nodiscard]] size_t segment_free(const_reference segment) const {
             if constexpr (std::integral<value_type>) {
-                return std::countr_zero(static_cast<storage::value_type>(~segment));
+                return std::countr_zero(static_cast<value_type>(~segment));
             }
 
             return slot_handler(segment, [](storage_word word) -> size_t {
@@ -992,11 +998,11 @@ namespace dice::template_library {
 
         void reset_all() requires(!has_dynamic_extent) {
             if constexpr (std::integral<value_type>) {
-                std::fill(inner_.begin(), inner_.end(), 0x00);
+                std::fill(inner_.begin(), inner_.end(), value_type{});
             }
             else {
                 for (auto &segment : inner_) {
-                    slot_handler(segment, 0x00);
+                    slot_handler(segment, storage_word{});
                 }
             }
         }
@@ -1025,7 +1031,7 @@ namespace dice::template_library {
             auto it = begin() + size_in_bits();
             auto end = begin();
 
-            auto perform_shrink = [this](auto const& segment) {
+            auto perform_shrink = [this](auto &segment) {
                 auto ptr_dist = std::distance(inner_.data(), &segment);
                 if constexpr (!has_max_extent) {
                     inner_ = storage(inner_.data(), inner_.data() + ptr_dist);
@@ -1036,7 +1042,7 @@ namespace dice::template_library {
             };
 
             while (it != end) {
-                auto segment = (it - 1).get();
+                auto &segment = (it - 1).get();
                 if constexpr (std::integral<value_type>) {
                     if (static_cast<value_type>(~segment) != 0x00) {
                         perform_shrink(segment);
@@ -1210,7 +1216,7 @@ namespace dice::template_library {
          */
         void set_positions(std::ranges::input_range auto&& positions) {
             positions_cntl(std::forward<decltype(positions)>(positions), [this](auto pos) {
-                set(pos);
+                this->set(pos);
             });
         }
 
@@ -1221,7 +1227,7 @@ namespace dice::template_library {
          */
         void reset_positions(std::ranges::input_range auto&& positions) {
             positions_cntl(std::forward<decltype(positions)>(positions), [this](auto pos) {
-                reset(pos);
+                this->reset(pos);
             });
         }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -28,13 +28,6 @@ namespace dice::template_library {
         };
     };
 
-    template<>
-    struct merge_functor<bool> {
-        bool operator()(bool const v1, bool const v2) const {
-            return v1 & v2;
-        }
-    };
-
     struct bitset_const {
         static constexpr size_t bit_mode = 0x00;
         static constexpr size_t segment_mode = 0x01;
@@ -64,17 +57,17 @@ namespace dice::template_library {
     private:
         struct bitset_iterator {
         private:
-            storage::pointer cur_segment_;
-            offset          cur_offset_{};
+            segment       cur_segment_{};
+            offset        cur_offset_{};
             bitset *const backing_bitset_;
 
         public:
             explicit bitset_iterator(storage &bitset) noexcept :
-                cur_segment_{bitset.data()}, backing_bitset_{&bitset} {}
+                backing_bitset_{&bitset} {}
 
             explicit bitset_iterator(storage &bitset, offset const& o) :
-                cur_segment_{bitset.data()}, backing_bitset_{&bitset}{
-                if (o >= segment_size) {
+                backing_bitset_{&bitset}{
+                if (o >= segment_size_in_bits) {
                     throw std::out_of_range{"bitset_iterator: o >= segment_size"};
                 }
                 cur_offset_ = o;
@@ -82,28 +75,29 @@ namespace dice::template_library {
 
             explicit bitset_iterator(storage &bitset, offset const& o, segment const& s) :
                 backing_bitset_{&bitset}{
-                if (o >= segment_size) {
+                if (o >= segment_size_in_bits) {
                     throw std::out_of_range{"bitset_iterator: o >= segment_size"};
                 }
 
-                if (bitset.data() + s >= bitset.size()) {
+                if (s >= bitset.size()) {
                     throw std::out_of_range{"bitset_iterator: segment out of bounds"};
                 }
 
                 cur_offset_ = o;
-                cur_segment_ = bitset.data() + s;
+                cur_segment_ = s;
             }
 
             void operator=(bool const b) const noexcept {
                 if (b) {
-                    backing_bitset_->set(std::distance(cur_segment_, backing_bitset_->inner_.data()), cur_offset_);
+                    ;
+                    backing_bitset_->set(calc_global_idx(cur_segment_, cur_offset_));
                     return;
                 }
-                backing_bitset_->unset(std::distance(cur_segment_, backing_bitset_->inner_.data()), cur_offset_);
+                backing_bitset_->unset(calc_global_idx(cur_segment_, cur_offset_));
             }
 
             bool operator*() const noexcept {
-                return backing_bitset_->test(std::distance(cur_segment_, backing_bitset_->inner_.data()), cur_offset_);
+                return backing_bitset_->test(calc_global_idx(cur_segment_, cur_offset_));
             }
 
             // shared iterator for mode=0 (bits) mode>=1 (segments)
@@ -156,12 +150,22 @@ namespace dice::template_library {
                 return *this;
             }
 
-            T const& get() {
-                return *cur_segment_;
+            bitset_iterator operator+(size_t rh_add) {
+                bitset_iterator tmp = *this;
+                tmp += rh_add;
+                return tmp;
+            }
+
+            T const& get() const {
+                return *(backing_bitset_->inner_.data() + cur_segment_);
+            }
+
+            T& get() {
+                return *(backing_bitset_->inner_.data() + cur_segment_);
             }
 
             bool consumed() const noexcept {
-                return cur_segment_ >= backing_bitset_->inner_.data() + backing_bitset_->size();
+                return cur_segment_ >= backing_bitset_->size();
             }
 
             friend bool operator==(std::default_sentinel_t, bitset_iterator const& it) {
@@ -238,7 +242,7 @@ namespace dice::template_library {
             }
         }
 
-        [[nodiscard]] static constexpr global_ix calc_global_idx(segment const s, offset const o) {
+        [[nodiscard]] static constexpr global_ix calc_global_idx(segment const s, offset const o) noexcept {
             return s * segment_size_in_bits + o;
         }
 
@@ -276,9 +280,7 @@ namespace dice::template_library {
             auto const segment = calc_which_segment(ix);
             auto const offset  = calc_which_offset(ix);
 
-            using result_t = std::invoke_result_t<F, bitset*, size_t, size_t>;
-
-            if constexpr (std::is_void_v<result_t>) {
+            if constexpr (std::is_void_v<std::invoke_result_t<F, bitset*, size_t, size_t>>) {
                 std::invoke(std::forward<F>(ops), this, segment, offset);
                 return;
             }
@@ -288,10 +290,8 @@ namespace dice::template_library {
         }
 
         template<typename F>
-        auto bitset_op_cntl(F &&ops, storage::const_reference segment) -> std::invoke_result_t<F, typename storage::const_reference> {
-            using result_t = std::invoke_result_t<F, bitset*, typename storage::const_reference>;
-
-            if constexpr (std::is_void_v<result_t>) {
+        auto bitset_op_cntl(F &&ops, storage::const_reference segment) const -> std::invoke_result_t<F, bitset*, typename storage::const_reference> {
+            if constexpr (std::is_void_v<std::invoke_result_t<F, bitset*, typename storage::const_reference>>) {
                 std::invoke(std::forward<F>(ops), this, segment);
                 return;
             }
@@ -300,19 +300,19 @@ namespace dice::template_library {
             }
         }
 
-        void segment_set(segment const s, offset const o) {
+        void segment_set(segment const s, offset const o) noexcept {
             *(inner_.data() + s) |= 1uz << o;
         }
 
-        void segment_flip(segment const s, offset const o) {
+        void segment_flip(segment const s, offset const o) noexcept {
             *(inner_.data() + s) ^= 1uz << o;
         }
 
-        void segment_unset(segment const s, offset const o) {
+        void segment_unset(segment const s, offset const o) noexcept {
             *(inner_.data() + s) &= ~(1uz << o);
         }
 
-        [[nodiscard]] bool segment_test(segment const s, offset const o) {
+        [[nodiscard]] bool segment_test(segment const s, offset const o) noexcept {
             return *(inner_.data() + s) & 1uz << o;
         }
 
@@ -338,7 +338,7 @@ namespace dice::template_library {
         template<typename F, typename M, typename Tp, typename Ops=add_op>
         requires std::is_same_v<std::invoke_result_t<F, typename storage::const_reference>, Tp> &&
             std::invocable<M, Tp, Tp>
-        Tp segment_handler(F &&handler, M &&merge, Tp initial) {
+        Tp segment_handler(F &&handler, M &&merge, Tp initial) const {
             Tp merge_val{initial};
             for (auto const &segment : inner_) {
                 merge_val = std::invoke(std::forward<M>(merge), Ops{}, merge_val,
@@ -349,7 +349,7 @@ namespace dice::template_library {
         }
 
         template<typename F>
-        bool segment_handler(F &&handler, bitset const& other) {
+        bool segment_handler(F &&handler, bitset const& other) const {
             auto self_it = begin();
             auto outer_it = other.begin();
 
@@ -360,7 +360,7 @@ namespace dice::template_library {
             auto end_sentinel = end();
 
             while (self_it != end_sentinel) {
-                if (std::invoke(std::forward<F>(handler), self_it.get(), outer_it.get())) {
+                if (!std::invoke(std::forward<F>(handler), self_it.get(), outer_it.get())) {
                     return false;
                 }
                 ++self_it;
@@ -370,7 +370,7 @@ namespace dice::template_library {
         }
 
         template<typename F, typename M, typename Tp, typename Ops=add_op>
-        [[nodiscard]] Tp slot_handler(storage::const_reference segment, F &&f, M&& m, Tp initial) {
+        [[nodiscard]] Tp slot_handler(storage::const_reference segment, F &&f, M&& m, Tp initial) const {
             Tp merge_val{initial};
             auto [word, end] = segment_slots(segment);
 
@@ -382,7 +382,7 @@ namespace dice::template_library {
         }
 
         template<typename Ops=add_op>
-        void slot_handler(storage::const_reference segment, storage::const_reference other) {
+        void slot_handler(storage::reference segment, storage::const_reference other) {
             auto merge_func = dice::template_library::merge_functor<storage_word>{};
             auto [word, end] = segment_slots(segment);
             auto [word2, end2] = segment_slots(other);
@@ -392,7 +392,7 @@ namespace dice::template_library {
             }
         }
 
-        bool slot_handler(storage::const_reference segment, storage::const_reference other) {
+        bool slot_handler(storage::const_reference segment, storage::const_reference other) const {
             auto [word, end] = segment_slots(segment);
             auto [word2, end2] = segment_slots(other);
 
@@ -529,7 +529,7 @@ namespace dice::template_library {
             return bitset_mod_cntl(DefaultModeTag{}, &bitset::segment_test, ix);
         }
 
-        [[nodiscard]] size_t count() {
+        [[nodiscard]] size_t count() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_count, segment);
             }, merge_functor<size_t>{}, 0);
@@ -541,15 +541,16 @@ namespace dice::template_library {
 
                 if (offset != segment_size_in_bits) {
                     auto seg = std::distance(inner_.data(), &segment);
-                    set(seg, offset);
+                    segment_set(seg, offset);
                     return calc_global_idx(seg, offset);
                 }
             }
 
+            // if dynamic extent we should dynamically check if we can add a further segment
             if constexpr (storage::has_dynamic_extent) {
                 if constexpr (!has_storage_limit) {
                     inner_.resize(inner_.size() + 1);
-                    *static_cast<storage_word_const_pointer>(inner_.end() - 1) = 0x01;
+                    *reinterpret_cast<storage_word_pointer>(inner_.end() - 1) = 0x01;
 
                     return calc_global_idx(std::distance(inner_.data(), inner_.end()), 0);
                 }
@@ -557,7 +558,7 @@ namespace dice::template_library {
                     if (inner_.size() == inner_.max_size()) {
                         return storage_size_in_bits;
                     }
-                    *static_cast<storage_word_const_pointer>(inner_.end()) = 0x01;
+                    *reinterpret_cast<storage_word_pointer>(inner_.end()) = 0x01;
                     inner_.resize(inner_.size() + 1);
 
                     return calc_global_idx(std::distance(inner_.data(), inner_.end()), 0);
@@ -609,11 +610,11 @@ namespace dice::template_library {
             }, merge_functor<bool>{}, true);
         }
 
-        constexpr iterator begin() {
+        constexpr iterator begin() noexcept {
             return iterator{*this};
         }
 
-        constexpr std::default_sentinel_t end() {
+        constexpr std::default_sentinel_t end() const noexcept {
             return std::default_sentinel;
         }
 
@@ -622,7 +623,7 @@ namespace dice::template_library {
         }
 
         constexpr size_t size_in_bits() const noexcept {
-            return size() * 8;
+            return size() * segment_size_in_bits;
         }
 
         constexpr size_t inner_size() const noexcept {
@@ -633,7 +634,7 @@ namespace dice::template_library {
             return segment_size_in_bits;
         }
 
-        bool operator ==(bitset const& alt_storage) const noexcept {
+        bool operator==(bitset const& alt_storage) const noexcept {
             return segment_handler([this](typename storage::const_reference segment_first, typename storage::const_reference segment_second) {
                 return slot_handler(segment_first, segment_second);
             }, alt_storage);
@@ -650,14 +651,14 @@ namespace dice::template_library {
         }
 
         bitset& operator &=(bitset const& alt_storage) noexcept {
-            segment_handler([this](typename storage::const_reference segment_first, typename storage::const_reference segment_second) {
+            segment_handler([this](typename storage::reference segment_first, typename storage::const_reference segment_second) {
                 slot_handler<bit_and_op>(segment_first, segment_second);
             }, alt_storage);
             return *this;
         }
 
         bitset& operator |=(bitset const& alt_storage) noexcept {
-            segment_handler([this](typename storage::const_reference segment_first, typename storage::const_reference segment_second) {
+            segment_handler([this](typename storage::reference segment_first, typename storage::const_reference segment_second) {
                 slot_handler<bit_or_op>(segment_first, segment_second);
             }, alt_storage);
             return *this;
@@ -739,7 +740,7 @@ struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
         auto it = storage.begin();
         auto end = storage.end();
         auto segments = storage.size();
-        auto segment_size = storage.inner();
+        auto segment_size = storage.inner_size();
         auto segment_size_in_bits = storage.inner_size_in_bits();
 
         auto out = ctx.out();
@@ -789,6 +790,8 @@ struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
         }
         *out++ = ']';
         *out++ = '\n';
+
+        return out;
     }
 };
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -658,19 +658,27 @@ struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
 
         while (it != end) {
             *out++ = '[';
-            auto const& segment = it.get();
             if (hex) {
+                auto const& segment = it.get();
                 if constexpr (std::integral<T>) {
                    out = std::format_to(out, "{:x}", segment);
                 }
-                // proper align
-                ++it.template operator++<dice::template_library::bitset_const::segment_mode>();
+                else {
+                    auto [word, end] = storage.segment_slots(segment);
+
+                    for (; word != end; ++word) {
+                        out = std::format_to(out, "{:x}", *word);
+                    }
+                }
+                it.template operator++<dice::template_library::bitset_const::segment_mode>();
             }
             else if (binary) {
                 for (auto segment_bit{0uz}; segment_bit < segment_size; ++segment_bit) {
-                    *out++ = *it ? '1' : '0';
-                    ++it;
+                    *out++ = *it++ ? '1' : '0';
                 }
+            }
+            else {
+                ++it;
             }
             *out++ = ']';
             *out++ = '\n';

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -602,42 +602,56 @@ namespace dice::template_library {
         [[nodiscard]] size_t countr_zero() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_countr_zero, segment);
+            }, [](size_t const val) {
+                return val == segment_size_in_bits;
             }, merge_functor<size_t>{}, 0);
         }
 
         [[nodiscard]] size_t countl_zero() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_countl_zero, segment);
+            }, [](size_t const val) {
+                return val == segment_size_in_bits;
             }, merge_functor<size_t>{}, 0);
         }
 
         [[nodiscard]] size_t countr_one() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_countr_one, segment);
+            }, [](size_t const val) {
+                return val == segment_size_in_bits;
             }, merge_functor<size_t>{}, 0);
         }
 
         [[nodiscard]] size_t countl_one() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_countl_one, segment);
+            }, [](size_t const val) {
+                return val == segment_size_in_bits;
             }, merge_functor<size_t>{}, 0);
         }
 
         [[nodiscard]] bool all_set() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_all_set, segment);
-            }, merge_functor<bool>{}, true);
+            }, [](bool const val) {
+                return val;
+            },merge_functor<bool>{}, true);
         }
 
         [[nodiscard]] bool any_set() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_any_set, segment);
+            }, [](bool const val) {
+                return val;
             }, merge_functor<bool>{}, true);
         }
 
         [[nodiscard]] bool none_set() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_none_set, segment);
+            }, [](bool const val) {
+                return val;
             }, merge_functor<bool>{}, true);
         }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -5,6 +5,7 @@
 #include <bit>
 #include <functional>
 #include <numeric>
+#include <format>
 
 namespace dice::template_library {
 
@@ -452,6 +453,33 @@ namespace dice::template_library {
     template<typename T>
     static constexpr bitset<T, dynamic_extent, dynamic_extent> create_bitset(std::initializer_list<T> const list) {
         return bitset<T, dynamic_extent, dynamic_extent>{list};
+    }
+}
+
+template<typename T, size_t extent, size_t max_extent>
+struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
+    bool hex = false;
+    bool debug = false;
+
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        while (it != ctx.end()) {
+            if (*it != 'x' && *it != '?') {
+                throw std::format_error("Invalid format args for dice::template_library::bitset.");
+            }
+
+            if (*it == '?') {
+                debug = true;
+            }
+            else {
+                hex = true;
+            }
+            ++it;
+        }
+    }
+
+    auto format(dice::template_library::bitset<T, extent, max_extent> const& storage, std::format_context& ctx) const {
+
     }
 };
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -150,6 +150,10 @@ namespace dice::template_library {
             }
         }
 
+        [[nodiscard]] static constexpr global_ix calc_global_idx(segment const s, offset const o) {
+            return s * segment_size_in_bits + o;
+        }
+
         template<typename F>
         auto bitset_mod_cntl(AutoModeTag, F&& ops, global_ix const ix) -> std::invoke_result_t<F, bitset*, size_t, size_t> {
             if (!fits_in_storage(ix)) {
@@ -220,18 +224,24 @@ namespace dice::template_library {
             *(inner_.data() + s) &= ~(1uz << o);
         }
 
-        bool test(segment const s, offset const o) {
+        [[nodiscard]] bool test(segment const s, offset const o) {
             return *(inner_.data() + s) & 1uz << o;
         }
 
-        size_t count(storage::const_reference segment) {
+        [[nodiscard]] size_t count(storage::const_reference segment) {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::popcount(segment);
             }
 
-            auto const bytes = reinterpret_cast<const std::uint8_t*>(&segment);
+            auto byte = reinterpret_cast<const std::uint8_t*>(&segment);
+            auto const end = byte + segment_size;
 
-            return std::accumulate(bytes, bytes + segment_size, 0);
+            auto accumulated{0uz};
+            for (; byte != end; ++byte) {
+                accumulated += std::popcount(*byte);
+            }
+
+            return accumulated;
         }
 
 #ifdef __SIZEOF_INT128__
@@ -242,6 +252,23 @@ namespace dice::template_library {
             return std::popcount(lo) + std::popcount(hi);
         }
 #endif
+
+        [[nodiscard]] size_t segment_free(storage::const_reference segment) {
+            if constexpr (std::integral<typename storage::value_type>) {
+                return std::countr_zero(~segment);
+            }
+
+            auto byte = reinterpret_cast<const std::uint8_t*>(&segment);
+            auto const end = byte + segment_size;
+
+            for (; byte != end; ++byte) {
+                if (auto const segment_free = static_cast<uint8_t>(~(*byte)); segment_free != 0) {
+                    return std::countr_zero(segment_free);
+                }
+            }
+
+            return segment_size_in_bits;
+        }
 
     public:
         using iterator = bitset_iterator;
@@ -258,15 +285,49 @@ namespace dice::template_library {
             bitset_mod_cntl(AutoModeTag{}, &bitset::unset, ix);
         }
 
-        bool test(global_ix const ix) {
+        [[nodiscard]] bool test(global_ix const ix) {
             return bitset_mod_cntl(AutoModeTag{}, &bitset::test, ix);
         }
 
-        size_t count() {
+        [[nodiscard]] size_t count() {
             size_t accumulated{0};
             for (auto const &segment : inner_) {
                 accumulated += bitset_op_cntl(&bitset::count, segment);
             }
+
+            return accumulated;
+        }
+
+        size_t set_first_free() {
+            for (auto const &segment : inner_) {
+                auto offset = bitset_op_cntl(&bitset::set_first_free, segment);
+
+                if (offset != segment_size_in_bits) {
+                    auto seg = std::distance(inner_.data(), &segment);
+                    set(seg, offset);
+                    return calc_global_idx(seg, offset);
+                }
+            }
+
+            if constexpr (storage::has_dynamic_extent) {
+                if constexpr (!has_storage_limit) {
+                    inner_.resize(inner_.size() + 1);
+                    *(inner_.end() - 1) = 0x01;
+
+                    return calc_global_idx(std::distance(inner_.end(), inner_.data(), 0));
+                }
+                else {
+                    if (inner_.size() == inner_.max_size()) {
+                        return storage_size_in_bits;
+                    }
+                    *inner_.end() = 0x01;
+                    inner_.resize(inner_.size() + 1);
+
+                    return calc_global_idx(std::distance(inner_.end(), inner_.data()), 0);
+                }
+            }
+
+            return storage_size_in_bits;
         }
 
         constexpr iterator begin() {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -126,12 +126,7 @@ namespace dice::template_library {
                 }
 
                 reference const& operator=(bool const b) const noexcept {
-                    if (b) {
-                        backing_bitset_->set(calc_global_idx(seg, off));
-                    }
-                    else {
-                        backing_bitset_->reset(calc_global_idx(seg, off));
-                    }
+                    backing_bitset_->set(calc_global_idx(seg, off), b);
                     return *this;
                 }
             };
@@ -801,13 +796,30 @@ namespace dice::template_library {
 
         /**
          * Set a bit high for offset ix
+         *
+         * @param ix offset to use
          */
         void set(global_ix const ix) {
             bitset_mod_cntl(&bitset::segment_set, ix);
         }
 
         /**
+         * Set a bit based on $high for offset ix
+         *
+         * @param ix offset to use
+         * @param high which bit state
+         */
+        void set(global_ix const ix, bool const high) {
+            if (high) {
+                set(ix); return;
+            }
+            reset(ix);
+        }
+
+        /**
          * Flip a bit for offset ix
+         *
+         * @param ix offset to use
          */
         void flip(global_ix const ix) {
             bitset_mod_cntl(&bitset::segment_flip, ix);
@@ -815,6 +827,8 @@ namespace dice::template_library {
 
         /**
          * Set a bit low for offset ix
+         *
+         * @param ix offset to use
          */
         void reset(global_ix const ix) {
             bitset_mod_cntl(&bitset::segment_unset, ix);
@@ -822,6 +836,8 @@ namespace dice::template_library {
 
         /**
          * Test a bit (low, high) for offset ix
+         *
+         * @param ix offset to use
          *
          * @return bool indicating the state of ix
          */

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -118,9 +118,31 @@ namespace dice::template_library {
             }
 
             template<size_t mode=bitset_const::bit_mode>
+            bitset_iterator& operator--() noexcept {
+                if constexpr (mode == bitset_const::bit_mode) {
+                    if (cur_offset_ == 0) {
+                        --cur_segment_;
+                        cur_offset_ = segment_size_in_bits-1;
+                        return *this;
+                    }
+                    --cur_offset_;
+                    return *this;
+                }
+                --cur_segment_;
+                return *this;
+            }
+
+            template<size_t mode=bitset_const::bit_mode>
             bitset_iterator operator++(int) noexcept {
                 auto tmp = *this;
                 operator++<mode>();
+                return tmp;
+            }
+
+            template<size_t mode=bitset_const::bit_mode>
+            bitset_iterator operator--(int) noexcept {
+                auto tmp = *this;
+                operator--<mode>();
                 return tmp;
             }
 
@@ -152,9 +174,39 @@ namespace dice::template_library {
                 return *this;
             }
 
+            template<size_t mode=bitset_const::bit_mode>
+            bitset_iterator& operator-=(size_t const skip) noexcept {
+                auto skip_handler = [this](size_t const skip_size) {
+                    auto global_ix = calc_global_idx(cur_segment_, cur_offset_);
+
+                    global_ix = global_ix >= skip_size ? global_ix - skip_size : 0;
+
+                    auto offset = calc_which_offset(global_ix);
+                    auto seg = calc_which_segment(global_ix);
+
+                    cur_segment_ = seg;
+                    cur_offset_ = offset;
+                };
+
+                if constexpr (mode == bitset_const::bit_mode) {
+                    skip_handler(skip);
+                }
+                else {
+                    skip_handler(skip * segment_size_in_bits);
+                }
+
+                return *this;
+            }
+
             bitset_iterator operator+(size_t rh_add) const noexcept {
                 bitset_iterator tmp = *this;
                 tmp += rh_add;
+                return tmp;
+            }
+
+            bitset_iterator operator-(size_t rh_sub) const noexcept {
+                bitset_iterator tmp = *this;
+                tmp -= rh_sub;
                 return tmp;
             }
 
@@ -316,8 +368,12 @@ namespace dice::template_library {
             return o / (segment_align * 8);
         }
 
-        storage_word_pointer get_chunk_raw(segment const s, offset const o) const noexcept {
+        storage_word_pointer get_chunk_raw(segment const s, offset const o) noexcept {
             return reinterpret_cast<storage_word_pointer>(inner_.data() + s) + which_chunk(o);
+        }
+
+        storage_word_const_pointer get_chunk_raw(segment const s, offset const o) const noexcept {
+            return reinterpret_cast<storage_word_const_pointer>(inner_.data() + s) + which_chunk(o);
         }
 
         void segment_set(segment const s, offset const o) noexcept {
@@ -393,6 +449,27 @@ namespace dice::template_library {
 
         template<typename F>
         bool segment_handler(F &&handler, bitset const& other) {
+            auto self_it = begin();
+            auto outer_it = other.begin();
+
+            if (size() != other.size()) {
+                return false;
+            }
+
+            auto end_sentinel = end();
+
+            while (self_it != end_sentinel) {
+                if (!std::invoke(std::forward<F>(handler), self_it.get(), outer_it.get())) {
+                    return false;
+                }
+                self_it.template operator++<bitset_const::segment_mode>();
+                outer_it.template operator++<bitset_const::segment_mode>();
+            }
+            return true;
+        }
+
+        template<typename F>
+        bool segment_handler(F &&handler, bitset const& other) const {
             auto self_it = begin();
             auto outer_it = other.begin();
 
@@ -498,7 +575,7 @@ namespace dice::template_library {
 
         [[nodiscard]] size_t segment_free(storage::const_reference segment) const {
             if constexpr (std::integral<typename storage::value_type>) {
-                return std::countr_zero(~segment);
+                return std::countr_zero(static_cast<storage::value_type>(~segment));
             }
 
             return slot_handler(segment, [](storage_word word) -> size_t {
@@ -601,8 +678,15 @@ namespace dice::template_library {
         constexpr bitset &operator=(bitset &&) = default;
         constexpr ~bitset() = default;
 
-        [[nodiscard]] std::pair<storage_word_pointer, storage_word_const_pointer> segment_slots(storage::const_reference segment) const noexcept {
+        [[nodiscard]] std::pair<storage_word_const_pointer, storage_word_const_pointer> segment_slots(storage::const_reference segment) const noexcept {
             auto word = reinterpret_cast<storage_word_const_pointer>(&segment);
+            auto const end = word + segment_steps;
+
+            return std::pair{word, end};
+        }
+
+        [[nodiscard]] std::pair<storage_word_pointer, storage_word_pointer> segment_slots(storage::reference segment) const noexcept {
+            auto word = reinterpret_cast<storage_word_pointer>(&segment);
             auto const end = word + segment_steps;
 
             return std::pair{word, end};
@@ -746,11 +830,11 @@ namespace dice::template_library {
             return size() * segment_size_in_bits;
         }
 
-        constexpr size_t inner_size() const noexcept {
+        static constexpr size_t inner_size() noexcept {
             return segment_size;
         }
 
-        constexpr size_t inner_size_in_bits() const noexcept {
+        static constexpr size_t inner_size_in_bits() noexcept {
             return segment_size_in_bits;
         }
 
@@ -761,18 +845,19 @@ namespace dice::template_library {
         }
 
         bitset& operator<<=(size_t shift) {
-            std::move(begin() + shift, begin() + size_in_bits(), begin());
+            //std::move(begin() + shift, begin() + size_in_bits(), begin());
             return *this;
         }
 
         bitset& operator>>=(size_t shift) {
-            std::move_backward(begin(), begin() + size_in_bits() - shift, begin() + size_in_bits());
+            //std::move_backward(begin(), begin() + size_in_bits() - shift, begin() + size_in_bits());
             return *this;
         }
 
         bitset& operator &=(bitset const& alt_storage) noexcept {
             segment_handler([this](typename storage::reference segment_first, typename storage::const_reference segment_second) {
                 slot_handler<bit_and_op>(segment_first, segment_second);
+                return true;
             }, alt_storage);
             return *this;
         }
@@ -780,6 +865,7 @@ namespace dice::template_library {
         bitset& operator |=(bitset const& alt_storage) noexcept {
             segment_handler([this](typename storage::reference segment_first, typename storage::const_reference segment_second) {
                 slot_handler<bit_or_op>(segment_first, segment_second);
+                return true;
             }, alt_storage);
             return *this;
         }

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -10,14 +10,14 @@
 namespace dice::template_library {
 
     template<typename Tp>
-        struct MergeFunctor {
+        struct merge_functor {
         Tp operator()(Tp const v1, Tp const v2) const noexcept {
             return v1 + v2;
         };
     };
 
     template<>
-    struct MergeFunctor<bool> {
+    struct merge_functor<bool> {
         bool operator()(bool const v1, bool const v2) const {
             return v1 & v2;
         }
@@ -370,7 +370,7 @@ namespace dice::template_library {
 
             return slot_handler(segment, [](storage_word_const_pointer word) -> size_t {
                 return std::countl_zero(*word);
-            }, MergeFunctor<size_t>{}, 0uz);
+            }, merge_functor<size_t>{}, 0uz);
         }
 
         [[nodiscard]] size_t countr_zero(storage::const_reference segment) const noexcept {
@@ -380,7 +380,7 @@ namespace dice::template_library {
 
             return slot_handler(segment, [](storage_word_const_pointer word) -> size_t {
                 return std::countr_zero(*word);
-            }, MergeFunctor<size_t>{}, 0uz);
+            }, merge_functor<size_t>{}, 0uz);
         }
 
         [[nodiscard]] size_t countl_one(storage::const_reference segment) const noexcept {
@@ -390,7 +390,7 @@ namespace dice::template_library {
 
             return slot_handler(segment, [](storage_word_const_pointer word) -> size_t {
                 return std::countl_one(*word);
-            }, MergeFunctor<size_t>{}, 0uz);
+            }, merge_functor<size_t>{}, 0uz);
         }
 
         [[nodiscard]] size_t countr_one(storage::const_reference segment) const noexcept {
@@ -400,7 +400,7 @@ namespace dice::template_library {
 
             return slot_handler(segment, [](storage_word_const_pointer word) -> size_t {
                 return std::countr_one(*word);
-            }, MergeFunctor<size_t>{}, 0uz);
+            }, merge_functor<size_t>{}, 0uz);
         }
 
         [[nodiscard]] bool all_set(storage::const_reference segment) const noexcept {
@@ -522,43 +522,43 @@ namespace dice::template_library {
         [[nodiscard]] size_t countr_zero() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::countr_zero, segment);
-            }, MergeFunctor<size_t>{}, 0);
+            }, merge_functor<size_t>{}, 0);
         }
 
         [[nodiscard]] size_t countl_zero() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::countl_zero, segment);
-            }, MergeFunctor<size_t>{}, 0);
+            }, merge_functor<size_t>{}, 0);
         }
 
         [[nodiscard]] size_t countr_one() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::countr_one, segment);
-            }, MergeFunctor<size_t>{}, 0);
+            }, merge_functor<size_t>{}, 0);
         }
 
         [[nodiscard]] size_t countl_one() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::countl_one, segment);
-            }, MergeFunctor<size_t>{}, 0);
+            }, merge_functor<size_t>{}, 0);
         }
 
         [[nodiscard]] bool all_set() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::all_set, segment);
-            }, MergeFunctor<bool>{}, true);
+            }, merge_functor<bool>{}, true);
         }
 
         [[nodiscard]] bool any_set() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::any_set, segment);
-            }, MergeFunctor<bool>{}, true);
+            }, merge_functor<bool>{}, true);
         }
 
         [[nodiscard]] bool none_set() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::none_set, segment);
-            }, MergeFunctor<bool>{}, true);
+            }, merge_functor<bool>{}, true);
         }
 
         constexpr iterator begin() {
@@ -664,9 +664,9 @@ struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
                    out = std::format_to(out, "{:x}", segment);
                 }
                 else {
-                    auto [word, end] = storage.segment_slots(segment);
+                    auto [word, word_end] = storage.segment_slots(segment);
 
-                    for (; word != end; ++word) {
+                    for (; word != word_end; ++word) {
                         out = std::format_to(out, "{:x}", *word);
                     }
                 }

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -821,6 +821,24 @@ namespace dice::template_library {
             return segment_count(segment) == 0x00;
         }
 
+        template<typename F>
+        void positions_cntl(std::ranges::input_range auto&& positions, F&& pos_f) {
+            if constexpr (std::ranges::sized_range<decltype(positions)>) {
+                auto position_elements = std::ranges::size(positions);
+                if (position_elements >= storage_size_in_bits) {
+                    throw std::range_error{"bitset::set_positions range out of bounds"};
+                }
+            }
+            else {
+                auto position_elements = std::ranges::distance(positions);
+                if (position_elements >= storage_size_in_bits) {
+                    throw std::range_error{"bitset::set_positions range out of bounds"};
+                }
+            }
+
+            std::ranges::for_each(positions, std::forward<F>(pos_f));
+        }
+
     public:
         using iterator = bitset_iterator<false>;
         using const_iterator = bitset_iterator<true>;
@@ -1134,25 +1152,7 @@ namespace dice::template_library {
         auto positions() const -> std::ranges::input_range auto {
             return std::ranges::subrange(pbegin(), pend());
         }
-
-        template<typename F>
-        void positions_cntl(std::ranges::input_range auto&& positions, F&& pos_f) {
-            if constexpr (std::ranges::sized_range<decltype(positions)>) {
-                auto position_elements = std::ranges::size(positions);
-                if (position_elements >= storage_size_in_bits) {
-                    throw std::range_error{"bitset::set_positions range out of bounds"};
-                }
-            }
-            else {
-                auto position_elements = std::ranges::distance(positions);
-                if (position_elements >= storage_size_in_bits) {
-                    throw std::range_error{"bitset::set_positions range out of bounds"};
-                }
-            }
-
-            std::ranges::for_each(positions, std::forward<F>(pos_f));
-        }
-
+        
         void set_positions(std::ranges::input_range auto&& positions) {
             positions_cntl(std::forward<decltype(positions)>(positions), [this](auto pos) {
                 set(pos);

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -171,8 +171,8 @@ namespace dice::template_library {
                 auto skip_handler = [this](size_t const skip_size) {
                     auto global_ix = calc_global_idx(cur_segment_, cur_offset_) + skip_size;
 
-                    if (global_ix >= storage_size_in_bits) {
-                        cur_segment_ = segments;
+                    if (global_ix >= backing_bitset_->size_in_bits()) {
+                        cur_segment_ = backing_bitset_->size();
                         cur_offset_ = 0;
                         return;
                     }
@@ -689,7 +689,7 @@ namespace dice::template_library {
         }
 
         [[nodiscard]] bool segment_all_set(storage::const_reference segment) const noexcept {
-            return segment_free(segment) == segment_size_in_bits;
+            return segment_count(segment) == segment_size_in_bits;
         }
 
         [[nodiscard]] bool segment_any_set(storage::const_reference segment) const noexcept {
@@ -697,7 +697,7 @@ namespace dice::template_library {
         }
 
         [[nodiscard]] bool segment_none_set(storage::const_reference segment) const noexcept {
-            return segment_free(segment) == 0x00;
+            return segment_count(segment) == 0x00;
         }
 
     public:
@@ -808,7 +808,7 @@ namespace dice::template_library {
 
             return storage_size_in_bits;
         }
-        
+
         [[nodiscard]] size_t countr_zero() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_countr_zero, segment);
@@ -876,11 +876,11 @@ namespace dice::template_library {
         }
 
         constexpr const_reverse_iterator rbegin() const noexcept {
-            return reverse_iterator{begin() + size_in_bits()};
+            return const_reverse_iterator{begin() + size_in_bits()};
         }
 
         constexpr reverse_iterator rend() noexcept {
-            return const_reverse_iterator{begin()};
+            return reverse_iterator{begin()};
         }
 
         constexpr const_reverse_iterator rend() const noexcept {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -162,12 +162,18 @@ namespace dice::template_library {
                 return *(backing_bitset_->inner_.data() + cur_segment_);
             }
 
-            T& get() {
+            T& get() requires(!is_const) {
                 return *(backing_bitset_->inner_.data() + cur_segment_);
             }
 
             bool consumed() const noexcept {
                 return cur_segment_ >= backing_bitset_->size();
+            }
+
+            friend bool operator==(bitset_iterator const& lhs, bitset_iterator const& rhs){
+                return lhs.backing_bitset_ == rhs.backing_bitset_ &&
+                       lhs.cur_segment_ == rhs.cur_segment_ &&
+                       lhs.cur_offset_ == rhs.cur_offset_;
             }
 
             friend bool operator==(std::default_sentinel_t, bitset_iterator const& it) {
@@ -356,22 +362,21 @@ namespace dice::template_library {
 
         [[nodiscard]] size_t segment_count(storage::const_reference segment) const noexcept {
             if constexpr (std::integral<typename storage::value_type>) {
-                return std::popcount(segment);
+                if constexpr (std::is_same_v<typename storage::value_type, __uint128_t>) {
+                    uint64_t const lo = static_cast<uint64_t>(segment);
+                    uint64_t const hi = static_cast<uint64_t>(segment >> 64);
+
+                    return std::popcount(lo) + std::popcount(hi);
+                }
+                else {
+                    return std::popcount(segment);
+                }
             }
 
             return slot_handler(segment, [](storage_word word) -> size_t {
                 return std::popcount(word);
-            }, merge_functor<storage_word>{}, 0uz);
+            }, merge_functor<storage_word>{}, 0uz, add_op{});
         }
-
-#ifdef __SIZEOF_INT128__
-        [[nodiscard]] size_t segment_count(__uint128_t const& segment) const noexcept {
-            uint64_t const lo = static_cast<uint64_t>(segment);
-            uint64_t const hi = static_cast<uint64_t>(segment >> 64);
-
-            return std::popcount(lo) + std::popcount(hi);
-        }
-#endif
 
         template<typename F, typename M, typename Tp, typename Ops>
         requires std::is_same_v<std::invoke_result_t<F, typename storage::const_reference>, Tp> &&
@@ -387,7 +392,7 @@ namespace dice::template_library {
         }
 
         template<typename F>
-        bool segment_handler(F &&handler, bitset const& other) const {
+        bool segment_handler(F &&handler, bitset const& other) {
             auto self_it = begin();
             auto outer_it = other.begin();
 
@@ -596,7 +601,7 @@ namespace dice::template_library {
         constexpr bitset &operator=(bitset &&) = default;
         constexpr ~bitset() = default;
 
-        [[nodiscard]] std::pair<storage_word_const_pointer, storage_word_const_pointer> segment_slots(storage::const_reference segment) const noexcept {
+        [[nodiscard]] std::pair<storage_word_pointer, storage_word_const_pointer> segment_slots(storage::const_reference segment) const noexcept {
             auto word = reinterpret_cast<storage_word_const_pointer>(&segment);
             auto const end = word + segment_steps;
 
@@ -632,7 +637,7 @@ namespace dice::template_library {
         }
 
         [[nodiscard]] size_t set_first_free() {
-            for (auto const &segment : inner_) {
+            for (auto &segment : inner_) {
                 auto offset = bitset_op_cntl(&bitset::segment_free, segment);
 
                 if (offset != segment_size_in_bits) {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -1,0 +1,208 @@
+#ifndef DICE_TEMPLATELIBRARY_BITSET_HPP
+#define DICE_TEMPLATELIBRARY_BITSET_HPP
+
+#include <dice/template-library/flex_array.hpp>
+#include <bit>
+#include <functional>
+
+namespace dice::template_library {
+
+    template<typename T, size_t extent, size_t segments>
+    struct bitset {
+        static constexpr bool   has_storage_limit = segments != dynamic_extent;
+        static constexpr size_t segment_size = sizeof(T);
+        static constexpr size_t segment_size_in_bits = segment_size * 8;
+        static constexpr size_t storage_size = !has_storage_limit ? dynamic_extent : segment_size * segments;
+        static constexpr size_t storage_size_in_bits = !has_storage_limit ? dynamic_extent : storage_size * 8;
+
+        using storage   = flex_array<T, extent, segments>;
+        using global_ix = size_t;
+        using segment   = size_t;
+        using offset    = size_t;
+
+    private:
+        struct AutoModeTag {};
+        struct DefaultModeTag {};
+
+        storage inner_;
+
+        [[nodiscard]] constexpr size_t require_segments(global_ix const ix) const requires (!has_storage_limit) {
+            auto const bit_pos = bits_consumed();
+            if (bit_pos >= ix) {
+                return 0;
+            }
+
+            auto const bit_off = bit_pos - ix;
+
+            return [bit_off] {
+                if constexpr (std::has_single_bit(segment_size_in_bits)) {
+                    return bit_off >> std::countr_zero(segment_size_in_bits);
+                }
+                else {
+                    return bit_off / segment_size_in_bits;
+                }
+            }();
+        }
+
+        void constexpr expand_segments(global_ix const ix) requires (!has_storage_limit) {
+            auto const to_add = require_segments(ix);
+            if (to_add == 0) {
+                return;
+            }
+
+            inner_.resize(inner_.size() + to_add);
+        }
+
+        [[nodiscard]] constexpr size_t bits_consumed() const noexcept {
+            return inner_.size() * segment_size_in_bits;
+        }
+
+        [[nodiscard]] static constexpr bool fits_in_storage(global_ix const ix) noexcept {
+            if constexpr (has_storage_limit) {
+                return ix < storage_size_in_bits;
+            }
+
+            return true;
+        }
+
+        [[nodiscard]] static constexpr segment calc_which_segment(global_ix const ix) noexcept {
+            if constexpr (std::has_single_bit(segment_size_in_bits)) {
+                return ix >> std::countr_zero(segment_size_in_bits);
+            }
+            else {
+                return ix / segment_size_in_bits;
+            }
+        }
+
+        [[nodiscard]] static constexpr offset calc_which_offset(global_ix const ix) noexcept {
+            if constexpr (std::has_single_bit(segment_size_in_bits)) {
+                return ix & (segment_size_in_bits-1);
+            }
+            else {
+                return ix % segment_size_in_bits;
+            }
+        }
+
+        template<typename F>
+        auto bitset_mod_cntl(AutoModeTag, F&& ops, global_ix const ix) -> std::invoke_result_t<F, bitset*, size_t, size_t> {
+            if (!fits_in_storage(ix)) {
+                throw std::out_of_range{"bitset::set: ix out of range"};
+            }
+
+            // auto expands if we don't have storage limit
+            if constexpr (!has_storage_limit) {
+                expand_segments(ix);
+            }
+
+            auto const segment = calc_which_segment(ix);
+            auto const offset  = calc_which_offset(ix);
+
+            using result_t = std::invoke_result_t<F, bitset*, size_t, size_t>;
+
+            if constexpr (std::is_void_v<result_t>) {
+                std::invoke(std::forward<F>(ops), this, segment, offset);
+                return;
+            }
+            else {
+                return std::invoke(std::forward<F>(ops), this, segment, offset);
+            }
+        }
+
+        template<typename F>
+        auto bitset_mod_cntl(DefaultModeTag, F&& ops, global_ix const ix) -> std::invoke_result_t<F, bitset*, size_t, size_t> {
+            if (!fits_in_storage(ix)) {
+                throw std::out_of_range{"bitset::set: ix out of range"};
+            }
+
+            auto const segment = calc_which_segment(ix);
+            auto const offset  = calc_which_offset(ix);
+
+            using result_t = std::invoke_result_t<F, bitset*, size_t, size_t>;
+
+            if constexpr (std::is_void_v<result_t>) {
+                std::invoke(std::forward<F>(ops), this, segment, offset);
+                return;
+            }
+            else {
+                return std::invoke(std::forward<F>(ops), this, segment, offset);
+            }
+        }
+
+        template<typename F>
+        auto bitset_op_cntl(F&& ops) -> std::invoke_result_t<F> {
+            using result_t = std::invoke_result_t<F, bitset*>;
+
+            if constexpr (std::is_void_v<result_t>) {
+                std::invoke(std::forward<F>(ops), this);
+                return;
+            }
+            else {
+                return std::invoke(std::forward<F>(ops), this);
+            }
+        }
+
+        void set(segment const s, offset const o) {
+            *(inner_.data() + s) |= 1uz << o;
+        }
+
+        void flip(segment const s, offset const o) {
+            *(inner_.data() + s) ^= 1uz << o;
+        }
+
+        void unset(segment const s, offset const o) {
+            *(inner_.data() + s) &= ~(1uz << o);
+        }
+
+        bool test(segment const s, offset const o) {
+            return *(inner_.data() + s) & 1uz << o;
+        }
+
+        size_t count(T const& segment) {
+            
+        }
+
+    public:
+        void set(global_ix const ix) {
+            bitset_mod_cntl(AutoModeTag{}, &bitset::set, ix);
+        }
+
+        void flip(global_ix const ix) {
+            bitset_mod_cntl(AutoModeTag{}, &bitset::flip, ix);
+        }
+
+        void unset(global_ix const ix) {
+            bitset_mod_cntl(AutoModeTag{}, &bitset::unset, ix);
+        }
+
+        bool test(global_ix const ix) {
+            return bitset_mod_cntl(AutoModeTag{}, &bitset::test, ix);
+        }
+
+        size_t count() {
+            for (auto const &segment : inner_) {
+
+            }
+        }
+    };
+
+    static constexpr bitset<size_t, dynamic_extent, dynamic_extent> create_bitset(std::initializer_list<size_t> const list) {
+        return bitset<size_t, dynamic_extent, dynamic_extent>{list};
+    }
+
+    template<size_t bits>
+    static constexpr bitset<size_t, dynamic_extent, bits> create_bitset(std::initializer_list<size_t> const list) {
+        return bitset<size_t, dynamic_extent, bits>{list};
+    }
+
+    template<typename T, size_t bits>
+    static constexpr bitset<T, dynamic_extent, bits> create_bitset(std::initializer_list<T> const list) {
+        return bitset<T, dynamic_extent, bits>{list};
+    }
+
+    template<typename T>
+    static constexpr bitset<T, dynamic_extent, dynamic_extent> create_bitset(std::initializer_list<T> const list) {
+        return bitset<T, dynamic_extent, dynamic_extent>{list};
+    }
+};
+
+#endif //DICE_TEMPLATELIBRARY_BITSET_HPP

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -362,15 +362,15 @@ namespace dice::template_library {
 
         [[nodiscard]] size_t segment_count(storage::const_reference segment) const noexcept {
             if constexpr (std::integral<typename storage::value_type>) {
+#ifdef __SIZEOF_INT128__
                 if constexpr (std::is_same_v<typename storage::value_type, __uint128_t>) {
                     uint64_t const lo = static_cast<uint64_t>(segment);
                     uint64_t const hi = static_cast<uint64_t>(segment >> 64);
 
                     return std::popcount(lo) + std::popcount(hi);
                 }
-                else {
-                    return std::popcount(segment);
-                }
+#endif
+                return std::popcount(segment);
             }
 
             return slot_handler(segment, [](storage_word word) -> size_t {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -8,6 +8,21 @@
 
 namespace dice::template_library {
 
+    template<typename Tp>
+        struct MergeFunctor {
+        Tp operator()(Tp const v1, Tp const v2) const noexcept {
+            return v1 + v2;
+        };
+    };
+
+    template<>
+    struct MergeFunctor<bool> {
+        bool operator()(bool const v1, bool const v2) const {
+            assert(v1 == v2);
+            return v1;
+        }
+    };
+
     template<typename T, size_t extent, size_t segments>
     struct bitset {
         static constexpr bool   has_storage_limit = segments != dynamic_extent;
@@ -358,27 +373,27 @@ namespace dice::template_library {
         }
 
         [[nodiscard]] size_t countr_zero() const {
-            segment_handler([this](T const& segment) {
+            return segment_handler([this](T const& segment) {
                 return bitset_op_cntl(&bitset::countr_zero, segment);
-            }, [](size_t const v1, size_t const v2) {
-                return v1 + v2;
-            });
+            }, MergeFunctor<size_t>{});
         }
 
         [[nodiscard]] size_t countl_zero() const {
-            segment_handler([this](T const& segment) {
+            return segment_handler([this](T const& segment) {
                 return bitset_op_cntl(&bitset::countl_zero, segment);
-            }, [](size_t const v1, size_t const v2) {
-                return v1 + v2;
-            });
+            }, MergeFunctor<size_t>{});
         }
 
         [[nodiscard]] size_t countr_one() const {
-
+            return segment_handler([this](T const& segment) {
+                return bitset_op_cntl(&bitset::countr_one, segment);
+            }, MergeFunctor<size_t>{});
         }
 
         [[nodiscard]] size_t countl_one() const {
-
+            return segment_handler([this](T const& segment) {
+                return bitset_op_cntl(&bitset::countl_one, segment);
+            }, MergeFunctor<size_t>{});
         }
 
         constexpr iterator begin() {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -4,6 +4,7 @@
 #include <dice/template-library/flex_array.hpp>
 #include <bit>
 #include <functional>
+#include <numeric>
 
 namespace dice::template_library {
 
@@ -129,7 +130,7 @@ namespace dice::template_library {
         }
 
         template<typename F>
-        auto bitset_op_cntl(F&& ops) -> std::invoke_result_t<F> {
+        auto bitset_op_cntl(F&& ops) -> std::invoke_result_t<F, typename storage::const_reference> {
             using result_t = std::invoke_result_t<F, bitset*>;
 
             if constexpr (std::is_void_v<result_t>) {
@@ -157,9 +158,24 @@ namespace dice::template_library {
             return *(inner_.data() + s) & 1uz << o;
         }
 
-        size_t count(T const& segment) {
-            
+        size_t count(storage::const_reference segment) {
+            if constexpr (std::integral<typename storage::value_type>) {
+                return std::popcount(segment);
+            }
+
+            auto const bytes = reinterpret_cast<const std::uint8_t*>(&segment);
+
+            return std::accumulate(bytes, bytes + segment_size, 0);
         }
+
+#ifdef __SIZEOF_INT128__
+        size_t count(__uint128_t const& segment) {
+            uint64_t const lo = static_cast<uint64_t>(segment);
+            uint64_t const hi = static_cast<uint64_t>(segment >> 64);
+
+            return std::popcount(lo) + std::popcount(hi);
+        }
+#endif
 
     public:
         void set(global_ix const ix) {
@@ -179,8 +195,9 @@ namespace dice::template_library {
         }
 
         size_t count() {
+            size_t accumulated{0};
             for (auto const &segment : inner_) {
-
+                accumulated += bitset_op_cntl(&bitset::count, segment);
             }
         }
     };

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -1139,6 +1139,10 @@ namespace dice::template_library {
             return positional_iterator{*this};
         }
 
+        constexpr std::default_sentinel_t pend() const noexcept {
+            return std::default_sentinel;
+        }
+
         /**
          * Returns consumed bits in bits
          *

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -965,6 +965,7 @@ struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
         auto segments = storage.size();
         auto segment_size = storage.inner_size();
         auto segment_size_in_bits = storage.inner_size_in_bits();
+        auto storage_size_in_bits = storage.storage_size_in_bits;
 
         auto out = ctx.out();
         *out++ = '[';
@@ -972,7 +973,8 @@ struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
 
         if (debug) {
             out = std::format_to(out, "Segments : {}\n", segments);
-            out = std::format_to(out, "Segment size : {}\n", segment_size);
+            out = std::format_to(out, "Segment size : {}\n", segment_size_in_bits);
+            out = std::format_to(out, "Storage size : {}\n", storage_size_in_bits);
 
             if (hex) {
                 out = std::format_to(out, "Segment Representation -> Hex(0xFF)\n");
@@ -988,13 +990,13 @@ struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
             if (hex) {
                 auto const& segment = it.get();
                 if constexpr (std::integral<T>) {
-                   out = std::format_to(out, "{:x}", segment);
+                   out = std::format_to(out, "{:#0{}x}", segment, (storage.segment_align * 8 / 4));
                 }
                 else {
                     auto [word, word_end] = storage.segment_slots(segment);
 
                     for (; word != word_end; ++word) {
-                        out = std::format_to(out, "{:x}", *word);
+                        out = std::format_to(out, "{:#0{}x}", *word, (storage.segment_align * 8) / 4);
                     }
                 }
                 it.template operator++<dice::template_library::bitset_const::segment_mode>();

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -666,6 +666,9 @@ namespace dice::template_library {
     public:
         using iterator = bitset_iterator<false>;
         using const_iterator = bitset_iterator<true>;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
         using bitref = bitset_iterator<true>::bit_ref;
         static constexpr Set mode_set = Set{};
         static constexpr Unset mode_unset = Unset{};
@@ -834,6 +837,22 @@ namespace dice::template_library {
 
         constexpr const_iterator begin() const noexcept {
             return const_iterator{*this};
+        }
+
+        constexpr reverse_iterator rbegin() noexcept {
+            return reverse_iterator{begin() + size_in_bits()};
+        }
+
+        constexpr const_reverse_iterator rbegin() const noexcept {
+            return reverse_iterator{begin() + size_in_bits()};
+        }
+
+        constexpr reverse_iterator rend() noexcept {
+            return const_reverse_iterator{begin()};
+        }
+
+        constexpr const_reverse_iterator rend() const noexcept {
+            return const_reverse_iterator{begin()};
         }
 
         constexpr std::default_sentinel_t end() const noexcept {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -955,6 +955,9 @@ namespace dice::template_library {
             return segment_test(segment, offset);
         }
 
+        /**
+         * Compacts the underlying storage backend, if applicable
+         */
         void shrink_to_fit() requires (has_dynamic_extent){
             auto it = begin() + size_in_bits();
             auto end = begin();

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -109,9 +109,15 @@ namespace dice::template_library {
                 segment seg_;
                 offset  off_;
 
-                bit_ref& operator=(bit_ref&) = delete;
+                bit_ref(bit_ref const&) = default;
+                bit_ref const& operator=(bit_ref const& other) const noexcept {
+                    return *this = static_cast<bool>(other);
+                }
 
-                operator bool() const noexcept {
+                bit_ref(bitset_pointer backing_bitset, segment const seg, offset const off) noexcept
+                    : backing_bitset_{backing_bitset}, seg_{seg}, off_{off} {}
+
+                explicit operator bool() const noexcept {
                     return backing_bitset_->test(calc_global_idx(seg_, off_));
                 }
 
@@ -1166,7 +1172,6 @@ struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
         auto it = storage.begin();
         auto end = storage.end();
         auto segments = storage.size();
-        auto segment_size = storage.inner_size();
         auto segment_size_in_bits = storage.inner_size_in_bits();
         auto storage_size_in_bits = storage.storage_size_in_bits;
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -587,8 +587,8 @@ namespace dice::template_library {
                 if (!std::invoke(std::forward<F>(handler), self_it.get(), outer_it.get())) {
                     return false;
                 }
-                self_it.template operator++<bitset_mode::SegmentMode>();
-                outer_it.template operator++<bitset_mode::SegmentMode>();
+                self_it = advance_segment(self_it);
+                outer_it = advance_segment(outer_it);
             }
             return true;
         }
@@ -608,8 +608,8 @@ namespace dice::template_library {
                 if (!std::invoke(std::forward<F>(handler), self_it.get(), outer_it.get())) {
                     return false;
                 }
-                self_it.template operator++<bitset_mode::SegmentMode>();
-                outer_it.template operator++<bitset_mode::SegmentMode>();
+                self_it = advance_segment(self_it);
+                outer_it = advance_segment(outer_it);
             }
             return true;
         }
@@ -623,7 +623,7 @@ namespace dice::template_library {
                 if (auto const val = std::invoke(std::forward<F>(handler), self_it.get()); !std::invoke(std::forward<Pr>(pred), val)) {
                     return false;
                 }
-                self_it.template operator++<bitset_mode::SegmentMode>();
+                self_it = advance_segment(self_it);
             }
             return true;
         }
@@ -641,7 +641,7 @@ namespace dice::template_library {
                 if (!std::invoke(std::forward<Pr>(pred), val)) {
                     return merge_val;
                 }
-                self_it.template operator++<bitset_mode::SegmentMode>();
+                self_it = advance_segment(self_it);
             }
             return merge_val;
         }
@@ -659,7 +659,7 @@ namespace dice::template_library {
                 if (!std::invoke(std::forward<Pr>(pred), val)) {
                     return merge_val;
                 }
-                self_it.template operator--<bitset_mode::SegmentMode>();
+                self_it = advance_segment_backwards(self_it);
             }
             return merge_val;
         }
@@ -1009,7 +1009,7 @@ namespace dice::template_library {
                         return;
                     }
                 }
-                it.template operator--<bitset_mode::SegmentMode>();
+                it = advance_segment_backwards(it);
             }
         }
 
@@ -1214,7 +1214,7 @@ namespace dice::template_library {
 
         /**
          * Returns updated iterator advanced backward by skip segment
-         * 
+         *
          * @param it bitset iterator
          * @param skip segments to skip
          * @return iterator advanced backwards by skip segments

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -1423,19 +1423,26 @@ struct std::formatter<dice::template_library::bitset<extent_, max_extent_, T>> {
 
     auto format(dice::template_library::bitset<extent_, max_extent_, T> const& storage, std::format_context& ctx) const {
         auto it = storage.begin();
-        auto end = storage.end();
-        auto segments = storage.size();
-        auto segment_size_in_bits = storage.inner_size_in_bits();
-        auto storage_size_in_bits = storage.storage_size_in_bits;
+        auto const end = storage.end();
+        auto const total_bits = storage.size_in_bits();
 
         auto out = ctx.out();
         *out++ = '[';
         *out++ = '\n';
 
         if (debug) {
+            size_t segment_bits = 0;
+            if (it != end) {
+                auto const seg_end = storage.advance_segment(it);
+                for (auto p = it; p != seg_end; ++p) {
+                    ++segment_bits;
+                }
+            }
+            auto const segments = (segment_bits == 0) ? 0uz : (total_bits / segment_bits);
+
             out = std::format_to(out, "Segments : {}\n", segments);
-            out = std::format_to(out, "Segment size : {}\n", segment_size_in_bits);
-            out = std::format_to(out, "Storage size : {}\n", storage_size_in_bits);
+            out = std::format_to(out, "Segment size : {}\n", segment_bits);
+            out = std::format_to(out, "Storage size : {}\n", total_bits);
 
             if (hex) {
                 out = std::format_to(out, "Segment Representation -> Hex(0xFF)\n");
@@ -1449,22 +1456,24 @@ struct std::formatter<dice::template_library::bitset<extent_, max_extent_, T>> {
         while (it != end) {
             *out++ = '[';
             if (hex) {
+                auto const seg_end = storage.advance_segment(it);
                 auto const& segment = it.get();
                 if constexpr (std::integral<T>) {
-                   out = std::format_to(out, "{:#0{}x}", segment, (storage.segment_align * 8 / 4));
+                   out = std::format_to(out, "{:#0{}x}", segment, sizeof(segment) * 2);
                 }
                 else {
                     auto [word, word_end] = storage.segment_slots(segment);
 
                     for (; word != word_end; ++word) {
-                        out = std::format_to(out, "{:#0{}x}", *word, (storage.segment_align * 8) / 4);
+                        out = std::format_to(out, "{:#0{}x}", *word, sizeof(*word) * 2);
                     }
                 }
-                it = storage.advance_segment(it);
+                it = seg_end;
             }
             else if (binary) {
-                for (auto segment_bit{0uz}; segment_bit < segment_size_in_bits; ++segment_bit) {
-                    *out++ = *it++ ? '1' : '0';
+                auto const seg_end = storage.advance_segment(it);
+                for (; it != seg_end; ++it) {
+                    *out++ = *it ? '1' : '0';
                 }
             }
             else {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -23,6 +23,11 @@ namespace dice::template_library {
         }
     };
 
+    struct bitset_const {
+        static constexpr size_t bit_mode = 0x00;
+        static constexpr size_t segment_mode = 0x01;
+    };
+
     template<typename T, size_t extent, size_t segments>
     struct bitset {
         static constexpr bool   has_storage_limit = segments != dynamic_extent;
@@ -35,9 +40,6 @@ namespace dice::template_library {
         using global_ix = size_t;
         using segment   = size_t;
         using offset    = size_t;
-
-        static constexpr size_t bit_mode = 0x00;
-        static constexpr size_t segment_mode = 0x01;
 
     private:
         struct bitset_iterator {
@@ -85,9 +87,9 @@ namespace dice::template_library {
             }
 
             // shared iterator for mode=0 (bits) mode>=1 (segments)
-            template<size_t mode>
+            template<size_t mode=bitset_const::bit_mode>
             bitset_iterator& operator++() noexcept {
-                if constexpr (mode == bit_mode) {
+                if constexpr (mode == bitset_const::bit_mode) {
                     if (++cur_offset_ >= segment_size_in_bits) {
                         ++cur_segment_;
                         cur_offset_ = 0;
@@ -99,7 +101,7 @@ namespace dice::template_library {
                 return *this;
             }
 
-            template<size_t mode>
+            template<size_t mode=bitset_const::bit_mode>
             bitset_iterator& operator+=(size_t const skip) noexcept {
                 auto skip_handler = [this](size_t skip_size) {
                     auto global_ix = calc_global_idx(cur_segment_, cur_offset_) + skip_size;
@@ -117,7 +119,7 @@ namespace dice::template_library {
                     cur_offset_ = offset;
                 };
 
-                if constexpr (mode == bit_mode) {
+                if constexpr (mode == bitset_const::bit_mode) {
                     skip_handler(skip);
                 }
                 else {
@@ -125,6 +127,10 @@ namespace dice::template_library {
                 }
 
                 return *this;
+            }
+
+            T const& get() {
+                return *cur_segment_;
             }
 
             bool consumed() const noexcept {
@@ -471,6 +477,22 @@ namespace dice::template_library {
         constexpr std::default_sentinel_t end() {
             return std::default_sentinel_t{};
         }
+
+        constexpr size_t size() const noexcept {
+            return inner_.size() * 8;
+        }
+
+        constexpr size_t size_in_bits() const noexcept {
+            return size() * 8;
+        }
+
+        constexpr size_t inner_size() const noexcept {
+            return segment_size;
+        }
+
+        constexpr size_t inner_size_in_bits() const noexcept {
+            return segment_size_in_bits;
+        }
     };
 
     static constexpr bitset<size_t, dynamic_extent, dynamic_extent> create_bitset(std::initializer_list<size_t> const list) {
@@ -497,26 +519,73 @@ template<typename T, size_t extent, size_t max_extent>
 struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
     bool hex = false;
     bool debug = false;
+    bool binary = false;
 
     constexpr auto parse(std::format_parse_context& ctx) {
         auto it = ctx.begin();
         while (it != ctx.end()) {
-            if (*it != 'x' && *it != '?') {
+            if (*it != 'x' && *it != '?' && *it != 'b') {
                 throw std::format_error("Invalid format args for dice::template_library::bitset.");
             }
 
             if (*it == '?') {
                 debug = true;
             }
-            else {
+
+            if (*it == 'b') {
                 hex = true;
+            }
+            else {
+                binary = true;
             }
             ++it;
         }
     }
 
     auto format(dice::template_library::bitset<T, extent, max_extent> const& storage, std::format_context& ctx) const {
+        auto it = storage.begin();
+        auto end = storage.end();
+        auto segments = storage.size();
+        auto segment_size = storage.inner_size();
 
+        auto out = ctx.out();
+        *out++ = '[';
+        *out++ = '\n';
+
+        if (debug) {
+            out = std::format_to(out, "Segments : {}\n", segments);
+            out = std::format_to(out, "Segment size : {}\n", segment_size);
+
+            if (hex) {
+                out = std::format_to(out, "Segment Representation -> Hex(0xFF)\n");
+            }
+            else {
+                out = std::format_to(out, "Segment Representation -> Bin(0b00)\n");
+            }
+            *out++ = '\n';
+        }
+
+        while (it != end) {
+            *out++ = '[';
+            auto const& segment = it.get();
+            if (hex) {
+                if constexpr (std::integral<T>) {
+                   out = std::format_to(out, "{:x}", segment);
+                }
+                // proper align
+                ++it.template operator++<dice::template_library::bitset_const::segment_mode>();
+            }
+            else if (binary) {
+                for (auto segment_bit{0uz}; segment_bit < segment_size; ++segment_bit) {
+                    *out++ = *it ? '1' : '0';
+                    ++it;
+                }
+            }
+            *out++ = ']';
+            *out++ = '\n';
+        }
+        *out++ = ']';
+        *out++ = '\n';
     }
 };
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -939,7 +939,7 @@ struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
 
     constexpr auto parse(std::format_parse_context& ctx) {
         auto it = ctx.begin();
-        while (it != ctx.end()) {
+        while (it != ctx.end() && *it != '}') {
             if (*it != 'x' && *it != '?' && *it != 'b') {
                 throw std::format_error("Invalid format args for dice::template_library::bitset.");
             }
@@ -956,6 +956,7 @@ struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
             }
             ++it;
         }
+        return it;
     }
 
     auto format(dice::template_library::bitset<T, extent, max_extent> const& storage, std::format_context& ctx) const {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -919,11 +919,11 @@ namespace dice::template_library {
 
         void set_all() requires(!has_dynamic_extent) {
             if constexpr (std::integral<value_type>) {
-                std::fill(inner_.begin(), inner_.end(), 0x01);
+                std::fill(inner_.begin(), inner_.end(), static_cast<value_type>(~value_type{0}));
             }
             else {
                 for (auto &segment : inner_) {
-                    slot_handler(segment, 0x01);
+                    slot_handler(segment, static_cast<storage_word>(~storage_word{0}));
                 }
             }
         }

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -163,11 +163,7 @@ namespace dice::template_library {
             }
 
             void operator=(bool const b) const noexcept requires(!is_const) {
-                if (b) {
-                    backing_bitset_->set(calc_global_idx(cur_segment_, cur_offset_));
-                    return;
-                }
-                backing_bitset_->reset(calc_global_idx(cur_segment_, cur_offset_));
+                backing_bitset_->set(calc_global_idx(cur_segment_, cur_offset_), b);
             }
 
             reference operator*() const noexcept {
@@ -302,6 +298,50 @@ namespace dice::template_library {
 
             friend bool operator==(bitset_iterator const& it, std::default_sentinel_t) {
                 return it.cur_segment_ >= it.backing_bitset_->size();
+            }
+        };
+
+        template<bool is_const>
+        struct position_iterator {
+        private:
+            using bitset_pointer = std::conditional_t<is_const, bitset const*, bitset*>;
+
+            bitset_iterator<is_const> it_;
+            bitset_pointer const backing_bitset_;
+
+        public:
+            explicit position_iterator(std::conditional_t<is_const,bitset const&, bitset&> bitset) noexcept
+                : it_{&bitset}, backing_bitset_{&bitset} {}
+
+            position_iterator operator++() {
+                auto offset  = (*it_).off;
+                auto segment = it_.get();
+
+                if constexpr (std::integral<typename storage::value_type>) {
+                    if (segment == 0x00) {
+                        it_ += inner_size_in_bits();
+                    }
+                    else {
+                        it_ += offset + std::countl_zero(segment >> (offset + 1));
+                    }
+                }
+                else {
+                    auto [word, _] = backing_bitset_->segment_slots(segment);
+                    for (auto i{0uz}; i < segment_steps; ++i) {
+                        if (word[i] == 0x00) {
+                            continue;
+                        }
+                        it_ += i * (sizeof(storage_word) * 8) + offset + std::countl_zero(segment >> (offset + 1));
+                        break;
+                    }
+                }
+                return *this;
+            }
+
+            position_iterator operator++(int) {
+                auto tmp = *this;
+                operator++();
+                return tmp;
             }
         };
 
@@ -652,6 +692,24 @@ namespace dice::template_library {
 
             for (; word != end && word2 != end2; ++word, ++word2) {
                 *word = merge_func(Ops{}, *word, *word2);
+            }
+        }
+
+        template<typename F>
+        void slot_handler(storage::reference segment, F&& f) {
+            auto [word, end] = segment_slots(segment);
+
+            for (; word != end; ++word) {
+                std::invoke(std::forward<F>(f), *word);
+            }
+        }
+
+        template<typename F>
+        void slot_handler(storage::const_reference segment, F&& f) {
+            auto [word, end] = segment_slots(segment);
+
+            for (; word != end; ++word) {
+                std::invoke(std::forward<F>(f), *word);
             }
         }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -316,21 +316,14 @@ namespace dice::template_library {
             return *(inner_.data() + s) & 1uz << o;
         }
 
-        // need to be fixed
         [[nodiscard]] size_t segment_count(storage::const_reference segment) {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::popcount(segment);
             }
 
-            auto byte = reinterpret_cast<const std::uint8_t*>(&segment);
-            auto const end = byte + segment_size;
-
-            auto accumulated{0uz};
-            for (; byte != end; ++byte) {
-                accumulated += std::popcount(*byte);
-            }
-
-            return accumulated;
+            return slot_handler(segment, [](storage_word word) -> size_t {
+                return std::popcount(word);
+            }, merge_functor<storage_word>{}, 0uz);
         }
 
 #ifdef __SIZEOF_INT128__
@@ -342,7 +335,7 @@ namespace dice::template_library {
         }
 #endif
 
-        template<typename F, typename M, typename Tp, typename Ops>
+        template<typename F, typename M, typename Tp, typename Ops=add_op>
         requires std::is_same_v<std::invoke_result_t<F, typename storage::const_reference>, Tp> &&
             std::invocable<M, Tp, Tp>
         Tp segment_handler(F &&handler, M &&merge, Tp initial) {
@@ -376,7 +369,7 @@ namespace dice::template_library {
             return true;
         }
 
-        template<typename F, typename M, typename Tp, typename Ops>
+        template<typename F, typename M, typename Tp, typename Ops=add_op>
         [[nodiscard]] Tp slot_handler(storage::const_reference segment, F &&f, M&& m, Tp initial) {
             Tp merge_val{initial};
             auto [word, end] = segment_slots(segment);
@@ -388,7 +381,7 @@ namespace dice::template_library {
             return merge_val;
         }
 
-        template<typename Ops>
+        template<typename Ops=add_op>
         void slot_handler(storage::const_reference segment, storage::const_reference other) {
             auto merge_func = dice::template_library::merge_functor<storage_word>{};
             auto [word, end] = segment_slots(segment);
@@ -433,8 +426,8 @@ namespace dice::template_library {
                 return std::countl_zero(segment);
             }
 
-            return slot_handler(segment, [](storage_word_const_pointer word) -> size_t {
-                return std::countl_zero(*word);
+            return slot_handler(segment, [](storage_word word) -> size_t {
+                return std::countl_zero(word);
             }, merge_functor<size_t>{}, 0uz);
         }
 
@@ -443,8 +436,8 @@ namespace dice::template_library {
                 return std::countr_zero(segment);
             }
 
-            return slot_handler(segment, [](storage_word_const_pointer word) -> size_t {
-                return std::countr_zero(*word);
+            return slot_handler(segment, [](storage_word word) -> size_t {
+                return std::countr_zero(word);
             }, merge_functor<size_t>{}, 0uz);
         }
 
@@ -453,8 +446,8 @@ namespace dice::template_library {
                 return std::countl_one(segment);
             }
 
-            return slot_handler(segment, [](storage_word_const_pointer word) -> size_t {
-                return std::countl_one(*word);
+            return slot_handler(segment, [](storage_word word) -> size_t {
+                return std::countl_one(word);
             }, merge_functor<size_t>{}, 0uz);
         }
 
@@ -463,8 +456,8 @@ namespace dice::template_library {
                 return std::countr_one(segment);
             }
 
-            return slot_handler(segment, [](storage_word_const_pointer word) -> size_t {
-                return std::countr_one(*word);
+            return slot_handler(segment, [](storage_word word) -> size_t {
+                return std::countr_one(word);
             }, merge_functor<size_t>{}, 0uz);
         }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -195,10 +195,10 @@ namespace dice::template_library {
 
             return [bit_off] {
                 if constexpr (std::has_single_bit(segment_size_in_bits)) {
-                    return bit_off >> std::countr_zero(segment_size_in_bits);
+                    return (bit_off + segment_size_in_bits - 1) >> std::countr_zero(segment_size_in_bits);
                 }
                 else {
-                    return bit_off / segment_size_in_bits;
+                    return (bit_off + segment_size_in_bits - 1) / segment_size_in_bits;
                 }
             }();
         }
@@ -316,7 +316,7 @@ namespace dice::template_library {
             return *(inner_.data() + s) & 1uz << o;
         }
 
-        [[nodiscard]] size_t segment_count(storage::const_reference segment) {
+        [[nodiscard]] size_t segment_count(storage::const_reference segment) const noexcept {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::popcount(segment);
             }
@@ -327,7 +327,7 @@ namespace dice::template_library {
         }
 
 #ifdef __SIZEOF_INT128__
-        size_t segment_count(__uint128_t const& segment) {
+        [[nodiscard]] size_t segment_count(__uint128_t const& segment) const noexcept {
             uint64_t const lo = static_cast<uint64_t>(segment);
             uint64_t const hi = static_cast<uint64_t>(segment >> 64);
 
@@ -338,7 +338,7 @@ namespace dice::template_library {
         template<typename F, typename M, typename Tp, typename Ops=add_op>
         requires std::is_same_v<std::invoke_result_t<F, typename storage::const_reference>, Tp> &&
             std::invocable<M, Tp, Tp>
-        Tp segment_handler(F &&handler, M &&merge, Tp initial) const {
+        [[nodiscard]] Tp segment_handler(F &&handler, M &&merge, Tp initial) const {
             Tp merge_val{initial};
             for (auto const &segment : inner_) {
                 merge_val = std::invoke(std::forward<M>(merge), Ops{}, merge_val,
@@ -367,6 +367,38 @@ namespace dice::template_library {
                 ++outer_it;
             }
             return true;
+        }
+
+        template<typename F, typename Pr>
+        bool segment_handler(F &&handler, Pr &&pred) const {
+            auto self_it = begin();
+            auto end_sentinel = end();
+
+            while (self_it != end_sentinel) {
+                if (auto const val = std::invoke(std::forward<F>(handler), self_it.get()); !std::invoke(std::forward<Pr>(pred), val)) {
+                    return false;
+                }
+                ++self_it;
+            }
+            return true;
+        }
+
+        template<typename F, typename Pr, typename M, typename Tp>
+        Tp segment_handler(F &&handler, Pr &&pred, M &&merge, Tp initial) const {
+            auto self_it = begin();
+            auto end_sentinel = end();
+
+            Tp merge_val{initial};
+
+            while (self_it != end_sentinel) {
+                Tp const val = std::invoke(std::forward<F>(handler), self_it.get());
+                merge_val = std::invoke(std::forward<M>(merge), merge_val, val);
+                if (!std::invoke(std::forward<Pr>(pred), val)) {
+                    return merge_val;
+                }
+                ++self_it;
+            }
+            return merge_val;
         }
 
         template<typename F, typename M, typename Tp, typename Ops=add_op>
@@ -546,7 +578,6 @@ namespace dice::template_library {
                 }
             }
 
-            // if dynamic extent we should dynamically check if we can add a further segment
             if constexpr (storage::has_dynamic_extent) {
                 if constexpr (!has_storage_limit) {
                     inner_.resize(inner_.size() + 1);
@@ -558,8 +589,8 @@ namespace dice::template_library {
                     if (inner_.size() == inner_.max_size()) {
                         return storage_size_in_bits;
                     }
-                    *reinterpret_cast<storage_word_pointer>(inner_.end()) = 0x01;
                     inner_.resize(inner_.size() + 1);
+                    *reinterpret_cast<storage_word_pointer>(inner_.end() - 1) = 0x01;
 
                     return calc_global_idx(std::distance(inner_.data(), inner_.end()), 0);
                 }

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -186,7 +186,7 @@ namespace dice::template_library {
 
         [[nodiscard]] constexpr size_t require_segments(global_ix const ix) const requires (!has_storage_limit) {
             auto const bit_pos = bits_consumed();
-            if (bit_pos >= ix) {
+            if (bit_pos > ix) {
                 return 0;
             }
 
@@ -194,10 +194,10 @@ namespace dice::template_library {
 
             return [bit_off] {
                 if constexpr (std::has_single_bit(segment_size_in_bits)) {
-                    return (bit_off + segment_size_in_bits - 1) >> std::countr_zero(segment_size_in_bits);
+                    return (bit_off >> std::countr_zero(segment_size_in_bits)) + 1;
                 }
                 else {
-                    return (bit_off + segment_size_in_bits - 1) / segment_size_in_bits;
+                    return bit_off / segment_size_in_bits + 1;
                 }
             }();
         }
@@ -300,11 +300,11 @@ namespace dice::template_library {
         }
 
         [[nodiscard]] static size_t offset_in_chunk(offset const o) noexcept {
-            return o % segment_align * 8;
+            return o % (segment_align * 8);
         }
 
         [[nodiscard]] static size_t which_chunk(offset const o) noexcept {
-            return o / segment_align * 8;
+            return o / (segment_align * 8);
         }
 
         storage_word_pointer get_chunk_raw(segment const s, offset const o) const noexcept {
@@ -398,8 +398,8 @@ namespace dice::template_library {
                 if (!std::invoke(std::forward<F>(handler), self_it.get(), outer_it.get())) {
                     return false;
                 }
-                ++self_it;
-                ++outer_it;
+                self_it.template operator++<bitset_const::segment_mode>();
+                outer_it.template operator++<bitset_const::segment_mode>();
             }
             return true;
         }
@@ -413,7 +413,7 @@ namespace dice::template_library {
                 if (auto const val = std::invoke(std::forward<F>(handler), self_it.get()); !std::invoke(std::forward<Pr>(pred), val)) {
                     return false;
                 }
-                ++self_it;
+                self_it.template operator++<bitset_const::segment_mode>();
             }
             return true;
         }
@@ -431,7 +431,7 @@ namespace dice::template_library {
                 if (!std::invoke(std::forward<Pr>(pred), val)) {
                     return merge_val;
                 }
-                ++self_it;
+                self_it.template operator++<bitset_const::segment_mode>();
             }
             return merge_val;
         }
@@ -637,7 +637,7 @@ namespace dice::template_library {
                     inner_.resize(inner_.size() + 1);
                     *reinterpret_cast<storage_word_pointer>(inner_.end() - 1) = 0x01;
 
-                    return calc_global_idx(std::distance(inner_.data(), inner_.data() + size()), 0);
+                    return calc_global_idx(size() - 1, 0);
                 }
                 else {
                     if (inner_.size() == inner_.max_size()) {
@@ -646,7 +646,7 @@ namespace dice::template_library {
                     inner_.resize(inner_.size() + 1);
                     *reinterpret_cast<storage_word_pointer>(inner_.end() - 1) = 0x01;
 
-                    return calc_global_idx(std::distance(inner_.data(), inner_.data() + size()), 0);
+                    return calc_global_idx(size() - 1, 0);
                 }
             }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -317,22 +317,12 @@ namespace dice::template_library {
             bitset_iterator<is_const> it_;
             bitset_pointer backing_bitset_ = nullptr;
 
-        public:
-            using iterator_category = std::input_iterator_tag;
-            using iterator_concept  = std::input_iterator_tag;
-            using value_type        = bool;
-            using pointer           = void;
-            using difference_type   = ptrdiff_t;
-
-            explicit position_iterator(std::conditional_t<is_const, bitset const&, bitset&> bitset) noexcept
-                : it_{bitset}, backing_bitset_{&bitset} {}
-
-            position_iterator& operator++() noexcept {
+            void seek(bool include_current) noexcept {
                 auto offset  = (*it_).off;
                 auto segment = it_.get();
 
                 if constexpr (std::integral<T>) {
-                    auto skip = offset + 1;
+                    auto skip = include_current ? offset : offset + 1;
 
                     while (true) {
                         T const shifted = (skip >= inner_size_in_bits())
@@ -357,7 +347,7 @@ namespace dice::template_library {
                 else {
                     constexpr size_t word_bits = sizeof(storage_word) * 8;
                     auto word_ix   = offset / word_bits;
-                    auto word_skip = (offset % word_bits) + 1;
+                    auto word_skip = include_current ? (offset % word_bits) : (offset % word_bits) + 1;
 
                     while (true) {
                         auto [word, _] = backing_bitset_->segment_slots(segment);
@@ -393,6 +383,24 @@ namespace dice::template_library {
                         segment = it_.get();
                     }
                 }
+            }
+
+        public:
+            using iterator_category = std::input_iterator_tag;
+            using iterator_concept  = std::input_iterator_tag;
+            using value_type        = bool;
+            using pointer           = void;
+            using difference_type   = ptrdiff_t;
+
+            explicit position_iterator(std::conditional_t<is_const, bitset const&, bitset&> bitset) noexcept
+                : it_{bitset}, backing_bitset_{&bitset} {
+                if (it_ != std::default_sentinel) {
+                    seek(true);
+                }
+            }
+
+            position_iterator& operator++() noexcept {
+                seek(false);
                 return *this;
             }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -1132,11 +1132,7 @@ namespace dice::template_library {
         }
 
         auto positions() const -> std::ranges::input_range auto {
-            return *this | std::views::filter([] (auto bitref) {
-                return static_cast<bool>(bitref);
-            }) | std::views::transform([] (auto bitref) {
-                return calc_global_idx(bitref.seg, bitref.off);
-            });
+            return std::ranges::subrange(pbegin(), pend());
         }
 
         template<typename F>

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -36,6 +36,9 @@ namespace dice::template_library {
         using segment   = size_t;
         using offset    = size_t;
 
+        static constexpr size_t bit_mode = 0x00;
+        static constexpr size_t segment_mode = 0x01;
+
     private:
         struct bitset_iterator {
         private:
@@ -81,12 +84,46 @@ namespace dice::template_library {
                 return backing_bitset_->test(std::distance(cur_segment_, backing_bitset_->inner_.data()), cur_offset_);
             }
 
-            bitset_iterator& operator++(int) noexcept {
-                if (++cur_offset_ >= segment_size_in_bits) {
-                    ++cur_segment_;
-                    cur_offset_ = 0;
+            // shared iterator for mode=0 (bits) mode>=1 (segments)
+            template<size_t mode>
+            bitset_iterator& operator++() noexcept {
+                if constexpr (mode == bit_mode) {
+                    if (++cur_offset_ >= segment_size_in_bits) {
+                        ++cur_segment_;
+                        cur_offset_ = 0;
+                        return *this;
+                    }
                     return *this;
                 }
+                ++cur_segment_;
+                return *this;
+            }
+
+            template<size_t mode>
+            bitset_iterator& operator+=(size_t const skip) noexcept {
+                auto skip_handler = [this](size_t skip_size) {
+                    auto global_ix = calc_global_idx(cur_segment_, cur_offset_) + skip_size;
+
+                    if (global_ix >= storage_size_in_bits) {
+                        cur_segment_ = segments;
+                        cur_offset_ = 0;
+                        return;
+                    }
+
+                    auto offset = calc_which_offset(global_ix);
+                    auto seg = calc_which_segment(global_ix);
+
+                    cur_segment_ = seg;
+                    cur_offset_ = offset;
+                };
+
+                if constexpr (mode == bit_mode) {
+                    skip_handler(skip);
+                }
+                else {
+                    skip_handler(skip * segment_size_in_bits);
+                }
+
                 return *this;
             }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -9,10 +9,22 @@
 
 namespace dice::template_library {
 
+    struct bit_and_op{};
+    struct add_op{};
+    struct bit_or_op{};
+
     template<typename Tp>
-        struct merge_functor {
-        Tp operator()(Tp const v1, Tp const v2) const noexcept {
+    struct merge_functor {
+        Tp operator()(add_op, Tp const v1, Tp const v2) const noexcept {
             return v1 + v2;
+        };
+
+        Tp operator()(bit_and_op, Tp const v1, Tp const v2) const noexcept {
+            return v1 & v2;
+        };
+
+        Tp operator()(bit_or_op, Tp const v1, Tp const v2) const noexcept {
+            return v1 | v2;
         };
     };
 
@@ -304,6 +316,7 @@ namespace dice::template_library {
             return *(inner_.data() + s) & 1uz << o;
         }
 
+        // need to be fixed
         [[nodiscard]] size_t segment_count(storage::const_reference segment) {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::popcount(segment);
@@ -329,29 +342,74 @@ namespace dice::template_library {
         }
 #endif
 
-        template<typename F, typename M, typename Tp>
+        template<typename F, typename M, typename Tp, typename Ops>
         requires std::is_same_v<std::invoke_result_t<F, typename storage::const_reference>, Tp> &&
             std::invocable<M, Tp, Tp>
         Tp segment_handler(F &&handler, M &&merge, Tp initial) {
             Tp merge_val{initial};
             for (auto const &segment : inner_) {
-                merge_val = std::invoke(std::forward<M>(merge), merge_val,
+                merge_val = std::invoke(std::forward<M>(merge), Ops{}, merge_val,
                     std::invoke(std::forward<F>(handler), segment));
             }
 
             return merge_val;
         }
 
-        template<typename F, typename M, typename Tp>
+        template<typename F>
+        bool segment_handler(F &&handler, bitset const& other) {
+            auto self_it = begin();
+            auto outer_it = other.begin();
+
+            if (size() != other.size()) {
+                return false;
+            }
+
+            auto end_sentinel = end();
+
+            while (self_it != end_sentinel) {
+                if (std::invoke(std::forward<F>(handler), self_it.get(), outer_it.get())) {
+                    return false;
+                }
+                ++self_it;
+                ++outer_it;
+            }
+            return true;
+        }
+
+        template<typename F, typename M, typename Tp, typename Ops>
         [[nodiscard]] Tp slot_handler(storage::const_reference segment, F &&f, M&& m, Tp initial) {
             Tp merge_val{initial};
             auto [word, end] = segment_slots(segment);
 
             for (; word != end; ++word) {
-                merge_val = std::invoke(std::forward<M>(m),merge_val, std::invoke(std::forward<F>(f), *word));
+                merge_val = std::invoke(std::forward<M>(m), Ops{}, merge_val, std::invoke(std::forward<F>(f), *word));
             }
 
             return merge_val;
+        }
+
+        template<typename Ops>
+        void slot_handler(storage::const_reference segment, storage::const_reference other) {
+            auto merge_func = dice::template_library::merge_functor<storage_word>{};
+            auto [word, end] = segment_slots(segment);
+            auto [word2, end2] = segment_slots(other);
+
+            for (; word != end && word2 != end2; ++word, ++word2) {
+                *word = merge_func(Ops{}, *word, *word2);
+            }
+        }
+
+        bool slot_handler(storage::const_reference segment, storage::const_reference other) {
+            auto [word, end] = segment_slots(segment);
+            auto [word2, end2] = segment_slots(other);
+
+            for (; word != end && word2 != end2; ++word, ++word2) {
+                if (*word != *word2) {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         [[nodiscard]] size_t segment_free(storage::const_reference segment) {
@@ -518,43 +576,43 @@ namespace dice::template_library {
 
         [[nodiscard]] size_t countr_zero() const {
             return segment_handler([this](typename storage::const_reference segment) {
-                return bitset_op_cntl(&bitset::countr_zero, segment);
+                return bitset_op_cntl(&bitset::segment_countr_zero, segment);
             }, merge_functor<size_t>{}, 0);
         }
 
         [[nodiscard]] size_t countl_zero() const {
             return segment_handler([this](typename storage::const_reference segment) {
-                return bitset_op_cntl(&bitset::countl_zero, segment);
+                return bitset_op_cntl(&bitset::segment_countl_zero, segment);
             }, merge_functor<size_t>{}, 0);
         }
 
         [[nodiscard]] size_t countr_one() const {
             return segment_handler([this](typename storage::const_reference segment) {
-                return bitset_op_cntl(&bitset::countr_one, segment);
+                return bitset_op_cntl(&bitset::segment_countr_one, segment);
             }, merge_functor<size_t>{}, 0);
         }
 
         [[nodiscard]] size_t countl_one() const {
             return segment_handler([this](typename storage::const_reference segment) {
-                return bitset_op_cntl(&bitset::countl_one, segment);
+                return bitset_op_cntl(&bitset::segment_countl_one, segment);
             }, merge_functor<size_t>{}, 0);
         }
 
         [[nodiscard]] bool all_set() const {
             return segment_handler([this](typename storage::const_reference segment) {
-                return bitset_op_cntl(&bitset::all_set, segment);
+                return bitset_op_cntl(&bitset::segment_all_set, segment);
             }, merge_functor<bool>{}, true);
         }
 
         [[nodiscard]] bool any_set() const {
             return segment_handler([this](typename storage::const_reference segment) {
-                return bitset_op_cntl(&bitset::any_set, segment);
+                return bitset_op_cntl(&bitset::segment_any_set, segment);
             }, merge_functor<bool>{}, true);
         }
 
         [[nodiscard]] bool none_set() const {
             return segment_handler([this](typename storage::const_reference segment) {
-                return bitset_op_cntl(&bitset::none_set, segment);
+                return bitset_op_cntl(&bitset::segment_none_set, segment);
             }, merge_functor<bool>{}, true);
         }
 
@@ -580,6 +638,60 @@ namespace dice::template_library {
 
         constexpr size_t inner_size_in_bits() const noexcept {
             return segment_size_in_bits;
+        }
+
+        bool operator ==(bitset const& alt_storage) const noexcept {
+            return segment_handler([this](typename storage::const_reference segment_first, typename storage::const_reference segment_second) {
+                return slot_handler(segment_first, segment_second);
+            }, alt_storage);
+        }
+
+        bitset& operator<<=(size_t shift) {
+            std::move(begin() + shift, begin() + size_in_bits(), begin());
+            return *this;
+        }
+
+        bitset& operator>>=(size_t shift) {
+            std::move_backward(begin(), begin() + size_in_bits() - shift, begin() + size_in_bits());
+            return *this;
+        }
+
+        bitset& operator &=(bitset const& alt_storage) noexcept {
+            segment_handler([this](typename storage::const_reference segment_first, typename storage::const_reference segment_second) {
+                slot_handler<bit_and_op>(segment_first, segment_second);
+            }, alt_storage);
+            return *this;
+        }
+
+        bitset& operator |=(bitset const& alt_storage) noexcept {
+            segment_handler([this](typename storage::const_reference segment_first, typename storage::const_reference segment_second) {
+                slot_handler<bit_or_op>(segment_first, segment_second);
+            }, alt_storage);
+            return *this;
+        }
+
+        bitset operator<<(size_t shift) const noexcept {
+            bitset tmp = *this;
+            tmp <<= shift;
+            return tmp;
+        }
+
+        bitset operator>>(size_t shift) const noexcept {
+            bitset tmp = *this;
+            tmp >>= shift;
+            return tmp;
+        }
+
+        bitset operator& (bitset const& bitset_v_second) const noexcept {
+            bitset tmp = *this;
+            tmp &= bitset_v_second;
+            return tmp;
+        }
+
+        bitset operator| (bitset const& bitset_v_second) const noexcept {
+            bitset tmp = *this;
+            tmp |= bitset_v_second;
+            return tmp;
         }
     };
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -109,7 +109,7 @@ namespace dice::template_library {
 
             segment       cur_segment_{};
             offset        cur_offset_{};
-            bitset_pointer const backing_bitset_;
+            bitset_pointer backing_bitset_;
 
         public:
             ///> proxy for the current bit position
@@ -1235,6 +1235,10 @@ namespace dice::template_library {
             return it.template operator++<bitset_mode::SegmentMode>();
         }
 
+        static const_iterator advance_segment(const_iterator it) {
+            return it.template operator++<bitset_mode::SegmentMode>();
+        }
+
         /**
          * Returns updated iterator advanced by skip segments
          *
@@ -1243,6 +1247,10 @@ namespace dice::template_library {
          * @return iterator advanced by skip segments
          */
         static iterator advance_segment(iterator it, size_t const skip) {
+            return it.template operator+=<bitset_mode::SegmentMode>(skip);
+        }
+
+        static const_iterator advance_segment(const_iterator it, size_t const skip) {
             return it.template operator+=<bitset_mode::SegmentMode>(skip);
         }
 
@@ -1256,6 +1264,10 @@ namespace dice::template_library {
             return it.template operator--<bitset_mode::SegmentMode>();
         }
 
+        static const_iterator advance_segment_backwards(const_iterator it) {
+            return it.template operator--<bitset_mode::SegmentMode>();
+        }
+
         /**
          * Returns updated iterator advanced backward by skip segment
          *
@@ -1264,6 +1276,10 @@ namespace dice::template_library {
          * @return iterator advanced backwards by skip segments
          */
         static iterator advance_segment_backwards(iterator it, size_t const skip) {
+            return it.template operator-=<bitset_mode::SegmentMode>(skip);
+        }
+
+        static const_iterator advance_segment_backwards(const_iterator it, size_t const skip) {
             return it.template operator-=<bitset_mode::SegmentMode>(skip);
         }
 
@@ -1376,8 +1392,8 @@ namespace dice::template_library {
     };
 }
 
-template<typename T, size_t extent, size_t max_extent>
-struct std::formatter<dice::template_library::bitset<extent, max_extent, T>> {
+template<typename T, size_t extent_, size_t max_extent_>
+struct std::formatter<dice::template_library::bitset<extent_, max_extent_, T>> {
     bool hex = false;
     bool debug = false;
     bool binary = false;
@@ -1405,7 +1421,7 @@ struct std::formatter<dice::template_library::bitset<extent, max_extent, T>> {
         return it;
     }
 
-    auto format(dice::template_library::bitset<extent, max_extent, T> const& storage, std::format_context& ctx) const {
+    auto format(dice::template_library::bitset<extent_, max_extent_, T> const& storage, std::format_context& ctx) const {
         auto it = storage.begin();
         auto end = storage.end();
         auto segments = storage.size();

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -861,12 +861,14 @@ namespace dice::template_library {
         }
 
         bitset& operator<<=(size_t shift) {
-            std::move(begin() + shift, begin() + size_in_bits(), begin());
+            auto dest_it = std::move(begin() + shift, begin() + size_in_bits(), begin());
+            std::fill(dest_it, begin() + size_in_bits(), false);
             return *this;
         }
 
         bitset& operator>>=(size_t shift) {
-            std::move_backward(begin(), begin() + size_in_bits() - shift, begin() + size_in_bits());
+            auto dest_it = std::move_backward(begin(), begin() + size_in_bits() - shift, begin() + size_in_bits());
+            std::fill(begin(), dest_it, false);
             return *this;
         }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -284,16 +284,12 @@ namespace dice::template_library {
                 return tmp;
             }
 
-            T const& get() const {
+            T const& get() const noexcept {
                 return *(backing_bitset_->inner_.data() + cur_segment_);
             }
 
-            T& get() requires(!is_const) {
+            [[nodiscard]] T& get() noexcept requires(!is_const){
                 return *(backing_bitset_->inner_.data() + cur_segment_);
-            }
-
-            bool consumed() const noexcept {
-                return cur_segment_ >= backing_bitset_->size();
             }
 
             friend bool operator==(bitset_iterator const& lhs, bitset_iterator const& rhs){
@@ -307,7 +303,7 @@ namespace dice::template_library {
             }
 
             friend bool operator==(bitset_iterator const& it, std::default_sentinel_t) {
-                return it.consumed();
+                return it.cur_segment_ >= it.backing_bitset_->size();
             }
         };
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -7,6 +7,7 @@
 #include <numeric>
 #include <format>
 #include <iterator>
+#include <ranges>
 
 namespace dice::template_library {
 
@@ -105,9 +106,11 @@ namespace dice::template_library {
         public:
             ///> proxy for the current bit position
             struct bit_ref {
+            private:
                 bitset_pointer backing_bitset_;
-                segment seg_;
-                offset  off_;
+            public:
+                segment seg;
+                offset  off;
 
                 bit_ref(bit_ref const&) = default;
                 bit_ref const& operator=(bit_ref const& other) const noexcept {
@@ -115,18 +118,18 @@ namespace dice::template_library {
                 }
 
                 bit_ref(bitset_pointer backing_bitset, segment const seg, offset const off) noexcept
-                    : backing_bitset_{backing_bitset}, seg_{seg}, off_{off} {}
+                    : backing_bitset_{backing_bitset}, seg{seg}, off{off} {}
 
                 explicit operator bool() const noexcept {
-                    return backing_bitset_->test(calc_global_idx(seg_, off_));
+                    return backing_bitset_->test(calc_global_idx(seg, off));
                 }
 
                 bit_ref const& operator=(bool const b) const noexcept {
                     if (b) {
-                        backing_bitset_->set(calc_global_idx(seg_, off_));
+                        backing_bitset_->set(calc_global_idx(seg, off));
                     }
                     else {
-                        backing_bitset_->unset(calc_global_idx(seg_, off_));
+                        backing_bitset_->unset(calc_global_idx(seg, off));
                     }
                     return *this;
                 }
@@ -955,6 +958,45 @@ namespace dice::template_library {
             }, [](bool const val) {
                 return val;
             }, merge_functor<bool>{}, true, bit_and_op{});
+        }
+
+        auto positions() const -> std::ranges::input_range auto {
+            return *this | std::views::filter([] (auto bitref) {
+                return static_cast<bool>(bitref);
+            }) | std::views::transform([] (auto bitref) {
+                return calc_global_idx(bitref.seg, bitref.off);
+            });
+        }
+
+
+        template<typename F>
+        void positions_cntl(std::ranges::input_range auto&& positions, F&& pos_f) {
+            if constexpr (std::ranges::sized_range<decltype(positions)>) {
+                auto position_elements = std::ranges::size(positions);
+                if (position_elements >= storage_size_in_bits) {
+                    throw std::range_error{"bitset::set_positions range out of bounds"};
+                }
+            }
+            else {
+                auto position_elements = std::ranges::distance(positions);
+                if (position_elements >= storage_size_in_bits) {
+                    throw std::range_error{"bitset::set_positions range out of bounds"};
+                }
+            }
+
+            std::ranges::for_each(positions, std::forward<F>(pos_f));
+        }
+
+        void set_positions(std::ranges::input_range auto&& positions) {
+            positions_cntl(std::forward<decltype(positions)>(positions), [this](auto pos) {
+                set(pos);
+            });
+        }
+
+        void reset_positions(std::ranges::input_range auto&& positions) {
+            positions_cntl(std::forward<decltype(positions)>(positions), [this](auto pos) {
+                unset(pos);
+            });
         }
 
         constexpr iterator begin() noexcept {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -32,6 +32,8 @@ namespace dice::template_library {
     struct bitset {
         static constexpr bool   has_storage_limit = segments != dynamic_extent;
         static constexpr size_t segment_size = sizeof(T);
+        static constexpr size_t segment_align = alignof(T);
+        static constexpr size_t segment_steps = segment_size / segment_align;
         static constexpr size_t segment_size_in_bits = segment_size * 8;
         static constexpr size_t storage_size = !has_storage_limit ? dynamic_extent : segment_size * segments;
         static constexpr size_t storage_size_in_bits = !has_storage_limit ? dynamic_extent : storage_size * 8;
@@ -40,6 +42,9 @@ namespace dice::template_library {
         using global_ix = size_t;
         using segment   = size_t;
         using offset    = size_t;
+
+        using storage_word = std::conditional_t<segment_align >= alignof(std::uint64_t), std::uint64_t,
+            std::conditional_t<segment_align >= alignof(std::uint32_t), std::uint32_t, std::uint8_t>>;
 
     private:
         struct bitset_iterator {
@@ -311,16 +316,34 @@ namespace dice::template_library {
         }
 #endif
 
+        [[nodiscard]] std::pair<storage_word*, storage_word*> segment_slots(storage::const_reference segment) {
+            auto word = reinterpret_cast<const storage_word*>(&segment);
+            auto const end = word + segment_steps;
+
+            return std::pair{word, end};
+        }
+
+        template<typename F, typename M, typename Tp>
+        [[nodiscard]] Tp slot_handler(storage::const_reference segment, F &&f, M&& m, Tp initial) {
+            Tp merge_val{initial};
+            auto [word, end] = segment_slots(segment);
+
+            for (; word != end; ++word) {
+                std::invoke(std::forward<M>(m),merge_val, std::invoke<F>(std::forward<F>(f), *word));
+            }
+
+            return merge_val;
+        }
+
         [[nodiscard]] size_t segment_free(storage::const_reference segment) {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::countr_zero(~segment);
             }
 
-            auto byte = reinterpret_cast<const std::uint8_t*>(&segment);
-            auto const end = byte + segment_size;
+            auto [word, end] = segment_slots(segment);
 
-            for (; byte != end; ++byte) {
-                if (auto const segment_free = static_cast<uint8_t>(~(*byte)); segment_free != 0) {
+            for (; word != end; ++word) {
+                if (auto const segment_free = static_cast<const storage_word>(~(*word)); segment_free != 0) {
                     return std::countr_zero(segment_free);
                 }
             }
@@ -328,13 +351,27 @@ namespace dice::template_library {
             return segment_size_in_bits;
         }
 
-        [[nodiscard]] size_t segment_countl_zero(storage::const_reference segment) const noexcept {
+        [[nodiscard]] size_t countl_zero(storage::const_reference segment) const noexcept {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::countl_zero(segment);
             }
+
+
         }
 
-        [[nodiscard]] size_t segment_countr_zero(storage::const_reference segment) const noexcept {
+        [[nodiscard]] size_t countr_zero(storage::const_reference segment) const noexcept {
+            if constexpr (std::integral<typename storage::value_type>) {
+                return std::countr_zero(segment);
+            }
+        }
+
+        [[nodiscard]] size_t countl_one(storage::const_reference segment) const noexcept {
+            if constexpr (std::integral<typename storage::value_type>) {
+                return std::countr_zero(segment);
+            }
+        }
+
+        [[nodiscard]] size_t countr_one(storage::const_reference segment) const noexcept {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::countr_zero(segment);
             }
@@ -420,7 +457,7 @@ namespace dice::template_library {
         Tp segment_handler(F &&handler, M &&merge, Tp initial) {
             Tp merge_val{initial};
             for (auto const &segment : inner_) {
-                std::invoke(std::forward<M>(merge)(
+                merge_val = std::invoke(std::forward<M>(merge)(
                     merge_val,
                     std::invoke(std::forward<F>(handler), segment)));
             }

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -326,21 +326,65 @@ namespace dice::template_library {
                 auto segment = it_.get();
 
                 if constexpr (std::integral<value_type>) {
-                    if (segment == 0x00) {
-                        it_ += inner_size_in_bits();
-                    }
-                    else {
-                        it_ += offset + std::countl_zero(segment >> (offset + 1));
+                    auto skip = offset + 1;
+
+                    while (true) {
+                        value_type const shifted = (skip >= inner_size_in_bits())
+                            ? value_type{0}
+                            : static_cast<value_type>(segment >> skip);
+
+                        if (shifted != 0x00) {
+                            it_ += (skip + std::countr_zero(shifted)) - offset;
+                            break;
+                        }
+
+                        it_ += inner_size_in_bits() - offset;
+                        if (it_ == std::default_sentinel) {
+                            break;
+                        }
+
+                        offset = 0;
+                        skip = 0;
+                        segment = it_.get();
                     }
                 }
                 else {
-                    auto [word, _] = backing_bitset_->segment_slots(segment);
-                    for (auto i{0uz}; i < segment_steps; ++i) {
-                        if (word[i] == 0x00) {
-                            continue;
+                    constexpr size_t word_bits = sizeof(storage_word) * 8;
+                    auto word_ix   = offset / word_bits;
+                    auto word_skip = (offset % word_bits) + 1;
+
+                    while (true) {
+                        auto [word, _] = backing_bitset_->segment_slots(segment);
+                        bool found = false;
+
+                        for (auto i{word_ix}; i < segment_steps; ++i) {
+                            auto const skip = (i == word_ix) ? word_skip : 0uz;
+                            storage_word const shifted = (skip >= word_bits)
+                                ? storage_word{0}
+                                : static_cast<storage_word>(word[i] >> skip);
+
+                            if (shifted == 0x00) {
+                                continue;
+                            }
+
+                            it_ += (i * word_bits + skip + std::countr_zero(shifted)) - offset;
+                            found = true;
+                            break;
                         }
-                        it_ += i * (sizeof(storage_word) * 8) + offset + std::countl_zero(segment >> (offset + 1));
-                        break;
+
+                        if (found) {
+                            break;
+                        }
+
+                        it_ += inner_size_in_bits() - offset;
+                        if (it_ == std::default_sentinel) {
+                            break;
+                        }
+
+                        offset = 0;
+                        word_ix = 0;
+                        word_skip = 0;
+                        segment = it_.get();
                     }
                 }
                 return *this;
@@ -1255,8 +1299,8 @@ namespace dice::template_library {
             return positional_iterator{*this};
         }
 
-        constexpr positional_iterator pbegin() const noexcept {
-            return positional_iterator{*this};
+        constexpr const_positional_iterator pbegin() const noexcept {
+            return const_positional_iterator{*this};
         }
 
         constexpr std::default_sentinel_t pend() const noexcept {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -70,6 +70,8 @@ namespace dice::template_library {
                 segment seg_;
                 offset  off_;
 
+                bit_ref& operator=(bit_ref&) = delete;
+
                 operator bool() const noexcept {
                     return backing_bitset_->test(calc_global_idx(seg_, off_));
                 }

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -22,6 +22,72 @@ namespace dice::template_library {
         using offset    = size_t;
 
     private:
+        struct bitset_iterator {
+        private:
+            storage::pointer cur_segment_;
+            offset          cur_offset_{};
+            bitset *const backing_bitset_;
+
+        public:
+            explicit bitset_iterator(storage &bitset) noexcept :
+                cur_segment_{bitset.data()}, backing_bitset_{&bitset} {}
+
+            explicit bitset_iterator(storage &bitset, offset const& o) :
+                cur_segment_{bitset.data()}, backing_bitset_{&bitset}{
+                if constexpr (o >= segment_size) {
+                    throw std::out_of_range{"bitset_iterator: o >= segment_size"};
+                }
+                cur_offset_ = o;
+            }
+
+            explicit bitset_iterator(storage &bitset, offset const& o, segment const& s) :
+                backing_bitset_{&bitset}{
+                if constexpr (o >= segment_size) {
+                    throw std::out_of_range{"bitset_iterator: o >= segment_size"};
+                }
+
+                if constexpr (cur_segment_ + s >= bitset.size()) {
+                    throw std::out_of_range{"bitset_iterator: segment out of bounds"};
+                }
+
+                cur_offset_ = o;
+                cur_segment_ = bitset.data() + s;
+            }
+
+            void operator=(bool const b) const noexcept {
+                if (b) {
+                    backing_bitset_->set(std::distance(cur_segment_, backing_bitset_->inner_.data()), cur_offset_);
+                    return;
+                }
+                backing_bitset_->unset(std::distance(cur_segment_, backing_bitset_->inner_.data()), cur_offset_);
+            }
+
+            bool operator*() const noexcept {
+                return backing_bitset_->test(std::distance(cur_segment_, backing_bitset_->inner_.data()), cur_offset_);
+            }
+
+            bitset_iterator& operator++(int) noexcept {
+                if (++cur_offset_ >= segment_size_in_bits) {
+                    ++cur_segment_;
+                    cur_offset_ = 0;
+                    return *this;
+                }
+                return *this;
+            }
+
+            bool consumed() const noexcept {
+                return cur_segment_ >= backing_bitset_;
+            }
+
+            friend bool operator==(std::default_sentinel_t, bitset_iterator const& it) {
+                return it == std::default_sentinel_t{};
+            }
+
+            friend bool operator==(bitset_iterator const& it, std::default_sentinel_t) {
+                return it.consumed();
+            }
+        };
+
         struct AutoModeTag {};
         struct DefaultModeTag {};
 
@@ -178,6 +244,8 @@ namespace dice::template_library {
 #endif
 
     public:
+        using iterator = bitset_iterator;
+
         void set(global_ix const ix) {
             bitset_mod_cntl(AutoModeTag{}, &bitset::set, ix);
         }
@@ -199,6 +267,14 @@ namespace dice::template_library {
             for (auto const &segment : inner_) {
                 accumulated += bitset_op_cntl(&bitset::count, segment);
             }
+        }
+
+        constexpr iterator begin() {
+            return iterator{*this};
+        }
+
+        constexpr std::default_sentinel_t end() {
+            return std::default_sentinel_t{};
         }
     };
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -6,6 +6,7 @@
 #include <functional>
 #include <numeric>
 #include <format>
+#include <iterator>
 
 namespace dice::template_library {
 
@@ -57,6 +58,7 @@ namespace dice::template_library {
     private:
         template<bool is_const>
         struct bitset_iterator {
+            using iterator_category = std::random_access_iterator_tag;
         private:
             using bitset_pointer = std::conditional_t<is_const, bitset const*, bitset*>;
 
@@ -75,7 +77,8 @@ namespace dice::template_library {
                 operator bool() const noexcept {
                     return backing_bitset_->test(calc_global_idx(seg_, off_));
                 }
-                bit_ref const& operator=(bool b) const noexcept {
+
+                bit_ref const& operator=(bool const b) const noexcept {
                     if (b) backing_bitset_->set(calc_global_idx(seg_, off_));
                     else   backing_bitset_->unset(calc_global_idx(seg_, off_));
                     return *this;
@@ -538,6 +541,24 @@ namespace dice::template_library {
             return merge_val;
         }
 
+        template<typename F, typename Pr, typename M, typename Tp, typename Ops>
+        Tp segment_handler_backwards(F &&handler, Pr &&pred, M &&merge, Tp initial, Ops ops=add_op{}) const {
+            auto self_it = begin() + size_in_bits();
+            auto end_it = begin();
+
+            Tp merge_val{initial};
+
+            while (self_it != end_it) {
+                Tp const val = std::invoke(std::forward<F>(handler), (self_it-1).get());
+                merge_val = std::invoke(std::forward<M>(merge), ops, merge_val, val);
+                if (!std::invoke(std::forward<Pr>(pred), val)) {
+                    return merge_val;
+                }
+                self_it.template operator--<bitset_const::segment_mode>();
+            }
+            return merge_val;
+        }
+
         template<typename F, typename M, typename Tp, typename Ops>
         [[nodiscard]] Tp slot_handler(storage::const_reference segment, F &&f, M&& m, Tp initial, Ops ops=add_op{}) const {
             Tp merge_val{initial};
@@ -557,6 +578,22 @@ namespace dice::template_library {
 
             for (; word != end; ++word) {
                 Tp const val = std::invoke(std::forward<F>(f), *word);
+                merge_val = std::invoke(std::forward<M>(m), ops, merge_val, val);
+                if (!std::invoke(std::forward<Pr>(pred), val)) {
+                    return merge_val;
+                }
+            }
+
+            return merge_val;
+        }
+
+        template<typename F, typename Pr, typename M, typename Tp, typename Ops>
+        [[nodiscard]] Tp slot_handler_backwards(storage::const_reference segment, F &&f, Pr &&pred, M&& m, Tp initial, Ops ops=add_op{}) const {
+            Tp merge_val{initial};
+            auto [word, end] = segment_slots(segment);
+
+            for (; end != word; --end) {
+                Tp const val = std::invoke(std::forward<F>(f), *(end - 1));
                 merge_val = std::invoke(std::forward<M>(m), ops, merge_val, val);
                 if (!std::invoke(std::forward<Pr>(pred), val)) {
                     return merge_val;
@@ -608,7 +645,7 @@ namespace dice::template_library {
                 return std::countl_zero(segment);
             }
 
-            return slot_handler(segment, [](storage_word word) -> size_t {
+            return slot_handler_backwards(segment, [](storage_word word) -> size_t {
                 return std::countl_zero(word);
             }, [](size_t const val) {
                 return val == sizeof(storage_word) * 8;
@@ -632,7 +669,7 @@ namespace dice::template_library {
                 return std::countl_one(segment);
             }
 
-            return slot_handler(segment, [](storage_word word) -> size_t {
+            return slot_handler_backwards(segment, [](storage_word word) -> size_t {
                 return std::countl_one(word);
             }, [](size_t const val) {
                 return val == sizeof(storage_word) * 8;
@@ -669,7 +706,6 @@ namespace dice::template_library {
         using reverse_iterator = std::reverse_iterator<iterator>;
         using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-        using bitref = bitset_iterator<true>::bit_ref;
         static constexpr Set mode_set = Set{};
         static constexpr Unset mode_unset = Unset{};
 
@@ -772,11 +808,7 @@ namespace dice::template_library {
 
             return storage_size_in_bits;
         }
-
-        /* TODO: countl_zero & countl_one are currently walking the segments in the wrong directon
-                the same also applies for the inner slot handling
-                use a backward iterator + modes for traversing backwards*/
-
+        
         [[nodiscard]] size_t countr_zero() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_countr_zero, segment);
@@ -786,7 +818,7 @@ namespace dice::template_library {
         }
 
         [[nodiscard]] size_t countl_zero() const {
-            return segment_handler([this](typename storage::const_reference segment) {
+            return segment_handler_backwards([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_countl_zero, segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;
@@ -802,7 +834,7 @@ namespace dice::template_library {
         }
 
         [[nodiscard]] size_t countl_one() const {
-            return segment_handler([this](typename storage::const_reference segment) {
+            return segment_handler_backwards([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_countl_one, segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -38,7 +38,7 @@ namespace dice::template_library {
         static constexpr bool   has_storage_limit = segments != dynamic_extent;
         static constexpr size_t segment_size = sizeof(T);
         static constexpr size_t segment_align = alignof(T);
-        static constexpr size_t segment_steps = segment_size / segment_align;
+        static constexpr size_t segment_steps = segment_size / segment_align; ///> how many chunks fit within one segment
         static constexpr size_t segment_size_in_bits = segment_size * 8;
         static constexpr size_t storage_size = !has_storage_limit ? dynamic_extent : segment_size * segments;
         static constexpr size_t storage_size_in_bits = !has_storage_limit ? dynamic_extent : storage_size * 8;
@@ -89,7 +89,6 @@ namespace dice::template_library {
 
             void operator=(bool const b) const noexcept {
                 if (b) {
-                    ;
                     backing_bitset_->set(calc_global_idx(cur_segment_, cur_offset_));
                     return;
                 }
@@ -300,20 +299,56 @@ namespace dice::template_library {
             }
         }
 
+        [[nodiscard]] static size_t offset_in_chunk(offset const o) noexcept {
+            return o % segment_align;
+        }
+
+        [[nodiscard]] static size_t which_chunk(offset const o) noexcept {
+            return o / segment_align;
+        }
+
+        storage_word_pointer get_chunk_raw(segment const s, offset const o) const noexcept {
+            return reinterpret_cast<storage_word_pointer>(inner_.data() + s) + which_chunk(o);
+        }
+
         void segment_set(segment const s, offset const o) noexcept {
-            *(inner_.data() + s) |= 1uz << o;
+            if constexpr (std::is_integral_v<T>) {
+                *(inner_.data() + s) |= 1uz << o;
+            }
+            else {
+                auto chunk_raw = get_chunk_raw(s, o);
+                *chunk_raw |= 1uz << offset_in_chunk(o);
+            }
         }
 
         void segment_flip(segment const s, offset const o) noexcept {
-            *(inner_.data() + s) ^= 1uz << o;
+            if constexpr (std::is_integral_v<T>) {
+                *(inner_.data() + s) ^= 1uz << o;
+            }
+            else {
+                auto chunk_raw = get_chunk_raw(s, o);
+                *chunk_raw ^= 1uz << offset_in_chunk(o);
+            }
         }
 
         void segment_unset(segment const s, offset const o) noexcept {
-            *(inner_.data() + s) &= ~(1uz << o);
+            if constexpr (std::is_integral_v<T>) {
+                *(inner_.data() + s) &= ~(1uz << o);
+            }
+            else {
+                auto chunk_raw = get_chunk_raw(s, o);
+                *chunk_raw &= ~(1uz << offset_in_chunk(o));
+            }
         }
 
         [[nodiscard]] bool segment_test(segment const s, offset const o) noexcept {
-            return *(inner_.data() + s) & 1uz << o;
+            if constexpr (std::is_integral_v<T>) {
+                return *(inner_.data() + s) & 1uz << o;
+            }
+            else {
+                auto chunk_raw = get_chunk_raw(s, o);
+                return *chunk_raw & 1uz << offset_in_chunk(o);
+            }
         }
 
         [[nodiscard]] size_t segment_count(storage::const_reference segment) const noexcept {
@@ -413,6 +448,22 @@ namespace dice::template_library {
             return merge_val;
         }
 
+        template<typename F, typename Pr, typename M, typename Tp, typename Ops=add_op>
+        [[nodiscard]] Tp slot_handler(storage::const_reference segment, F &&f, Pr &&pred, M&& m, Tp initial) const {
+            Tp merge_val{initial};
+            auto [word, end] = segment_slots(segment);
+
+            for (; word != end; ++word) {
+                Tp const val = std::invoke(std::forward<F>(f), *word);
+                merge_val = std::invoke(std::forward<M>(m), Ops{}, merge_val, val);
+                if (!std::invoke(std::forward<Pr>(pred), val)) {
+                    return merge_val;
+                }
+            }
+
+            return merge_val;
+        }
+
         template<typename Ops=add_op>
         void slot_handler(storage::reference segment, storage::const_reference other) {
             auto merge_func = dice::template_library::merge_functor<storage_word>{};
@@ -444,9 +495,9 @@ namespace dice::template_library {
 
             auto [word, end] = segment_slots(segment);
 
-            for (; word != end; ++word) {
+            for (auto c{0uz}; word != end; ++word, ++c) {
                 if (auto const segment_free = static_cast<const storage_word>(~(*word)); segment_free != 0) {
-                    return std::countr_zero(segment_free);
+                    return (sizeof(storage_word) * 8) * c + std::countr_zero(segment_free);
                 }
             }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -78,7 +78,13 @@ namespace dice::template_library {
         using global_ix = size_t;
         using segment   = size_t;
         using offset    = size_t;
+        
+    public:
+        using value_type = storage::value_type;
+        using reference  = storage::reference;
+        using const_reference = storage::const_reference;
 
+    private:
         static constexpr bool   has_max_extent = storage::has_max_extent;
         static constexpr bool   has_dynamic_extent = storage::has_dynamic_extent;
         static constexpr size_t segment_size = sizeof(T);
@@ -318,7 +324,7 @@ namespace dice::template_library {
                 auto offset  = (*it_).off;
                 auto segment = it_.get();
 
-                if constexpr (std::integral<typename storage::value_type>) {
+                if constexpr (std::integral<value_type>) {
                     if (segment == 0x00) {
                         it_ += inner_size_in_bits();
                     }
@@ -468,8 +474,8 @@ namespace dice::template_library {
         }
 
         template<typename F>
-        auto bitset_op_cntl(F &&ops, storage::const_reference segment) const -> std::invoke_result_t<F, bitset*, typename storage::const_reference> {
-            if constexpr (std::is_void_v<std::invoke_result_t<F, bitset*, typename storage::const_reference>>) {
+        auto bitset_op_cntl(F &&ops, const_reference segment) const -> std::invoke_result_t<F, bitset*, const_reference> {
+            if constexpr (std::is_void_v<std::invoke_result_t<F, bitset*, const_reference>>) {
                 std::invoke(std::forward<F>(ops), this, segment);
                 return;
             }
@@ -534,10 +540,10 @@ namespace dice::template_library {
             }
         }
 
-        [[nodiscard]] size_t segment_count(storage::const_reference segment) const noexcept {
-            if constexpr (std::integral<typename storage::value_type>) {
+        [[nodiscard]] size_t segment_count(const_reference segment) const noexcept {
+            if constexpr (std::integral<value_type>) {
 #ifdef __SIZEOF_INT128__
-                if constexpr (std::is_same_v<typename storage::value_type, __uint128_t>) {
+                if constexpr (std::is_same_v<value_type, __uint128_t>) {
                     uint64_t const lo = static_cast<uint64_t>(segment);
                     uint64_t const hi = static_cast<uint64_t>(segment >> 64);
 
@@ -553,7 +559,7 @@ namespace dice::template_library {
         }
 
         template<typename F, typename M, typename Tp, typename Ops>
-        requires std::is_same_v<std::invoke_result_t<F, typename storage::const_reference>, Tp> &&
+        requires std::is_same_v<std::invoke_result_t<F, const_reference>, Tp> &&
             std::invocable<M, Ops, Tp, Tp>
         [[nodiscard]] Tp segment_handler(F &&handler, M &&merge, Tp initial, Ops ops=add_op{}) const {
             Tp merge_val{initial};
@@ -658,7 +664,7 @@ namespace dice::template_library {
         }
 
         template<typename F, typename M, typename Tp, typename Ops>
-        [[nodiscard]] Tp slot_handler(storage::const_reference segment, F &&f, M&& m, Tp initial, Ops ops=add_op{}) const {
+        [[nodiscard]] Tp slot_handler(const_reference segment, F &&f, M&& m, Tp initial, Ops ops=add_op{}) const {
             Tp merge_val{initial};
             auto [word, end] = segment_slots(segment);
 
@@ -670,7 +676,7 @@ namespace dice::template_library {
         }
 
         template<typename F, typename Pr, typename M, typename Tp, typename Ops>
-        [[nodiscard]] Tp slot_handler(storage::const_reference segment, F &&f, Pr &&pred, M&& m, Tp initial, Ops ops=add_op{}) const {
+        [[nodiscard]] Tp slot_handler(const_reference segment, F &&f, Pr &&pred, M&& m, Tp initial, Ops ops=add_op{}) const {
             Tp merge_val{initial};
             auto [word, end] = segment_slots(segment);
 
@@ -686,7 +692,7 @@ namespace dice::template_library {
         }
 
         template<typename F, typename Pr, typename M, typename Tp, typename Ops>
-        [[nodiscard]] Tp slot_handler_backwards(storage::const_reference segment, F &&f, Pr &&pred, M&& m, Tp initial, Ops ops=add_op{}) const {
+        [[nodiscard]] Tp slot_handler_backwards(const_reference segment, F &&f, Pr &&pred, M&& m, Tp initial, Ops ops=add_op{}) const {
             Tp merge_val{initial};
             auto [word, end] = segment_slots(segment);
 
@@ -702,7 +708,7 @@ namespace dice::template_library {
         }
 
         template<typename Ops=add_op>
-        void slot_handler(storage::reference segment, storage::const_reference other) {
+        void slot_handler(reference segment, const_reference other) {
             auto merge_func = dice::template_library::merge_functor<storage_word>{};
             auto [word, end] = segment_slots(segment);
             auto [word2, end2] = segment_slots(other);
@@ -713,7 +719,7 @@ namespace dice::template_library {
         }
 
         template<typename F>
-        void slot_handler(storage::reference segment, F&& f) {
+        void slot_handler(const_reference segment, F&& f) {
             auto [word, end] = segment_slots(segment);
 
             for (; word != end; ++word) {
@@ -722,15 +728,15 @@ namespace dice::template_library {
         }
 
         template<typename F>
-        void slot_handler(storage::const_reference segment, F&& f) {
+        void slot_handler(reference segment, storage_word val) {
             auto [word, end] = segment_slots(segment);
 
             for (; word != end; ++word) {
-                std::invoke(std::forward<F>(f), *word);
+                *word = val;
             }
         }
 
-        bool slot_handler(storage::const_reference segment, storage::const_reference other) const {
+        bool slot_handler(const_reference segment, const_reference other) const {
             auto [word, end] = segment_slots(segment);
             auto [word2, end2] = segment_slots(other);
 
@@ -743,8 +749,8 @@ namespace dice::template_library {
             return true;
         }
 
-        [[nodiscard]] size_t segment_free(storage::const_reference segment) const {
-            if constexpr (std::integral<typename storage::value_type>) {
+        [[nodiscard]] size_t segment_free(const_reference segment) const {
+            if constexpr (std::integral<value_type>) {
                 return std::countr_zero(static_cast<storage::value_type>(~segment));
             }
 
@@ -756,8 +762,8 @@ namespace dice::template_library {
             }, merge_functor<size_t>{}, 0uz, add_op{});
         }
 
-        [[nodiscard]] size_t segment_countl_zero(storage::const_reference segment) const noexcept {
-            if constexpr (std::integral<typename storage::value_type>) {
+        [[nodiscard]] size_t segment_countl_zero(const_reference segment) const noexcept {
+            if constexpr (std::integral<value_type>) {
                 return std::countl_zero(segment);
             }
 
@@ -768,8 +774,8 @@ namespace dice::template_library {
             }, merge_functor<size_t>{}, 0uz, add_op{});
         }
 
-        [[nodiscard]] size_t segment_countr_zero(storage::const_reference segment) const noexcept {
-            if constexpr (std::integral<typename storage::value_type>) {
+        [[nodiscard]] size_t segment_countr_zero(const_reference segment) const noexcept {
+            if constexpr (std::integral<value_type>) {
                 return std::countr_zero(segment);
             }
 
@@ -780,8 +786,8 @@ namespace dice::template_library {
             }, merge_functor<size_t>{}, 0uz, add_op{});
         }
 
-        [[nodiscard]] size_t segment_countl_one(storage::const_reference segment) const noexcept {
-            if constexpr (std::integral<typename storage::value_type>) {
+        [[nodiscard]] size_t segment_countl_one(const_reference segment) const noexcept {
+            if constexpr (std::integral<value_type>) {
                 return std::countl_one(segment);
             }
 
@@ -792,8 +798,8 @@ namespace dice::template_library {
             }, merge_functor<size_t>{}, 0uz, add_op{});
         }
 
-        [[nodiscard]] size_t segment_countr_one(storage::const_reference segment) const noexcept {
-            if constexpr (std::integral<typename storage::value_type>) {
+        [[nodiscard]] size_t segment_countr_one(const_reference segment) const noexcept {
+            if constexpr (std::integral<value_type>) {
                 return std::countr_one(segment);
             }
 
@@ -804,15 +810,15 @@ namespace dice::template_library {
             }, merge_functor<size_t>{}, 0uz, add_op{});
         }
 
-        [[nodiscard]] bool segment_all_set(storage::const_reference segment) const noexcept {
+        [[nodiscard]] bool segment_all_set(const_reference segment) const noexcept {
             return segment_count(segment) == segment_size_in_bits;
         }
 
-        [[nodiscard]] bool segment_any_set(storage::const_reference segment) const noexcept {
+        [[nodiscard]] bool segment_any_set(const_reference segment) const noexcept {
             return segment_count(segment) != 0;
         }
 
-        [[nodiscard]] bool segment_none_set(storage::const_reference segment) const noexcept {
+        [[nodiscard]] bool segment_none_set(const_reference segment) const noexcept {
             return segment_count(segment) == 0x00;
         }
 
@@ -852,7 +858,7 @@ namespace dice::template_library {
          *
          * @return a pair containing word pointers to both segment ends (start, end)
          */
-        [[nodiscard]] std::pair<storage_word_const_pointer, storage_word_const_pointer> segment_slots(storage::const_reference segment) const noexcept {
+        [[nodiscard]] std::pair<storage_word_const_pointer, storage_word_const_pointer> segment_slots(const_reference segment) const noexcept {
             auto word = reinterpret_cast<storage_word_const_pointer>(&segment);
             auto const end = word + segment_steps;
 
@@ -864,7 +870,7 @@ namespace dice::template_library {
          *
          * @return a pair containing word pointers to both segment ends (start, end)
          */
-        [[nodiscard]] std::pair<storage_word_pointer, storage_word_pointer> segment_slots(storage::reference segment) const noexcept {
+        [[nodiscard]] std::pair<storage_word_pointer, storage_word_pointer> segment_slots(reference segment) const noexcept {
             auto word = reinterpret_cast<storage_word_pointer>(&segment);
             auto const end = word + segment_steps;
 
@@ -893,6 +899,17 @@ namespace dice::template_library {
             reset(ix);
         }
 
+        void set_all() requires(!has_dynamic_extent) {
+            if constexpr (std::integral<value_type>) {
+                std::fill(inner_.begin(), inner_.end(), 0x01);
+            }
+            else {
+                for (auto &segment : inner_) {
+                    slot_handler(segment, 0x01);
+                }
+            }
+        }
+
         /**
          * Flip a bit for offset ix
          *
@@ -909,6 +926,17 @@ namespace dice::template_library {
          */
         void reset(global_ix const ix) {
             bitset_mod_cntl(&bitset::segment_unset, ix);
+        }
+
+        void reset_all() requires(!has_dynamic_extent) {
+            if constexpr (std::integral<value_type>) {
+                std::fill(inner_.begin(), inner_.end(), 0x00);
+            }
+            else {
+                for (auto &segment : inner_) {
+                    slot_handler(segment, 0x00);
+                }
+            }
         }
 
         /**
@@ -934,7 +962,7 @@ namespace dice::template_library {
          * @return total bits set
          */
         [[nodiscard]] size_t count() const {
-            return segment_handler([this](typename storage::const_reference segment) {
+            return segment_handler([this](const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_count, segment);
             }, merge_functor<size_t>{}, 0uz, add_op{});
         }
@@ -982,7 +1010,7 @@ namespace dice::template_library {
          * @return ix to non-zero entry
          */
         [[nodiscard]] size_t countr_zero() const {
-            return segment_handler([this](typename storage::const_reference segment) {
+            return segment_handler([this](const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_countr_zero, segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;
@@ -995,7 +1023,7 @@ namespace dice::template_library {
          * @return ix to non-zero entry
          */
         [[nodiscard]] size_t countl_zero() const {
-            return segment_handler_backwards([this](typename storage::const_reference segment) {
+            return segment_handler_backwards([this](const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_countl_zero, segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;
@@ -1008,7 +1036,7 @@ namespace dice::template_library {
          * @return ix to zero entry
          */
         [[nodiscard]] size_t countr_one() const {
-            return segment_handler([this](typename storage::const_reference segment) {
+            return segment_handler([this](const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_countr_one, segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;
@@ -1021,7 +1049,7 @@ namespace dice::template_library {
          * @return ix to zero entry
          */
         [[nodiscard]] size_t countl_one() const {
-            return segment_handler_backwards([this](typename storage::const_reference segment) {
+            return segment_handler_backwards([this](const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_countl_one, segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;
@@ -1034,7 +1062,7 @@ namespace dice::template_library {
          * @return queried state
          */
         [[nodiscard]] bool all_set() const {
-            return segment_handler([this](typename storage::const_reference segment) {
+            return segment_handler([this](const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_all_set, segment);
             }, [](bool const val) {
                 return val;
@@ -1047,7 +1075,7 @@ namespace dice::template_library {
          * @return queried state
          */
         [[nodiscard]] bool any_set() const {
-            return segment_handler([this](typename storage::const_reference segment) {
+            return segment_handler([this](const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_any_set, segment);
             }, merge_functor<bool>{}, false, bit_or_op{});
         }
@@ -1058,7 +1086,7 @@ namespace dice::template_library {
          * @return queried state
          */
         [[nodiscard]] bool none_set() const {
-            return segment_handler([this](typename storage::const_reference segment) {
+            return segment_handler([this](const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_none_set, segment);
             }, [](bool const val) {
                 return val;
@@ -1153,7 +1181,7 @@ namespace dice::template_library {
         }
 
         bool operator==(bitset const& alt_storage) const noexcept {
-            return segment_handler([this](typename storage::const_reference segment_first, typename storage::const_reference segment_second) {
+            return segment_handler([this](const_reference segment_first, const_reference segment_second) {
                 return slot_handler(segment_first, segment_second);
             }, alt_storage);
         }
@@ -1171,7 +1199,7 @@ namespace dice::template_library {
         }
 
         bitset& operator&=(bitset const& alt_storage) noexcept {
-            segment_handler([this](typename storage::reference segment_first, typename storage::const_reference segment_second) {
+            segment_handler([this](reference segment_first, const_reference segment_second) {
                 slot_handler<bit_and_op>(segment_first, segment_second);
                 return true;
             }, alt_storage);
@@ -1179,7 +1207,7 @@ namespace dice::template_library {
         }
 
         bitset& operator|=(bitset const& alt_storage) noexcept {
-            segment_handler([this](typename storage::reference segment_first, typename storage::const_reference segment_second) {
+            segment_handler([this](reference segment_first, const_reference segment_second) {
                 slot_handler<bit_or_op>(segment_first, segment_second);
                 return true;
             }, alt_storage);

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -109,6 +109,13 @@ namespace dice::template_library {
             }
 
             template<size_t mode=bitset_const::bit_mode>
+            bitset_iterator operator++(int) noexcept {
+                auto tmp = *this;
+                operator++<mode>();
+                return tmp;
+            }
+
+            template<size_t mode=bitset_const::bit_mode>
             bitset_iterator& operator+=(size_t const skip) noexcept {
                 auto skip_handler = [this](size_t skip_size) {
                     auto global_ix = calc_global_idx(cur_segment_, cur_offset_) + skip_size;
@@ -141,11 +148,11 @@ namespace dice::template_library {
             }
 
             bool consumed() const noexcept {
-                return cur_segment_ >= backing_bitset_;
+                return cur_segment_ >= backing_bitset_->inner_.data() + backing_bitset_->size();
             }
 
             friend bool operator==(std::default_sentinel_t, bitset_iterator const& it) {
-                return it == std::default_sentinel_t{};
+                return it == std::default_sentinel;
             }
 
             friend bool operator==(bitset_iterator const& it, std::default_sentinel_t) {
@@ -155,6 +162,9 @@ namespace dice::template_library {
 
         struct AutoModeTag {};
         struct DefaultModeTag {};
+
+        struct Set{};
+        struct Unset{};
 
         storage inner_;
 
@@ -409,6 +419,34 @@ namespace dice::template_library {
 
     public:
         using iterator = bitset_iterator;
+        static constexpr Set mode_set = Set{};
+        static constexpr Unset mode_unset = Unset{};
+
+        constexpr bitset(std::initializer_list<T> const segment_v) : inner_{segment_v} {}
+        constexpr bitset(Set, size_t const size) requires(!has_storage_limit) : inner_{} {
+            inner_.resize(size);
+            auto it = begin();
+            auto it_end = end();
+
+            while (it != it_end) {
+                *it++ = true;
+            }
+        }
+        constexpr bitset(Unset, size_t const size) requires(!has_storage_limit) : inner_{} {
+            inner_.resize(size);
+            auto it = begin();
+            auto it_end = end();
+
+            while (it != it_end) {
+                *it++ = false;
+            }
+        }
+
+        constexpr bitset(bitset const&) = default;
+        constexpr bitset(bitset &&) = default;
+        constexpr bitset &operator=(bitset const&) = default;
+        constexpr bitset &operator=(bitset &&) = default;
+        constexpr ~bitset() = default;
 
         void set(global_ix const ix) {
             bitset_mod_cntl(AutoModeTag{}, &bitset::set, ix);
@@ -423,7 +461,7 @@ namespace dice::template_library {
         }
 
         [[nodiscard]] bool test(global_ix const ix) {
-            return bitset_mod_cntl(AutoModeTag{}, &bitset::test, ix);
+            return bitset_mod_cntl(DefaultModeTag{}, &bitset::test, ix);
         }
 
         [[nodiscard]] size_t count() {
@@ -528,7 +566,7 @@ namespace dice::template_library {
         }
 
         constexpr std::default_sentinel_t end() {
-            return std::default_sentinel_t{};
+            return std::default_sentinel;
         }
 
         constexpr size_t size() const noexcept {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -130,7 +130,7 @@ namespace dice::template_library {
                         backing_bitset_->set(calc_global_idx(seg, off));
                     }
                     else {
-                        backing_bitset_->unset(calc_global_idx(seg, off));
+                        backing_bitset_->reset(calc_global_idx(seg, off));
                     }
                     return *this;
                 }
@@ -172,7 +172,7 @@ namespace dice::template_library {
                     backing_bitset_->set(calc_global_idx(cur_segment_, cur_offset_));
                     return;
                 }
-                backing_bitset_->unset(calc_global_idx(cur_segment_, cur_offset_));
+                backing_bitset_->reset(calc_global_idx(cur_segment_, cur_offset_));
             }
 
             reference operator*() const noexcept {
@@ -816,7 +816,7 @@ namespace dice::template_library {
         /**
          * Set a bit low for offset ix
          */
-        void unset(global_ix const ix) {
+        void reset(global_ix const ix) {
             bitset_mod_cntl(&bitset::segment_unset, ix);
         }
 
@@ -1006,7 +1006,7 @@ namespace dice::template_library {
 
         void reset_positions(std::ranges::input_range auto&& positions) {
             positions_cntl(std::forward<decltype(positions)>(positions), [this](auto pos) {
-                unset(pos);
+                reset(pos);
             });
         }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -74,19 +74,20 @@ namespace dice::template_library {
     template<size_t extent, size_t segments, typename T = uint64_t>
     struct bitset {
     private:
-        static constexpr bool   has_storage_limit = segments != dynamic_extent;
-        static constexpr size_t segment_size = sizeof(T);
-        static constexpr size_t segment_align = alignof(T);
-        static constexpr size_t segment_steps = segment_size / segment_align; ///> how many chunks fit within one segment
-        static constexpr size_t segment_size_in_bits = segment_size * 8;
-        static constexpr size_t storage_size = !has_storage_limit ? dynamic_extent : segment_size * segments;
-        static constexpr size_t storage_size_in_bits = !has_storage_limit ? dynamic_extent : storage_size * 8;
-
         using storage   = flex_array<T, extent, segments>;
         using global_ix = size_t;
         using segment   = size_t;
         using offset    = size_t;
 
+        static constexpr bool   has_max_extent = storage::has_max_extent;
+        static constexpr bool   has_dynamic_extent = storage::has_dynamic_extent;
+        static constexpr size_t segment_size = sizeof(T);
+        static constexpr size_t segment_align = alignof(T);
+        static constexpr size_t segment_steps = segment_size / segment_align; ///> how many chunks fit within one segment
+        static constexpr size_t segment_size_in_bits = segment_size * 8;
+        static constexpr size_t storage_size = !has_max_extent ? dynamic_extent : segment_size * segments;
+        static constexpr size_t storage_size_in_bits = !has_max_extent ? dynamic_extent : storage_size * 8;
+        
         ///> word used for traversing the inner segment, instead of forcing 1 byte loads
         using storage_word = std::conditional_t<segment_align >= alignof(std::uint64_t), std::uint64_t,
             std::conditional_t<segment_align >= alignof(std::uint32_t), std::uint32_t,
@@ -312,7 +313,7 @@ namespace dice::template_library {
 
         storage inner_;
 
-        [[nodiscard]] constexpr size_t require_segments(global_ix const ix) const requires (storage::has_dynamic_extent) {
+        [[nodiscard]] constexpr size_t require_segments(global_ix const ix) const requires (has_dynamic_extent) {
             auto const bit_pos = bits_consumed();
             if (bit_pos > ix) {
                 return 0;
@@ -330,7 +331,7 @@ namespace dice::template_library {
             }();
         }
 
-        void constexpr expand_segments(global_ix const ix) requires (storage::has_dynamic_extent) {
+        void constexpr expand_segments(global_ix const ix) requires (has_dynamic_extent) {
             auto const to_add = require_segments(ix);
             if (to_add == 0) {
                 return;
@@ -349,7 +350,7 @@ namespace dice::template_library {
         }
 
         [[nodiscard]] static constexpr bool fits_in_storage(global_ix const ix) noexcept {
-            if constexpr (has_storage_limit) {
+            if constexpr (has_max_extent) {
                 return ix < storage_size_in_bits;
             }
 
@@ -385,7 +386,7 @@ namespace dice::template_library {
             }
 
             // auto expands whenever the underlying storage can actually grow
-            if constexpr (storage::has_dynamic_extent) {
+            if constexpr (has_dynamic_extent) {
                 expand_segments(ix);
             }
 
@@ -753,7 +754,7 @@ namespace dice::template_library {
          *
          * @param size segment size to set low
          */
-        explicit constexpr bitset(size_t const size) requires(!has_storage_limit) : inner_{} {
+        explicit constexpr bitset(size_t const size) requires(!has_max_extent) : inner_{} {
             inner_.resize(size);
         }
 
@@ -850,8 +851,8 @@ namespace dice::template_library {
                 }
             }
 
-            if constexpr (storage::has_dynamic_extent) {
-                if constexpr (!has_storage_limit) {
+            if constexpr (has_dynamic_extent) {
+                if constexpr (!has_max_extent) {
                     inner_.resize(inner_.size() + 1);
                     *reinterpret_cast<storage_word_pointer>(inner_.end() - 1) = 0x01;
 
@@ -967,7 +968,6 @@ namespace dice::template_library {
                 return calc_global_idx(bitref.seg, bitref.off);
             });
         }
-
 
         template<typename F>
         void positions_cntl(std::ranges::input_range auto&& positions, F&& pos_f) {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -305,15 +305,16 @@ namespace dice::template_library {
         struct position_iterator {
         private:
             using bitset_pointer = std::conditional_t<is_const, bitset const*, bitset*>;
+            using reference = bitset_iterator<is_const>::reference;
 
             bitset_iterator<is_const> it_;
             bitset_pointer const backing_bitset_;
 
         public:
-            explicit position_iterator(std::conditional_t<is_const,bitset const&, bitset&> bitset) noexcept
+            explicit position_iterator(std::conditional_t<is_const, bitset const&, bitset&> bitset) noexcept
                 : it_{&bitset}, backing_bitset_{&bitset} {}
 
-            position_iterator operator++() {
+            position_iterator operator++() noexcept {
                 auto offset  = (*it_).off;
                 auto segment = it_.get();
 
@@ -338,10 +339,26 @@ namespace dice::template_library {
                 return *this;
             }
 
-            position_iterator operator++(int) {
+            position_iterator operator++(int) noexcept {
                 auto tmp = *this;
                 operator++();
                 return tmp;
+            }
+
+            reference operator* () const noexcept {
+                return *it_;
+            }
+
+            friend bool operator==(position_iterator const& lhs, position_iterator const& rhs){
+                return lhs.it_ == rhs.it_;
+            }
+
+            friend bool operator==(std::default_sentinel_t, position_iterator const& it) {
+                return it == std::default_sentinel;
+            }
+
+            friend bool operator==(position_iterator const& it, std::default_sentinel_t) {
+                return it.it_ == std::default_sentinel;
             }
         };
 
@@ -804,6 +821,8 @@ namespace dice::template_library {
         using const_iterator = bitset_iterator<true>;
         using reverse_iterator = std::reverse_iterator<iterator>;
         using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+        using positional_iterator = position_iterator<false>;
+        using const_positional_iterator = position_iterator<true>;
 
         /**
          * Initializes the bitset using an initializer list
@@ -1110,6 +1129,14 @@ namespace dice::template_library {
 
         constexpr std::default_sentinel_t end() const noexcept {
             return std::default_sentinel;
+        }
+
+        constexpr positional_iterator pbegin() noexcept {
+            return positional_iterator{*this};
+        }
+
+        constexpr positional_iterator pbegin() const noexcept {
+            return positional_iterator{*this};
         }
 
         /**

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -65,6 +65,21 @@ namespace dice::template_library {
             bitset_pointer const backing_bitset_;
 
         public:
+            struct bit_ref {
+                bitset_pointer backing_bitset_;
+                segment seg_;
+                offset  off_;
+
+                operator bool() const noexcept {
+                    return backing_bitset_->test(calc_global_idx(seg_, off_));
+                }
+                bit_ref const& operator=(bool b) const noexcept {
+                    if (b) backing_bitset_->set(calc_global_idx(seg_, off_));
+                    else   backing_bitset_->unset(calc_global_idx(seg_, off_));
+                    return *this;
+                }
+            };
+
             explicit bitset_iterator(std::conditional_t<is_const,bitset const&, bitset&> bitset) noexcept :
                 backing_bitset_{&bitset} {}
 
@@ -98,8 +113,8 @@ namespace dice::template_library {
                 backing_bitset_->unset(calc_global_idx(cur_segment_, cur_offset_));
             }
 
-            bool operator*() const noexcept {
-                return backing_bitset_->test(calc_global_idx(cur_segment_, cur_offset_));
+            bit_ref operator*() const noexcept {
+                return bit_ref {backing_bitset_, cur_segment_, cur_offset_};
             }
 
             // shared iterator for mode=0 (bits) mode>=1 (segments)
@@ -649,6 +664,7 @@ namespace dice::template_library {
     public:
         using iterator = bitset_iterator<false>;
         using const_iterator = bitset_iterator<true>;
+        using bitref = bitset_iterator<true>::bit_ref;
         static constexpr Set mode_set = Set{};
         static constexpr Unset mode_unset = Unset{};
 
@@ -659,7 +675,7 @@ namespace dice::template_library {
             auto it_end = end();
 
             while (it != it_end) {
-                it++ = true;
+                *it++ = true;
             }
         }
         constexpr bitset(Unset, size_t const size) requires(!has_storage_limit) : inner_{} {
@@ -668,7 +684,7 @@ namespace dice::template_library {
             auto it_end = end();
 
             while (it != it_end) {
-                it++ = false;
+                *it++ = false;
             }
         }
 
@@ -845,12 +861,12 @@ namespace dice::template_library {
         }
 
         bitset& operator<<=(size_t shift) {
-            //std::move(begin() + shift, begin() + size_in_bits(), begin());
+            std::move(begin() + shift, begin() + size_in_bits(), begin());
             return *this;
         }
 
         bitset& operator>>=(size_t shift) {
-            //std::move_backward(begin(), begin() + size_in_bits() - shift, begin() + size_in_bits());
+            std::move_backward(begin(), begin() + size_in_bits() - shift, begin() + size_in_bits());
             return *this;
         }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -1150,34 +1150,75 @@ namespace dice::template_library {
             }, merge_functor<bool>{}, true, bit_and_op{});
         }
 
+        /**
+         * Returns range whose bits are set high
+         *
+         * @return input range containing the positions
+         */
         auto positions() const -> std::ranges::input_range auto {
             return std::ranges::subrange(pbegin(), pend());
         }
 
+        /**
+         * Set bits high on position given positions range
+         *
+         * @param positions input range of positions
+         */
         void set_positions(std::ranges::input_range auto&& positions) {
             positions_cntl(std::forward<decltype(positions)>(positions), [this](auto pos) {
                 set(pos);
             });
         }
 
+        /**
+         * Reset bits on position given positions range
+         *
+         * @param positions input range of positions
+         */
         void reset_positions(std::ranges::input_range auto&& positions) {
             positions_cntl(std::forward<decltype(positions)>(positions), [this](auto pos) {
                 reset(pos);
             });
         }
 
+        /**
+         * Returns updated iterator advanced by one segment
+         *
+         * @param it bitset iterator
+         * @return iterator advanced by one segment
+         */
         static iterator advance_segment(iterator it) {
             return it.template operator++<bitset_mode::SegmentMode>();
         }
 
+        /**
+         * Returns updated iterator advanced by skip segments
+         *
+         * @param it bitset iterator
+         * @param skip segments to skip
+         * @return iterator advanced by skip segments
+         */
         static iterator advance_segment(iterator it, size_t const skip) {
             return it.template operator+=<bitset_mode::SegmentMode>(skip);
         }
 
+        /**
+         * Returns updated iterator advanced backward by one segment
+         *
+         * @param it bitset iterator
+         * @return iterator advanced backwards by one segment
+         */
         static iterator advance_segment_backwards(iterator it) {
             return it.template operator--<bitset_mode::SegmentMode>();
         }
 
+        /**
+         * Returns updated iterator advanced backward by skip segment
+         * 
+         * @param it bitset iterator
+         * @param skip segments to skip
+         * @return iterator advanced backwards by skip segments
+         */
         static iterator advance_segment_backwards(iterator it, size_t const skip) {
             return it.template operator-=<bitset_mode::SegmentMode>(skip);
         }

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -1152,7 +1152,7 @@ namespace dice::template_library {
         auto positions() const -> std::ranges::input_range auto {
             return std::ranges::subrange(pbegin(), pend());
         }
-        
+
         void set_positions(std::ranges::input_range auto&& positions) {
             positions_cntl(std::forward<decltype(positions)>(positions), [this](auto pos) {
                 set(pos);
@@ -1165,6 +1165,22 @@ namespace dice::template_library {
             });
         }
 
+        static iterator advance_segment(iterator& it) {
+            return it.template operator++<bitset_mode::SegmentMode>();
+        }
+
+        static iterator advance_segment(iterator& it, size_t const skip) {
+            return it.template operator+=<bitset_mode::SegmentMode>(skip);
+        }
+
+        static iterator advance_segment_backwards(iterator& it) {
+            return it.template operator--<bitset_mode::SegmentMode>();
+        }
+
+        static iterator advance_segment_backwards(iterator& it, size_t const skip) {
+            return it.template operator-=<bitset_mode::SegmentMode>(skip);
+        }
+        
         constexpr iterator begin() noexcept {
             return iterator{*this};
         }

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -288,7 +288,7 @@ namespace dice::template_library {
                 return tmp;
             }
 
-            T const& get() const noexcept {
+            [[nodiscard]] T const& get() const noexcept {
                 return *(backing_bitset_->inner_.data() + cur_segment_);
             }
 
@@ -377,6 +377,14 @@ namespace dice::template_library {
 
         [[nodiscard]] static constexpr global_ix calc_global_idx(segment const s, offset const o) noexcept {
             return s * segment_size_in_bits + o;
+        }
+
+        [[nodiscard]] static constexpr size_t inner_size() noexcept {
+            return segment_size;
+        }
+
+        [[nodiscard]] static constexpr size_t inner_size_in_bits() noexcept {
+            return segment_size_in_bits;
         }
 
         template<typename F>
@@ -1038,19 +1046,6 @@ namespace dice::template_library {
          */
         constexpr size_t size_in_bits() const noexcept {
             return size() * segment_size_in_bits;
-        }
-
-        static constexpr size_t inner_size() noexcept {
-            return segment_size;
-        }
-
-        /**
-         * Returns the per segment size in bits
-         *
-         * @return size in bits
-         */
-        static constexpr size_t inner_size_in_bits() noexcept {
-            return segment_size_in_bits;
         }
 
         bool operator==(bitset const& alt_storage) const noexcept {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -62,10 +62,10 @@ namespace dice::template_library {
             bitset *const backing_bitset_;
 
         public:
-            explicit bitset_iterator(storage &bitset) noexcept :
+            explicit bitset_iterator(bitset &bitset) noexcept :
                 backing_bitset_{&bitset} {}
 
-            explicit bitset_iterator(storage &bitset, offset const& o) :
+            explicit bitset_iterator(bitset &bitset, offset const& o) :
                 backing_bitset_{&bitset}{
                 if (o >= segment_size_in_bits) {
                     throw std::out_of_range{"bitset_iterator: o >= segment_size"};
@@ -73,7 +73,7 @@ namespace dice::template_library {
                 cur_offset_ = o;
             }
 
-            explicit bitset_iterator(storage &bitset, offset const& o, segment const& s) :
+            explicit bitset_iterator(bitset &bitset, offset const& o, segment const& s) :
                 backing_bitset_{&bitset}{
                 if (o >= segment_size_in_bits) {
                     throw std::out_of_range{"bitset_iterator: o >= segment_size"};
@@ -418,7 +418,7 @@ namespace dice::template_library {
             return true;
         }
 
-        template<typename F, typename Pr, typename M, typename Tp>
+        template<typename F, typename Pr, typename M, typename Tp, typename Ops=add_op>
         Tp segment_handler(F &&handler, Pr &&pred, M &&merge, Tp initial) const {
             auto self_it = begin();
             auto end_sentinel = end();
@@ -427,7 +427,7 @@ namespace dice::template_library {
 
             while (self_it != end_sentinel) {
                 Tp const val = std::invoke(std::forward<F>(handler), self_it.get());
-                merge_val = std::invoke(std::forward<M>(merge), merge_val, val);
+                merge_val = std::invoke(std::forward<M>(merge), Ops{}, merge_val, val);
                 if (!std::invoke(std::forward<Pr>(pred), val)) {
                     return merge_val;
                 }
@@ -488,16 +488,16 @@ namespace dice::template_library {
             return true;
         }
 
-        [[nodiscard]] size_t segment_free(storage::const_reference segment) {
+        [[nodiscard]] size_t segment_free(storage::const_reference segment) const {
             if constexpr (std::integral<typename storage::value_type>) {
                 return std::countr_zero(~segment);
             }
 
             return slot_handler(segment, [](storage_word word) -> size_t {
-                auto const segment_free = static_cast<const storage_word>(~(*word));
+                auto const segment_free = static_cast<const storage_word>(~word);
                 return std::countr_zero(segment_free);
             }, [](size_t const val) {
-                return val != 0;
+                return val == sizeof(storage_word) * 8;
             }, merge_functor<size_t>{}, 0uz);
         }
 
@@ -509,7 +509,7 @@ namespace dice::template_library {
             return slot_handler(segment, [](storage_word word) -> size_t {
                 return std::countl_zero(word);
             }, [](size_t const val) {
-                return val == sizeof(storage_word);
+                return val == sizeof(storage_word) * 8;
             }, merge_functor<size_t>{}, 0uz);
         }
 
@@ -521,7 +521,7 @@ namespace dice::template_library {
             return slot_handler(segment, [](storage_word word) -> size_t {
                 return std::countr_zero(word);
             }, [](size_t const val) {
-                return val == sizeof(storage_word);
+                return val == sizeof(storage_word) * 8;
             }, merge_functor<size_t>{}, 0uz);
         }
 
@@ -533,7 +533,7 @@ namespace dice::template_library {
             return slot_handler(segment, [](storage_word word) -> size_t {
                 return std::countl_one(word);
             }, [](size_t const val) {
-                return val == sizeof(storage_word);
+                return val == sizeof(storage_word) * 8;
             }, merge_functor<size_t>{}, 0uz);
         }
 
@@ -545,7 +545,7 @@ namespace dice::template_library {
             return slot_handler(segment, [](storage_word word) -> size_t {
                 return std::countr_one(word);
             }, [](size_t const val) {
-                return val == sizeof(storage_word);
+                return val == sizeof(storage_word) * 8;
             }, merge_functor<size_t>{}, 0uz);
         }
 
@@ -575,7 +575,7 @@ namespace dice::template_library {
             auto it_end = end();
 
             while (it != it_end) {
-                *it++ = true;
+                it++ = true;
             }
         }
         constexpr bitset(Unset, size_t const size) requires(!has_storage_limit) : inner_{} {
@@ -584,7 +584,7 @@ namespace dice::template_library {
             auto it_end = end();
 
             while (it != it_end) {
-                *it++ = false;
+                it++ = false;
             }
         }
 
@@ -594,7 +594,7 @@ namespace dice::template_library {
         constexpr bitset &operator=(bitset &&) = default;
         constexpr ~bitset() = default;
 
-        [[nodiscard]] std::pair<storage_word_const_pointer, storage_word_const_pointer> segment_slots(storage::const_reference segment) {
+        [[nodiscard]] std::pair<storage_word_const_pointer, storage_word_const_pointer> segment_slots(storage::const_reference segment) const noexcept {
             auto word = reinterpret_cast<storage_word_const_pointer>(&segment);
             auto const end = word + segment_steps;
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -200,7 +200,7 @@ namespace dice::template_library {
         }
 
         template<typename F>
-        auto bitset_op_cntl(F&& ops) -> std::invoke_result_t<F, typename storage::const_reference> {
+        auto bitset_op_cntl(F &&ops) -> std::invoke_result_t<F, typename storage::const_reference> {
             using result_t = std::invoke_result_t<F, bitset*>;
 
             if constexpr (std::is_void_v<result_t>) {
@@ -270,6 +270,19 @@ namespace dice::template_library {
             return segment_size_in_bits;
         }
 
+        [[nodiscard]] size_t segment_countl_zero(storage::const_reference segment) {
+            if constexpr (std::integral<typename storage::value_type>) {
+                return std::countl_zero(segment);
+            }
+        }
+
+        [[nodiscard]] size_t segment_countr_zero(storage::const_reference segment) {
+            if constexpr (std::integral<typename storage::value_type>) {
+                return std::countr_zero(segment);
+            }
+        }
+
+
     public:
         using iterator = bitset_iterator;
 
@@ -298,7 +311,7 @@ namespace dice::template_library {
             return accumulated;
         }
 
-        size_t set_first_free() {
+        [[nodiscard]] size_t set_first_free() {
             for (auto const &segment : inner_) {
                 auto offset = bitset_op_cntl(&bitset::set_first_free, segment);
 
@@ -328,6 +341,44 @@ namespace dice::template_library {
             }
 
             return storage_size_in_bits;
+        }
+
+        template<typename F, typename M, typename Tp>
+        requires std::is_same_v<std::invoke_result_t<F, typename storage::const_reference>, Tp> &&
+            std::invocable<M, Tp, Tp>
+        Tp segment_handler(F &&handler, M &&merge) {
+            Tp merge_val{};
+            for (auto const &segment : inner_) {
+                std::invoke(std::forward<M>(merge)(
+                    merge_val,
+                    std::invoke(std::forward<F>(handler), segment)));
+            }
+
+            return merge_val;
+        }
+
+        [[nodiscard]] size_t countr_zero() const {
+            segment_handler([this](T const& segment) {
+                return bitset_op_cntl(&bitset::countr_zero, segment);
+            }, [](size_t const v1, size_t const v2) {
+                return v1 + v2;
+            });
+        }
+
+        [[nodiscard]] size_t countl_zero() const {
+            segment_handler([this](T const& segment) {
+                return bitset_op_cntl(&bitset::countl_zero, segment);
+            }, [](size_t const v1, size_t const v2) {
+                return v1 + v2;
+            });
+        }
+
+        [[nodiscard]] size_t countr_one() const {
+
+        }
+
+        [[nodiscard]] size_t countl_one() const {
+
         }
 
         constexpr iterator begin() {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -37,9 +37,9 @@ namespace dice::template_library {
      * The underlying mode to iterate over the storage
      * Used within the **bitset_iterator**
      */
-    struct bitset_const {
-        static constexpr size_t bit_mode = 0x00;
-        static constexpr size_t segment_mode = 0x01;
+    enum class bitset_mode : uint8_t {
+        BitMode = 0x00,
+        SegmentMode = 0x01,
     };
 
     /**
@@ -70,8 +70,9 @@ namespace dice::template_library {
      * @tparam extent extent of the bitset
      * @tparam segments max segments for the underlying bitset : use dynamic_extent to uncap limit
      */
-    template<typename T, size_t extent, size_t segments>
+    template<size_t extent, size_t segments, typename T = uint64_t>
     struct bitset {
+    private:
         static constexpr bool   has_storage_limit = segments != dynamic_extent;
         static constexpr size_t segment_size = sizeof(T);
         static constexpr size_t segment_align = alignof(T);
@@ -92,7 +93,6 @@ namespace dice::template_library {
         using storage_word_pointer = storage_word *;
         using storage_word_const_pointer = storage_word const *;
 
-    private:
         template<bool is_const>
         struct bitset_iterator {
         private:
@@ -177,9 +177,9 @@ namespace dice::template_library {
             }
 
             // shared iterator for mode=0 (bits) mode>=1 (segments)
-            template<size_t mode=bitset_const::bit_mode>
+            template<bitset_mode mode = bitset_mode::BitMode>
             bitset_iterator& operator++() noexcept {
-                if constexpr (mode == bitset_const::bit_mode) {
+                if constexpr (mode == bitset_mode::BitMode) {
                     if (++cur_offset_ >= segment_size_in_bits) {
                         ++cur_segment_;
                         cur_offset_ = 0;
@@ -191,9 +191,9 @@ namespace dice::template_library {
                 return *this;
             }
 
-            template<size_t mode=bitset_const::bit_mode>
+            template<bitset_mode mode = bitset_mode::BitMode>
             bitset_iterator& operator--() noexcept {
-                if constexpr (mode == bitset_const::bit_mode) {
+                if constexpr (mode == bitset_mode::BitMode) {
                     if (cur_offset_ == 0) {
                         --cur_segment_;
                         cur_offset_ = segment_size_in_bits-1;
@@ -206,21 +206,21 @@ namespace dice::template_library {
                 return *this;
             }
 
-            template<size_t mode=bitset_const::bit_mode>
+            template<bitset_mode mode = bitset_mode::BitMode>
             bitset_iterator operator++(int) noexcept {
                 auto tmp = *this;
                 operator++<mode>();
                 return tmp;
             }
 
-            template<size_t mode=bitset_const::bit_mode>
+            template<bitset_mode mode = bitset_mode::BitMode>
             bitset_iterator operator--(int) noexcept {
                 auto tmp = *this;
                 operator--<mode>();
                 return tmp;
             }
 
-            template<size_t mode=bitset_const::bit_mode>
+            template<bitset_mode mode = bitset_mode::BitMode>
             bitset_iterator& operator+=(size_t const skip) noexcept {
                 auto skip_handler = [this](size_t const skip_size) {
                     auto global_ix = calc_global_idx(cur_segment_, cur_offset_) + skip_size;
@@ -238,7 +238,7 @@ namespace dice::template_library {
                     cur_offset_ = offset;
                 };
 
-                if constexpr (mode == bitset_const::bit_mode) {
+                if constexpr (mode == bitset_mode::BitMode) {
                     skip_handler(skip);
                 }
                 else {
@@ -248,7 +248,7 @@ namespace dice::template_library {
                 return *this;
             }
 
-            template<size_t mode=bitset_const::bit_mode>
+            template<bitset_mode mode = bitset_mode::BitMode>
             bitset_iterator& operator-=(size_t const skip) noexcept {
                 auto skip_handler = [this](size_t const skip_size) {
                     auto global_ix = calc_global_idx(cur_segment_, cur_offset_);
@@ -262,7 +262,7 @@ namespace dice::template_library {
                     cur_offset_ = offset;
                 };
 
-                if constexpr (mode == bitset_const::bit_mode) {
+                if constexpr (mode == bitset_mode::BitMode) {
                     skip_handler(skip);
                 }
                 else {
@@ -310,9 +310,6 @@ namespace dice::template_library {
                 return it.consumed();
             }
         };
-
-        struct Set{};
-        struct Unset{};
 
         storage inner_;
 
@@ -520,8 +517,8 @@ namespace dice::template_library {
                 if (!std::invoke(std::forward<F>(handler), self_it.get(), outer_it.get())) {
                     return false;
                 }
-                self_it.template operator++<bitset_const::segment_mode>();
-                outer_it.template operator++<bitset_const::segment_mode>();
+                self_it.template operator++<bitset_mode::SegmentMode>();
+                outer_it.template operator++<bitset_mode::SegmentMode>();
             }
             return true;
         }
@@ -541,8 +538,8 @@ namespace dice::template_library {
                 if (!std::invoke(std::forward<F>(handler), self_it.get(), outer_it.get())) {
                     return false;
                 }
-                self_it.template operator++<bitset_const::segment_mode>();
-                outer_it.template operator++<bitset_const::segment_mode>();
+                self_it.template operator++<bitset_mode::SegmentMode>();
+                outer_it.template operator++<bitset_mode::SegmentMode>();
             }
             return true;
         }
@@ -556,7 +553,7 @@ namespace dice::template_library {
                 if (auto const val = std::invoke(std::forward<F>(handler), self_it.get()); !std::invoke(std::forward<Pr>(pred), val)) {
                     return false;
                 }
-                self_it.template operator++<bitset_const::segment_mode>();
+                self_it.template operator++<bitset_mode::SegmentMode>();
             }
             return true;
         }
@@ -574,7 +571,7 @@ namespace dice::template_library {
                 if (!std::invoke(std::forward<Pr>(pred), val)) {
                     return merge_val;
                 }
-                self_it.template operator++<bitset_const::segment_mode>();
+                self_it.template operator++<bitset_mode::SegmentMode>();
             }
             return merge_val;
         }
@@ -592,7 +589,7 @@ namespace dice::template_library {
                 if (!std::invoke(std::forward<Pr>(pred), val)) {
                     return merge_val;
                 }
-                self_it.template operator--<bitset_const::segment_mode>();
+                self_it.template operator--<bitset_mode::SegmentMode>();
             }
             return merge_val;
         }
@@ -744,9 +741,6 @@ namespace dice::template_library {
         using reverse_iterator = std::reverse_iterator<iterator>;
         using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-        static constexpr Set mode_set = Set{};
-        static constexpr Unset mode_unset = Unset{};
-
         /**
          * Initializes the bitset using an initializer list
          *
@@ -758,32 +752,10 @@ namespace dice::template_library {
          * Initializes the bitset using a given segment size
          * Requires the underlying storage to be uncapped
          *
-         * @param size segment size to set high
-         */
-        constexpr bitset(Set, size_t const size) requires(!has_storage_limit) : inner_{} {
-            inner_.resize(size);
-            auto it = begin();
-            auto it_end = end();
-
-            while (it != it_end) {
-                *it++ = true;
-            }
-        }
-
-        /**
-         * Initializes the bitset using a given segment size
-         * Requires the underlying storage to be uncapped
-         *
          * @param size segment size to set low
          */
-        constexpr bitset(Unset, size_t const size) requires(!has_storage_limit) : inner_{} {
+        explicit constexpr bitset(size_t const size) requires(!has_storage_limit) : inner_{} {
             inner_.resize(size);
-            auto it = begin();
-            auto it_end = end();
-
-            while (it != it_end) {
-                *it++ = false;
-            }
         }
 
         constexpr bitset(bitset const&) = default;
@@ -1061,7 +1033,7 @@ namespace dice::template_library {
             return *this;
         }
 
-        bitset& operator &=(bitset const& alt_storage) noexcept {
+        bitset& operator&=(bitset const& alt_storage) noexcept {
             segment_handler([this](typename storage::reference segment_first, typename storage::const_reference segment_second) {
                 slot_handler<bit_and_op>(segment_first, segment_second);
                 return true;
@@ -1069,7 +1041,7 @@ namespace dice::template_library {
             return *this;
         }
 
-        bitset& operator |=(bitset const& alt_storage) noexcept {
+        bitset& operator|=(bitset const& alt_storage) noexcept {
             segment_handler([this](typename storage::reference segment_first, typename storage::const_reference segment_second) {
                 slot_handler<bit_or_op>(segment_first, segment_second);
                 return true;
@@ -1089,58 +1061,22 @@ namespace dice::template_library {
             return tmp;
         }
 
-        bitset operator& (bitset const& bitset_v_second) const noexcept {
+        bitset operator&(bitset const& bitset_v_second) const noexcept {
             bitset tmp = *this;
             tmp &= bitset_v_second;
             return tmp;
         }
 
-        bitset operator| (bitset const& bitset_v_second) const noexcept {
+        bitset operator|(bitset const& bitset_v_second) const noexcept {
             bitset tmp = *this;
             tmp |= bitset_v_second;
             return tmp;
         }
     };
-
-    /**
-     * Initializes a static bitset using an initializer list of segment type size_t
-     * The resulting bitset has max capacity of segments
-     *
-     * @param list
-     * @return static bitset of type size_t
-     */
-    template<size_t segments>
-    static constexpr bitset<size_t, dynamic_extent, segments> create_bitset(std::initializer_list<size_t> const list) {
-        return bitset<size_t, dynamic_extent, segments>{list};
-    }
-
-    /**
-     * Initializes a static bitset using an initializer list of segment type T
-     * The resulting bitset has max capacity of segments
-     *
-     * @param list initializer list
-     * @return static bitset of type T
-     */
-    template<typename T, size_t segments>
-    static constexpr bitset<T, dynamic_extent, segments> create_bitset(std::initializer_list<T> const list) {
-        return bitset<T, dynamic_extent, segments>{list};
-    }
-
-    /**
-     * Initializes a dynamic bitset using an initializer list of segment type T
-     *
-     * @tparam T segment type
-     * @param list initializer list
-     * @return dynamic bitset of type T
-     */
-    template<typename T>
-    static constexpr bitset<T, dynamic_extent, dynamic_extent> create_bitset(std::initializer_list<T> const list) {
-        return bitset<T, dynamic_extent, dynamic_extent>{list};
-    }
 }
 
 template<typename T, size_t extent, size_t max_extent>
-struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
+struct std::formatter<dice::template_library::bitset<extent, max_extent, T>> {
     bool hex = false;
     bool debug = false;
     bool binary = false;
@@ -1168,7 +1104,7 @@ struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
         return it;
     }
 
-    auto format(dice::template_library::bitset<T, extent, max_extent> const& storage, std::format_context& ctx) const {
+    auto format(dice::template_library::bitset<extent, max_extent, T> const& storage, std::format_context& ctx) const {
         auto it = storage.begin();
         auto end = storage.end();
         auto segments = storage.size();
@@ -1207,7 +1143,7 @@ struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
                         out = std::format_to(out, "{:#0{}x}", *word, (storage.segment_align * 8) / 4);
                     }
                 }
-                it.template operator++<dice::template_library::bitset_const::segment_mode>();
+                it.template operator++<dice::template_library::bitset_mode::SegmentMode>();
             }
             else if (binary) {
                 for (auto segment_bit{0uz}; segment_bit < segment_size_in_bits; ++segment_bit) {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -10,10 +10,14 @@
 
 namespace dice::template_library {
 
+    ///> operation markers
     struct bit_and_op{};
     struct add_op{};
     struct bit_or_op{};
 
+    /**
+     * merge functor: merging the results of two expressions together
+     */
     template<typename Tp>
     struct merge_functor {
         Tp operator()(add_op, Tp const v1, Tp const v2) const noexcept {
@@ -29,11 +33,43 @@ namespace dice::template_library {
         };
     };
 
+    /**
+     * The underlying mode to iterate over the storage
+     * Used within the **bitset_iterator**
+     */
     struct bitset_const {
         static constexpr size_t bit_mode = 0x00;
         static constexpr size_t segment_mode = 0x01;
     };
 
+    /**
+     * A multi-type bitset supporting both dynamic and static growth.
+     * - Core operations: set(), test(), flip(), etc.
+     * - Queries: any_set(), none_set(), etc.
+     * - Standard bit operations
+     * - Iteration at bit and segment granularity
+     *
+     * The segment type isn't restricted to integral types — a custom type
+     * can be used as the internal segment representation.
+     *
+     * Examples:
+     *
+     * // Dynamic: grows automatically as needed
+     * bitset<std::uint8_t, std::dynamic_extent, std::dynamic_extent> b{0x12, 0x13, 0x14};
+     * b.set(4000uz);
+     *
+     * // Static: resizes within a fixed capacity, no growth
+     * bitset<std::uint8_t, std::dynamic_extent, 10> b{0x12, 0x13, 0x14};
+     * b.set(42uz);
+     *
+     * // Fixed: fixed size and storage
+     * bitset<std::uint8_t, 10, 10> b{0x12, 0x13, 0x14};
+     * b.set(42uz);
+     *
+     * @tparam T value type : any type is allowed as representation of the segment itself
+     * @tparam extent extent of the bitset
+     * @tparam segments max segments for the underlying bitset : use dynamic_extent to uncap limit
+     */
     template<typename T, size_t extent, size_t segments>
     struct bitset {
         static constexpr bool   has_storage_limit = segments != dynamic_extent;
@@ -49,6 +85,7 @@ namespace dice::template_library {
         using segment   = size_t;
         using offset    = size_t;
 
+        ///> word used for traversing the inner segment, instead of forcing 1 byte loads
         using storage_word = std::conditional_t<segment_align >= alignof(std::uint64_t), std::uint64_t,
             std::conditional_t<segment_align >= alignof(std::uint32_t), std::uint32_t,
             std::conditional_t<segment_align >= alignof(std::uint16_t), std::uint16_t, std::uint8_t>>>;
@@ -67,6 +104,7 @@ namespace dice::template_library {
             bitset_pointer const backing_bitset_;
 
         public:
+            ///> proxy for the current bit position
             struct bit_ref {
                 bitset_pointer backing_bitset_;
                 segment seg_;
@@ -79,8 +117,12 @@ namespace dice::template_library {
                 }
 
                 bit_ref const& operator=(bool const b) const noexcept {
-                    if (b) backing_bitset_->set(calc_global_idx(seg_, off_));
-                    else   backing_bitset_->unset(calc_global_idx(seg_, off_));
+                    if (b) {
+                        backing_bitset_->set(calc_global_idx(seg_, off_));
+                    }
+                    else {
+                        backing_bitset_->unset(calc_global_idx(seg_, off_));
+                    }
                     return *this;
                 }
             };
@@ -257,15 +299,12 @@ namespace dice::template_library {
             }
         };
 
-        struct AutoModeTag {};
-        struct DefaultModeTag {};
-
         struct Set{};
         struct Unset{};
 
         storage inner_;
 
-        [[nodiscard]] constexpr size_t require_segments(global_ix const ix) const requires (!has_storage_limit) {
+        [[nodiscard]] constexpr size_t require_segments(global_ix const ix) const requires (storage::has_dynamic_extent) {
             auto const bit_pos = bits_consumed();
             if (bit_pos > ix) {
                 return 0;
@@ -283,13 +322,18 @@ namespace dice::template_library {
             }();
         }
 
-        void constexpr expand_segments(global_ix const ix) requires (!has_storage_limit) {
+        void constexpr expand_segments(global_ix const ix) requires (storage::has_dynamic_extent) {
             auto const to_add = require_segments(ix);
             if (to_add == 0) {
                 return;
             }
 
-            inner_.resize(inner_.size() + to_add);
+            // zero init all underlying bits when expanding x segments
+            auto const old_size = inner_.size();
+            inner_.resize(old_size + to_add);
+            for (auto i{old_size}; i < inner_.size(); ++i) {
+                inner_[i] = T{};
+            }
         }
 
         [[nodiscard]] constexpr size_t bits_consumed() const noexcept {
@@ -327,13 +371,13 @@ namespace dice::template_library {
         }
 
         template<typename F>
-        auto bitset_mod_cntl(AutoModeTag, F&& ops, global_ix const ix) -> std::invoke_result_t<F, bitset*, size_t, size_t> {
+        auto bitset_mod_cntl(F&& ops, global_ix const ix) -> std::invoke_result_t<F, bitset*, size_t, size_t> {
             if (!fits_in_storage(ix)) {
                 throw std::out_of_range{"bitset::set: ix out of range"};
             }
 
-            // auto expands if we don't have storage limit
-            if constexpr (!has_storage_limit) {
+            // auto expands whenever the underlying storage can actually grow
+            if constexpr (storage::has_dynamic_extent) {
                 expand_segments(ix);
             }
 
@@ -343,24 +387,6 @@ namespace dice::template_library {
             using result_t = std::invoke_result_t<F, bitset*, size_t, size_t>;
 
             if constexpr (std::is_void_v<result_t>) {
-                std::invoke(std::forward<F>(ops), this, segment, offset);
-                return;
-            }
-            else {
-                return std::invoke(std::forward<F>(ops), this, segment, offset);
-            }
-        }
-
-        template<typename F>
-        auto bitset_mod_cntl(DefaultModeTag, F&& ops, global_ix const ix) -> std::invoke_result_t<F, bitset*, size_t, size_t> {
-            if (!fits_in_storage(ix)) {
-                throw std::out_of_range{"bitset::set: ix out of range"};
-            }
-
-            auto const segment = calc_which_segment(ix);
-            auto const offset  = calc_which_offset(ix);
-
-            if constexpr (std::is_void_v<std::invoke_result_t<F, bitset*, size_t, size_t>>) {
                 std::invoke(std::forward<F>(ops), this, segment, offset);
                 return;
             }
@@ -709,7 +735,19 @@ namespace dice::template_library {
         static constexpr Set mode_set = Set{};
         static constexpr Unset mode_unset = Unset{};
 
+        /**
+         * Initializes the bitset using an initializer list
+         *
+         * @param segment_v initializer list of segment type
+         */
         constexpr bitset(std::initializer_list<T> const segment_v) : inner_{segment_v} {}
+
+        /**
+         * Initializes the bitset using a given segment size
+         * Requires the underlying storage to be uncapped
+         *
+         * @param size segment size to set high
+         */
         constexpr bitset(Set, size_t const size) requires(!has_storage_limit) : inner_{} {
             inner_.resize(size);
             auto it = begin();
@@ -719,6 +757,13 @@ namespace dice::template_library {
                 *it++ = true;
             }
         }
+
+        /**
+         * Initializes the bitset using a given segment size
+         * Requires the underlying storage to be uncapped
+         *
+         * @param size segment size to set low
+         */
         constexpr bitset(Unset, size_t const size) requires(!has_storage_limit) : inner_{} {
             inner_.resize(size);
             auto it = begin();
@@ -735,6 +780,11 @@ namespace dice::template_library {
         constexpr bitset &operator=(bitset &&) = default;
         constexpr ~bitset() = default;
 
+        /**
+         * Get word pointers for the corresponding segment
+         *
+         * @return a pair containing word pointers to both segment ends (start, end)
+         */
         [[nodiscard]] std::pair<storage_word_const_pointer, storage_word_const_pointer> segment_slots(storage::const_reference segment) const noexcept {
             auto word = reinterpret_cast<storage_word_const_pointer>(&segment);
             auto const end = word + segment_steps;
@@ -742,6 +792,11 @@ namespace dice::template_library {
             return std::pair{word, end};
         }
 
+        /**
+         * Get word pointers for the corresponding segment
+         *
+         * @return a pair containing word pointers to both segment ends (start, end)
+         */
         [[nodiscard]] std::pair<storage_word_pointer, storage_word_pointer> segment_slots(storage::reference segment) const noexcept {
             auto word = reinterpret_cast<storage_word_pointer>(&segment);
             auto const end = word + segment_steps;
@@ -749,18 +804,32 @@ namespace dice::template_library {
             return std::pair{word, end};
         }
 
+        /**
+         * Set a bit high for offset ix
+         */
         void set(global_ix const ix) {
-            bitset_mod_cntl(AutoModeTag{}, &bitset::segment_set, ix);
+            bitset_mod_cntl(&bitset::segment_set, ix);
         }
 
+        /**
+         * Flip a bit for offset ix
+         */
         void flip(global_ix const ix) {
-            bitset_mod_cntl(AutoModeTag{}, &bitset::segment_flip, ix);
+            bitset_mod_cntl(&bitset::segment_flip, ix);
         }
 
+        /**
+         * Set a bit low for offset ix
+         */
         void unset(global_ix const ix) {
-            bitset_mod_cntl(AutoModeTag{}, &bitset::segment_unset, ix);
+            bitset_mod_cntl(&bitset::segment_unset, ix);
         }
 
+        /**
+         * Test a bit (low, high) for offset ix
+         *
+         * @return bool indicating the state of ix
+         */
         [[nodiscard]] bool test(global_ix const ix) const {
             if (!fits_in_storage(ix)) {
                 throw std::out_of_range{"bitset::set: ix out of range"};
@@ -771,12 +840,22 @@ namespace dice::template_library {
             return segment_test(segment, offset);
         }
 
+        /**
+         * Counts the total bits set
+         *
+         * @return total bits set
+         */
         [[nodiscard]] size_t count() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_count, segment);
             }, merge_functor<size_t>{}, 0uz, add_op{});
         }
 
+        /**
+         * Sets the first bit high, and returns the corresponding index
+         *
+         * @return ix to first free index in bitset (if there is no free index, storage_size_in_bits is returned)
+         */
         [[nodiscard]] size_t set_first_free() {
             for (auto &segment : inner_) {
                 auto offset = bitset_op_cntl(&bitset::segment_free, segment);
@@ -809,6 +888,11 @@ namespace dice::template_library {
             return storage_size_in_bits;
         }
 
+        /**
+         * Counts consecutive zeros starting from LSB
+         *
+         * @return ix to non-zero entry
+         */
         [[nodiscard]] size_t countr_zero() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_countr_zero, segment);
@@ -817,6 +901,11 @@ namespace dice::template_library {
             }, merge_functor<size_t>{}, 0, add_op{});
         }
 
+        /**
+         * Counts consecutive zeros starting from MSB
+         *
+         * @return ix to non-zero entry
+         */
         [[nodiscard]] size_t countl_zero() const {
             return segment_handler_backwards([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_countl_zero, segment);
@@ -825,6 +914,11 @@ namespace dice::template_library {
             }, merge_functor<size_t>{}, 0, add_op{});
         }
 
+        /**
+         * Counts consecutive zeros starting from LSB
+         *
+         * @return ix to zero entry
+         */
         [[nodiscard]] size_t countr_one() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_countr_one, segment);
@@ -833,6 +927,11 @@ namespace dice::template_library {
             }, merge_functor<size_t>{}, 0, add_op{});
         }
 
+        /**
+         * Counts consecutive ones starting from MSB
+         *
+         * @return ix to zero entry
+         */
         [[nodiscard]] size_t countl_one() const {
             return segment_handler_backwards([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_countl_one, segment);
@@ -841,6 +940,11 @@ namespace dice::template_library {
             }, merge_functor<size_t>{}, 0, add_op{});
         }
 
+        /**
+         * Returns a bool indicating if all bits are set or not
+         *
+         * @return queried state
+         */
         [[nodiscard]] bool all_set() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_all_set, segment);
@@ -849,12 +953,22 @@ namespace dice::template_library {
             });
         }
 
+        /**
+         * Returns a bool indicating if any bit is set
+         *
+         * @return queried state
+         */
         [[nodiscard]] bool any_set() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_any_set, segment);
             }, merge_functor<bool>{}, false, bit_or_op{});
         }
 
+        /**
+         * Returns a bool indicating if no bit is set
+         *
+         * @return queried state
+         */
         [[nodiscard]] bool none_set() const {
             return segment_handler([this](typename storage::const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_none_set, segment);
@@ -895,6 +1009,11 @@ namespace dice::template_library {
             return inner_.size();
         }
 
+        /**
+         * Returns consumed bits in bits
+         *
+         * @return consumed bits
+         */
         constexpr size_t size_in_bits() const noexcept {
             return size() * segment_size_in_bits;
         }
@@ -903,6 +1022,11 @@ namespace dice::template_library {
             return segment_size;
         }
 
+        /**
+         * Returns the per segment size in bits
+         *
+         * @return size in bits
+         */
         static constexpr size_t inner_size_in_bits() noexcept {
             return segment_size_in_bits;
         }
@@ -966,20 +1090,37 @@ namespace dice::template_library {
         }
     };
 
-    static constexpr bitset<size_t, dynamic_extent, dynamic_extent> create_bitset(std::initializer_list<size_t> const list) {
-        return bitset<size_t, dynamic_extent, dynamic_extent>{list};
+    /**
+     * Initializes a static bitset using an initializer list of segment type size_t
+     * The resulting bitset has max capacity of segments
+     *
+     * @param list
+     * @return static bitset of type size_t
+     */
+    template<size_t segments>
+    static constexpr bitset<size_t, dynamic_extent, segments> create_bitset(std::initializer_list<size_t> const list) {
+        return bitset<size_t, dynamic_extent, segments>{list};
     }
 
-    template<size_t bits>
-    static constexpr bitset<size_t, dynamic_extent, bits> create_bitset(std::initializer_list<size_t> const list) {
-        return bitset<size_t, dynamic_extent, bits>{list};
+    /**
+     * Initializes a static bitset using an initializer list of segment type T
+     * The resulting bitset has max capacity of segments
+     *
+     * @param list initializer list
+     * @return static bitset of type T
+     */
+    template<typename T, size_t segments>
+    static constexpr bitset<T, dynamic_extent, segments> create_bitset(std::initializer_list<T> const list) {
+        return bitset<T, dynamic_extent, segments>{list};
     }
 
-    template<typename T, size_t bits>
-    static constexpr bitset<T, dynamic_extent, bits> create_bitset(std::initializer_list<T> const list) {
-        return bitset<T, dynamic_extent, bits>{list};
-    }
-
+    /**
+     * Initializes a dynamic bitset using an initializer list of segment type T
+     *
+     * @tparam T segment type
+     * @param list initializer list
+     * @return dynamic bitset of type T
+     */
     template<typename T>
     static constexpr bitset<T, dynamic_extent, dynamic_extent> create_bitset(std::initializer_list<T> const list) {
         return bitset<T, dynamic_extent, dynamic_extent>{list};
@@ -992,6 +1133,7 @@ struct std::formatter<dice::template_library::bitset<T, extent, max_extent>> {
     bool debug = false;
     bool binary = false;
 
+    ///> parse formatter context, only allowing hex, debug and binary symbol
     constexpr auto parse(std::format_parse_context& ctx) {
         auto it = ctx.begin();
         while (it != ctx.end() && *it != '}') {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -45,25 +45,32 @@ namespace dice::template_library {
      * - Queries: any_set(), none_set(), etc.
      * - Standard bit operations
      * - Iteration at bit and segment granularity
+     * - Positional Iteration
      *
-     * The segment type isn't restricted to integral types — a custom type
-     * can be used as the internal segment representation.
+     * The storage type isn't restricted to integral types — a custom type
+     * can be used as the internal storage representation.
      *
      * Examples:
      *
      * // Dynamic: grows automatically as needed
-     * bitset<std::uint8_t, std::dynamic_extent, std::dynamic_extent> b{0x12, 0x13, 0x14};
+     * bitset<std::dynamic_extent, std::dynamic_extent, std::uint8_t> b{0x12, 0x13, 0x14};
      * b.set(4000uz);
      *
      * // Static: resizes within a fixed capacity, no growth
-     * bitset<std::uint8_t, std::dynamic_extent, 10> b{0x12, 0x13, 0x14};
+     * bitset<std::dynamic_extent, 10, std::uint8_t> b{0x12, 0x13, 0x14};
      * b.set(42uz);
      *
      * // Fixed: fixed size and storage
-     * bitset<std::uint8_t, 10, 10> b{0x12, 0x13, 0x14};
+     * bitset<10, 10, std::uint8_t> b{0x12, 0x13, 0x14};
      * b.set(42uz);
      *
-     * @tparam T value type : any type is allowed as representation of the segment itself
+     * // Default type: (Dynamic)
+     * bitset<std::dynamic_extent, std::dynamic_extent> ...
+     *
+     * // Default type: (Static)
+     * bitset<10, 10> ...
+     *
+     * @tparam T value type : any type is allowed as representation of the underlying storage
      * @tparam extent extent of the bitset
      * @tparam bits minimal bits for the underlying bitset : use dynamic_extent to uncap limit
      */

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -961,6 +961,9 @@ namespace dice::template_library {
             return segment_handler([this](const_reference segment) {
                 return bitset_op_cntl(DICE_MEMFN(segment_any_set), segment);
             },
+                                   [](bool const val) { // only terminate if we find a bit set
+                                       return !val;
+                                   },
                                    std::bit_or<bool>{},
                                    false);
         }

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -508,10 +508,6 @@ namespace dice::template_library {
             return *(inner_.data() + s) & 1uz << o;
         }
 
-        [[nodiscard]] size_t segment_count(const_reference segment) const noexcept {
-            return std::popcount(segment);
-        }
-
         template<typename F, typename M, typename Tp>
         requires std::is_same_v<std::invoke_result_t<F, const_reference>, Tp> &&
             std::invocable<M, Tp, Tp>
@@ -638,36 +634,16 @@ namespace dice::template_library {
             return merge_val;
         }
 
-        [[nodiscard]] size_t segment_free(const_reference segment) const {
-            return std::countr_zero(static_cast<value_type>(~segment));
-        }
-
-        [[nodiscard]] size_t segment_countl_zero(const_reference segment) const noexcept {
-            return std::countl_zero(segment);
-        }
-
-        [[nodiscard]] size_t segment_countr_zero(const_reference segment) const noexcept {
-            return std::countr_zero(segment);
-        }
-
-        [[nodiscard]] size_t segment_countl_one(const_reference segment) const noexcept {
-            return std::countl_one(segment);
-        }
-
-        [[nodiscard]] size_t segment_countr_one(const_reference segment) const noexcept {
-            return std::countr_one(segment);
-        }
-
         [[nodiscard]] bool segment_all_set(const_reference segment) const noexcept {
-            return segment_count(segment) == segment_size_in_bits;
+            return std::popcount(segment) == segment_size_in_bits;
         }
 
         [[nodiscard]] bool segment_any_set(const_reference segment) const noexcept {
-            return segment_count(segment) != 0;
+            return std::popcount(segment) != 0x00;
         }
 
         [[nodiscard]] bool segment_none_set(const_reference segment) const noexcept {
-            return segment_count(segment) == 0x00;
+            return std::popcount(segment) == 0x00;
         }
 
         template<typename F>
@@ -813,8 +789,8 @@ namespace dice::template_library {
          * @return total bits set
          */
         [[nodiscard]] size_t count() const {
-            return segment_handler([this](const_reference segment) {
-                return bitset_op_cntl(&bitset::segment_count, segment);
+            return segment_handler([](const_reference segment) -> size_t {
+                return std::popcount(segment);
             }, std::plus<size_t>{}, 0uz);
         }
 
@@ -825,7 +801,7 @@ namespace dice::template_library {
          */
         [[nodiscard]] size_t set_first_free() {
             for (auto &segment : inner_) {
-                auto offset = bitset_op_cntl(&bitset::segment_free, segment);
+                auto offset = std::countr_zero(static_cast<value_type>(~segment));
 
                 if (offset != segment_size_in_bits) {
                     auto seg = std::distance(inner_.data(), &segment);
@@ -861,8 +837,8 @@ namespace dice::template_library {
          * @return ix to non-zero entry
          */
         [[nodiscard]] size_t countr_zero() const {
-            return segment_handler([this](const_reference segment) {
-                return bitset_op_cntl(&bitset::segment_countr_zero, segment);
+            return segment_handler([](const_reference segment) {
+                return std::countr_zero(segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;
             }, std::plus<size_t>{}, 0uz);
@@ -874,8 +850,8 @@ namespace dice::template_library {
          * @return ix to non-zero entry
          */
         [[nodiscard]] size_t countl_zero() const {
-            return segment_handler_backwards([this](const_reference segment) {
-                return bitset_op_cntl(&bitset::segment_countl_zero, segment);
+            return segment_handler_backwards([](const_reference segment) {
+                return std::countl_zero(segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;
             }, std::plus<size_t>{}, 0uz);
@@ -887,8 +863,8 @@ namespace dice::template_library {
          * @return ix to zero entry
          */
         [[nodiscard]] size_t countr_one() const {
-            return segment_handler([this](const_reference segment) {
-                return bitset_op_cntl(&bitset::segment_countr_one, segment);
+            return segment_handler([](const_reference segment) {
+                return std::countr_one(segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;
             }, std::plus<size_t>{}, 0uz);
@@ -900,8 +876,8 @@ namespace dice::template_library {
          * @return ix to zero entry
          */
         [[nodiscard]] size_t countl_one() const {
-            return segment_handler_backwards([this](const_reference segment) {
-                return bitset_op_cntl(&bitset::segment_countl_one, segment);
+            return segment_handler_backwards([](const_reference segment) {
+                return std::countl_one(segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;
             }, std::plus<size_t>{}, 0uz);

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -529,9 +529,10 @@ namespace dice::template_library {
             return *(inner_.data() + s) & T{1} << o;
         }
 
+        ///> folds across every segment via merge, no early exit
         template<typename F, typename M, typename Tp>
         requires std::is_same_v<std::invoke_result_t<F, segment_const_reference>, Tp> && std::invocable<M, Tp, Tp>
-        [[nodiscard]] Tp segment_handler(F &&handler, M &&merge, Tp initial) const {
+        [[nodiscard]] Tp segments_reduce(F &&handler, M &&merge, Tp initial) const {
             Tp merge_val{initial};
             for (auto const &segment : inner_) {
                 merge_val = std::invoke(std::forward<M>(merge), merge_val, std::invoke(std::forward<F>(handler), segment));
@@ -540,8 +541,9 @@ namespace dice::template_library {
             return merge_val;
         }
 
+        ///> in-place unary transform
         template<typename Ops>
-        void segment_handler() {
+        void segments_transform() {
             auto self_it = begin<bitset_mode::SegmentMode>();
             auto end_sentinel = end();
 
@@ -554,8 +556,9 @@ namespace dice::template_library {
             }
         }
 
+        ///> in-place binary transform
         template<typename Ops>
-        void segment_handler(bitset const &other) {
+        void segments_transform_with(bitset const &other) {
             auto self_it = begin<bitset_mode::SegmentMode>();
             auto outer_it = other.begin<bitset_mode::SegmentMode>();
             auto ops = Ops{};
@@ -574,8 +577,9 @@ namespace dice::template_library {
             }
         }
 
+        ///> true iff sizes match and handler(seg_this, seg_other) holds for every segment pair
         template<typename F>
-        bool segment_handler(F &&handler, bitset const &other) {
+        bool segments_pairwise_all_of(F &&handler, bitset const &other) const {
             auto self_it = begin<bitset_mode::SegmentMode>();
             auto outer_it = other.begin<bitset_mode::SegmentMode>();
 
@@ -595,29 +599,9 @@ namespace dice::template_library {
             return true;
         }
 
-        template<typename F>
-        bool segment_handler(F &&handler, bitset const &other) const {
-            auto self_it = begin<bitset_mode::SegmentMode>();
-            auto outer_it = other.begin<bitset_mode::SegmentMode>();
-
-            if (size() != other.size()) {
-                return false;
-            }
-
-            auto end_sentinel = end();
-
-            while (self_it != end_sentinel) {
-                if (!std::invoke(std::forward<F>(handler), self_it.get(), outer_it.get())) {
-                    return false;
-                }
-                ++self_it;
-                ++outer_it;
-            }
-            return true;
-        }
-
+        ///> true iff pred(handler(segment)) holds for every segment, early-exit on the first failure
         template<typename F, typename Pr>
-        bool segment_handler(F &&handler, Pr &&pred) const {
+        bool segments_all_of(F &&handler, Pr &&pred) const {
             auto self_it = begin<bitset_mode::SegmentMode>();
             auto end_sentinel = end();
 
@@ -630,8 +614,9 @@ namespace dice::template_library {
             return true;
         }
 
+        ///> folds handler(segment) across every segment, stopping early once pred(val) fails
         template<typename F, typename Pr, typename M, typename Tp>
-        Tp segment_handler(F &&handler, Pr &&pred, M &&merge, Tp initial) const {
+        Tp segments_reduce_while(F &&handler, Pr &&pred, M &&merge, Tp initial) const {
             auto self_it = begin<bitset_mode::SegmentMode>();
             auto end_sentinel = end();
 
@@ -648,8 +633,9 @@ namespace dice::template_library {
             return merge_val;
         }
 
+        ///> same as segments_reduce_while, but iterates segments in reverse order
         template<typename F, typename Pr, typename M, typename Tp>
-        Tp segment_handler_backwards(F &&handler, Pr &&pred, M &&merge, Tp initial) const {
+        Tp segments_reduce_while_reverse(F &&handler, Pr &&pred, M &&merge, Tp initial) const {
             auto self_it = rbegin<bitset_mode::SegmentMode>();
             auto end_it = rend<bitset_mode::SegmentMode>();
 
@@ -846,7 +832,7 @@ namespace dice::template_library {
          * @return total bits set
          */
         [[nodiscard]] size_t count() const {
-            return segment_handler([](segment_const_reference segment) -> size_t {
+            return segments_reduce([](segment_const_reference segment) -> size_t {
                 return std::popcount(segment);
             },
                                    std::plus<size_t>{},
@@ -895,7 +881,7 @@ namespace dice::template_library {
          * @return ix to non-zero entry
          */
         [[nodiscard]] size_t countr_zero() const {
-            return segment_handler([](segment_const_reference segment) {
+            return segments_reduce_while([](segment_const_reference segment) {
                 return std::countr_zero(segment);
             },
                                    [](size_t const val) {
@@ -911,7 +897,7 @@ namespace dice::template_library {
          * @return ix to non-zero entry
          */
         [[nodiscard]] size_t countl_zero() const {
-            return segment_handler_backwards([](segment_const_reference segment) {
+            return segments_reduce_while_reverse([](segment_const_reference segment) {
                 return std::countl_zero(segment);
             },
                                              [](size_t const val) {
@@ -927,7 +913,7 @@ namespace dice::template_library {
          * @return ix to zero entry
          */
         [[nodiscard]] size_t countr_one() const {
-            return segment_handler([](segment_const_reference segment) {
+            return segments_reduce_while([](segment_const_reference segment) {
                 return std::countr_one(segment);
             },
                                    [](size_t const val) {
@@ -943,7 +929,7 @@ namespace dice::template_library {
          * @return ix to zero entry
          */
         [[nodiscard]] size_t countl_one() const {
-            return segment_handler_backwards([](segment_const_reference segment) {
+            return segments_reduce_while_reverse([](segment_const_reference segment) {
                 return std::countl_one(segment);
             },
                                              [](size_t const val) {
@@ -959,7 +945,7 @@ namespace dice::template_library {
          * @return queried state
          */
         [[nodiscard]] bool all_set() const {
-            return segment_handler([this](segment_const_reference segment) {
+            return segments_all_of([this](segment_const_reference segment) {
                 return DICE_MEMFN(segment_all_set)(segment);
             },
                                    [](bool const val) {
@@ -973,7 +959,7 @@ namespace dice::template_library {
          * @return queried state
          */
         [[nodiscard]] bool any_set() const {
-            return segment_handler([this](segment_const_reference segment) {
+            return segments_reduce_while([this](segment_const_reference segment) {
                 return DICE_MEMFN(segment_any_set)(segment);
             },
                                    [](bool const val) { // only terminate if we find a bit set
@@ -989,7 +975,7 @@ namespace dice::template_library {
          * @return queried state
          */
         [[nodiscard]] bool none_set() const {
-            return segment_handler([this](segment_const_reference segment) {
+            return segments_reduce_while([this](segment_const_reference segment) {
                 return DICE_MEMFN(segment_none_set)(segment);
             },
                                    [](bool const val) {
@@ -1108,7 +1094,7 @@ namespace dice::template_library {
         }
 
         bool operator==(bitset const &alt_storage) const noexcept {
-            return segment_handler([](segment_const_reference segment_first, segment_const_reference segment_second) {
+            return segments_pairwise_all_of([](segment_const_reference segment_first, segment_const_reference segment_second) {
                 return segment_first == segment_second;
             },
                                    alt_storage);
@@ -1131,7 +1117,7 @@ namespace dice::template_library {
                 throw std::logic_error("bitset:: bitset size not match");
             }
 
-            segment_handler<std::bit_and<T>>(alt_storage);
+            segments_transform_with<std::bit_and<T>>(alt_storage);
             return *this;
         }
 
@@ -1140,7 +1126,7 @@ namespace dice::template_library {
                 throw std::logic_error("bitset:: bitset size not match");
             }
 
-            segment_handler<std::bit_or<T>>(alt_storage);
+            segments_transform_with<std::bit_or<T>>(alt_storage);
             return *this;
         }
 
@@ -1149,7 +1135,7 @@ namespace dice::template_library {
                 throw std::logic_error("bitset:: bitset size not match");
             }
 
-            segment_handler<std::bit_xor<T>>(alt_storage);
+            segments_transform_with<std::bit_xor<T>>(alt_storage);
             return *this;
         }
 
@@ -1197,7 +1183,7 @@ namespace dice::template_library {
 
         bitset operator~() const {
             bitset tmp = *this;
-            tmp.segment_handler<std::negate<T>>();
+            tmp.segments_transform<std::negate<T>>();
             return tmp;
         }
     };

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -62,6 +62,12 @@ namespace dice::template_library {
         using reference  = storage::reference;
         using const_reference = storage::const_reference;
 
+        ///> mode to be used for the underlying iterator - make caller enforce policy
+        enum class bitset_mode : uint8_t {
+            BitMode = 0x00,
+            SegmentMode = 0x01,
+        };
+
     private:
         static constexpr bool   has_max_extent = storage::has_max_extent;
         static constexpr bool   has_dynamic_extent = storage::has_dynamic_extent;
@@ -71,12 +77,7 @@ namespace dice::template_library {
         static constexpr size_t storage_size = !has_max_extent ? dynamic_extent : segment_size * segments;
         static constexpr size_t storage_size_in_bits = !has_max_extent ? dynamic_extent : storage_size * 8;
 
-        enum class bitset_mode : uint8_t {
-            BitMode = 0x00,
-            SegmentMode = 0x01,
-        };
-
-        template<bool is_const>
+        template<bool is_const, bitset_mode mode = bitset_mode::BitMode>
         struct bitset_iterator {
         private:
             using bitset_pointer = std::conditional_t<is_const, bitset const*, bitset*>;
@@ -166,7 +167,6 @@ namespace dice::template_library {
             }
 
             // shared iterator for mode=0 (bits) mode>=1 (segments)
-            template<bitset_mode mode = bitset_mode::BitMode>
             bitset_iterator& operator++() noexcept {
                 if constexpr (mode == bitset_mode::BitMode) {
                     if (++cur_offset_ >= segment_size_in_bits) {
@@ -180,7 +180,6 @@ namespace dice::template_library {
                 return *this;
             }
 
-            template<bitset_mode mode = bitset_mode::BitMode>
             bitset_iterator& operator--() noexcept {
                 if constexpr (mode == bitset_mode::BitMode) {
                     if (cur_offset_ == 0) {
@@ -195,24 +194,21 @@ namespace dice::template_library {
                 return *this;
             }
 
-            template<bitset_mode mode = bitset_mode::BitMode>
             bitset_iterator operator++(int) noexcept {
                 auto tmp = *this;
-                operator++<mode>();
+                operator++();
                 return tmp;
             }
 
-            template<bitset_mode mode = bitset_mode::BitMode>
             bitset_iterator operator--(int) noexcept {
                 auto tmp = *this;
-                operator--<mode>();
+                operator--();
                 return tmp;
             }
 
-            template<bitset_mode mode = bitset_mode::BitMode>
             bitset_iterator& operator+=(difference_type const skip) noexcept {
                 if (skip < 0) {
-                    return operator-=<mode>(-skip);
+                    return operator-=(-skip);
                 }
 
                 assert(skip >= 0);
@@ -243,10 +239,9 @@ namespace dice::template_library {
                 return *this;
             }
 
-            template<bitset_mode mode = bitset_mode::BitMode>
             bitset_iterator& operator-=(difference_type const skip) noexcept {
                 if (skip < 0) {
-                    return operator+=<mode>(-skip);
+                    return operator+=(-skip);
                 }
 
                 assert(skip >= 0);
@@ -335,13 +330,13 @@ namespace dice::template_library {
             }
         };
 
-        template<bool is_const>
+        template<bool is_const, bitset_mode mode>
         struct position_iterator {
         private:
             using bitset_pointer = std::conditional_t<is_const, bitset const*, bitset*>;
             using reference = bitset_iterator<is_const>::reference;
 
-            bitset_iterator<is_const> it_;
+            bitset_iterator<is_const, mode> it_;
             bitset_pointer backing_bitset_ = nullptr;
 
             ///> add bool to allow setting a start point, without skipping the initial offset
@@ -511,8 +506,7 @@ namespace dice::template_library {
             using result_t = std::invoke_result_t<F, bitset*, size_t, size_t>;
 
             if constexpr (std::is_void_v<result_t>) {
-                std::invoke(std::forward<F>(ops), this, segment, offset);
-                return;
+                return std::invoke(std::forward<F>(ops), this, segment, offset);
             }
             else {
                 return std::invoke(std::forward<F>(ops), this, segment, offset);
@@ -569,8 +563,8 @@ namespace dice::template_library {
 
         template<typename Ops>
         void segment_handler(bitset const &other) {
-            auto self_it = begin();
-            auto outer_it = other.begin();
+            auto self_it = begin<bitset_mode::SegmentMode>();
+            auto outer_it = other.begin<bitset_mode::SegmentMode>();
             auto ops = Ops{};
 
             if (size() != other.size()) {
@@ -583,15 +577,15 @@ namespace dice::template_library {
                 auto &seg_this = self_it.get(); auto &seg_other = outer_it.get();
                 seg_this = ops(seg_this, seg_other);
 
-                self_it = advance_segment(self_it);
-                outer_it = advance_segment(outer_it);
+                ++self_it;
+                ++outer_it;
             }
         }
 
         template<typename F>
         bool segment_handler(F &&handler, bitset const &other) {
-            auto self_it = begin();
-            auto outer_it = other.begin();
+            auto self_it = begin<bitset_mode::SegmentMode>();
+            auto outer_it = other.begin<bitset_mode::SegmentMode>();
 
             if (size() != other.size()) {
                 return false;
@@ -603,16 +597,16 @@ namespace dice::template_library {
                 if (!std::invoke(std::forward<F>(handler), self_it.get(), outer_it.get())) {
                     return false;
                 }
-                self_it = advance_segment(self_it);
-                outer_it = advance_segment(outer_it);
+                ++self_it;
+                ++outer_it;
             }
             return true;
         }
 
         template<typename F>
         bool segment_handler(F &&handler, bitset const &other) const {
-            auto self_it = begin();
-            auto outer_it = other.begin();
+            auto self_it = begin<bitset_mode::SegmentMode>();
+            auto outer_it = other.begin<bitset_mode::SegmentMode>();
 
             if (size() != other.size()) {
                 return false;
@@ -624,29 +618,29 @@ namespace dice::template_library {
                 if (!std::invoke(std::forward<F>(handler), self_it.get(), outer_it.get())) {
                     return false;
                 }
-                self_it = advance_segment(self_it);
-                outer_it = advance_segment(outer_it);
+                ++self_it;
+                ++outer_it;
             }
             return true;
         }
 
         template<typename F, typename Pr>
         bool segment_handler(F &&handler, Pr &&pred) const {
-            auto self_it = begin();
+            auto self_it = begin<bitset_mode::SegmentMode>();
             auto end_sentinel = end();
 
             while (self_it != end_sentinel) {
                 if (auto const val = std::invoke(std::forward<F>(handler), self_it.get()); !std::invoke(std::forward<Pr>(pred), val)) {
                     return false;
                 }
-                self_it = advance_segment(self_it);
+                ++self_it;
             }
             return true;
         }
 
         template<typename F, typename Pr, typename M, typename Tp>
         Tp segment_handler(F &&handler, Pr &&pred, M &&merge, Tp initial) const {
-            auto self_it = begin();
+            auto self_it = begin<bitset_mode::SegmentMode>();
             auto end_sentinel = end();
 
             Tp merge_val{initial};
@@ -657,15 +651,15 @@ namespace dice::template_library {
                 if (!std::invoke(std::forward<Pr>(pred), val)) {
                     return merge_val;
                 }
-                self_it = advance_segment(self_it);
+                ++self_it;
             }
             return merge_val;
         }
 
         template<typename F, typename Pr, typename M, typename Tp>
         Tp segment_handler_backwards(F &&handler, Pr &&pred, M &&merge, Tp initial) const {
-            auto self_it = begin() + size_in_bits();
-            auto end_it = begin();
+            auto self_it = begin<bitset_mode::SegmentMode>() + size();
+            auto end_it = begin<bitset_mode::SegmentMode>();
 
             Tp merge_val{initial};
 
@@ -675,7 +669,7 @@ namespace dice::template_library {
                 if (!std::invoke(std::forward<Pr>(pred), val)) {
                     return merge_val;
                 }
-                self_it = advance_segment_backwards(self_it);
+                --self_it;
             }
             return merge_val;
         }
@@ -699,12 +693,30 @@ namespace dice::template_library {
         }
 
     public:
-        using iterator = bitset_iterator<false>;
-        using const_iterator = bitset_iterator<true>;
-        using reverse_iterator = std::reverse_iterator<iterator>;
-        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-        using positional_iterator = position_iterator<false>;
-        using const_positional_iterator = position_iterator<true>;
+        template<bitset_mode mode>
+        using iterator = bitset_iterator<false, mode>;
+
+        template<bitset_mode mode>
+        using const_iterator = bitset_iterator<true, mode>;
+
+        template<bitset_mode mode>
+        using reverse_iterator = std::reverse_iterator<iterator<mode>>;
+
+        template<bitset_mode mode>
+        using const_reverse_iterator = std::reverse_iterator<const_iterator<mode>>;
+
+        template<bitset_mode mode>
+        using positional_iterator = position_iterator<false, mode>;
+
+        template<bitset_mode mode>
+        using const_positional_iterator = position_iterator<true, mode>;
+
+        using bit_iterator     = iterator<bitset_mode::BitMode>;
+        using segment_iterator = iterator<bitset_mode::SegmentMode>;
+
+        using const_bit_iterator = const_iterator<bitset_mode::BitMode>;
+        using const_segment_iterator = const_iterator<bitset_mode::SegmentMode>;
+        
 
         /**
          * Initializes the bitset using an initializer list
@@ -798,8 +810,8 @@ namespace dice::template_library {
          * Compacts the underlying storage backend, if applicable
          */
         void shrink_to_fit() requires (has_dynamic_extent){
-            auto it = begin() + size_in_bits();
-            auto end = begin();
+            auto it = begin<bitset_mode::SegmentMode>() + size();
+            auto end = begin<bitset_mode::SegmentMode>();
 
             while (it != end) {
                 auto &segment = (it - 1).get();
@@ -813,7 +825,7 @@ namespace dice::template_library {
                     }
                     return;
                 }
-                it = advance_segment_backwards(it);
+                --it;
             }
         }
 
@@ -989,98 +1001,48 @@ namespace dice::template_library {
             });
         }
 
-        /**
-         * Returns updated iterator advanced by one segment
-         *
-         * @param it bitset iterator
-         * @return iterator advanced by one segment
-         */
-        static iterator advance_segment(iterator it) {
-            return it.template operator++<bitset_mode::SegmentMode>();
+        template<bitset_mode mode=bitset_mode::BitMode>
+        constexpr iterator<mode> begin() noexcept {
+            return iterator<mode>{*this};
         }
 
-        static const_iterator advance_segment(const_iterator it) {
-            return it.template operator++<bitset_mode::SegmentMode>();
+        template<bitset_mode mode=bitset_mode::BitMode>
+        constexpr const_iterator<mode> begin() const noexcept {
+            return const_iterator<mode>{*this};
         }
 
-        /**
-         * Returns updated iterator advanced by skip segments
-         *
-         * @param it bitset iterator
-         * @param skip segments to skip
-         * @return iterator advanced by skip segments
-         */
-        static iterator advance_segment(iterator it, size_t const skip) {
-            return it.template operator+=<bitset_mode::SegmentMode>(skip);
+        template<bitset_mode mode=bitset_mode::BitMode>
+        constexpr reverse_iterator<mode> rbegin() noexcept {
+            return reverse_iterator<mode>{begin() + size_in_bits()};
         }
 
-        static const_iterator advance_segment(const_iterator it, size_t const skip) {
-            return it.template operator+=<bitset_mode::SegmentMode>(skip);
+        template<bitset_mode mode=bitset_mode::BitMode>
+        constexpr const_reverse_iterator<mode> rbegin() const noexcept {
+            return const_reverse_iterator<mode>{begin() + size_in_bits()};
         }
 
-        /**
-         * Returns updated iterator advanced backward by one segment
-         *
-         * @param it bitset iterator
-         * @return iterator advanced backwards by one segment
-         */
-        static iterator advance_segment_backwards(iterator it) {
-            return it.template operator--<bitset_mode::SegmentMode>();
+        template<bitset_mode mode=bitset_mode::BitMode>
+        constexpr reverse_iterator<mode> rend() noexcept {
+            return reverse_iterator<mode>{begin()};
         }
 
-        static const_iterator advance_segment_backwards(const_iterator it) {
-            return it.template operator--<bitset_mode::SegmentMode>();
-        }
-
-        /**
-         * Returns updated iterator advanced backward by skip segment
-         *
-         * @param it bitset iterator
-         * @param skip segments to skip
-         * @return iterator advanced backwards by skip segments
-         */
-        static iterator advance_segment_backwards(iterator it, size_t const skip) {
-            return it.template operator-=<bitset_mode::SegmentMode>(skip);
-        }
-
-        static const_iterator advance_segment_backwards(const_iterator it, size_t const skip) {
-            return it.template operator-=<bitset_mode::SegmentMode>(skip);
-        }
-
-        constexpr iterator begin() noexcept {
-            return iterator{*this};
-        }
-
-        constexpr const_iterator begin() const noexcept {
-            return const_iterator{*this};
-        }
-
-        constexpr reverse_iterator rbegin() noexcept {
-            return reverse_iterator{begin() + size_in_bits()};
-        }
-
-        constexpr const_reverse_iterator rbegin() const noexcept {
-            return const_reverse_iterator{begin() + size_in_bits()};
-        }
-
-        constexpr reverse_iterator rend() noexcept {
-            return reverse_iterator{begin()};
-        }
-
-        constexpr const_reverse_iterator rend() const noexcept {
-            return const_reverse_iterator{begin()};
+        template<bitset_mode mode=bitset_mode::BitMode>
+        constexpr const_reverse_iterator<mode> rend() const noexcept {
+            return const_reverse_iterator<mode>{begin()};
         }
 
         constexpr std::default_sentinel_t end() const noexcept {
             return std::default_sentinel;
         }
 
-        constexpr positional_iterator pbegin() noexcept {
-            return positional_iterator{*this};
+        template<bitset_mode mode=bitset_mode::BitMode>
+        constexpr positional_iterator<mode> pbegin() noexcept {
+            return positional_iterator<mode>{*this};
         }
 
-        constexpr const_positional_iterator pbegin() const noexcept {
-            return const_positional_iterator{*this};
+        template<bitset_mode mode=bitset_mode::BitMode>
+        constexpr const_positional_iterator<mode> pbegin() const noexcept {
+            return const_positional_iterator<mode>{*this};
         }
 
         constexpr std::default_sentinel_t pend() const noexcept {
@@ -1191,7 +1153,7 @@ struct std::formatter<dice::template_library::bitset<extent_, max_extent_, T>> {
         if (debug) {
             size_t segment_bits = 0;
             if (it != end) {
-                auto const seg_end = storage.advance_segment(it);
+                auto const seg_end = it + static_cast<ptrdiff_t>(sizeof(T) * 8);
                 for (auto p = it; p != seg_end; ++p) {
                     ++segment_bits;
                 }
@@ -1216,10 +1178,10 @@ struct std::formatter<dice::template_library::bitset<extent_, max_extent_, T>> {
             if (hex) {
                 auto const &segment = it.get();
                 out = std::format_to(out, "{:#0{}x}", segment, sizeof(segment) * 2);
-                it = storage.advance_segment(it);
+                it += static_cast<ptrdiff_t>(sizeof(T) * 8);
             }
             else if (binary) {
-                auto const seg_end = storage.advance_segment(it);
+                auto const seg_end = it + static_cast<ptrdiff_t>(sizeof(T) * 8);
                 for (; it != seg_end; ++it) {
                     *out++ = *it ? '1' : '0';
                 }

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -515,7 +515,7 @@ namespace dice::template_library {
 
         template<typename F>
         auto bitset_op_cntl(F &&ops, const_reference segment) const -> std::invoke_result_t<F, const_reference> {
-            return std::invoke(std::forward<F>(ops), segment);
+            return
         }
 
         [[nodiscard]] static size_t offset_in_chunk(offset const o) noexcept {
@@ -970,7 +970,7 @@ namespace dice::template_library {
          */
         [[nodiscard]] bool all_set() const {
             return segment_handler([this](const_reference segment) {
-                return bitset_op_cntl(DICE_MEMFN(segment_all_set), segment);
+                return DICE_MEMFN(segment_all_set)(segment);
             },
                                    [](bool const val) {
                                        return val;
@@ -984,7 +984,7 @@ namespace dice::template_library {
          */
         [[nodiscard]] bool any_set() const {
             return segment_handler([this](const_reference segment) {
-                return bitset_op_cntl(DICE_MEMFN(segment_any_set), segment);
+                return DICE_MEMFN(segment_any_set)(segment);
             },
                                    [](bool const val) { // only terminate if we find a bit set
                                        return !val;
@@ -1000,7 +1000,7 @@ namespace dice::template_library {
          */
         [[nodiscard]] bool none_set() const {
             return segment_handler([this](const_reference segment) {
-                return bitset_op_cntl(DICE_MEMFN(segment_none_set), segment);
+                return DICE_MEMFN(segment_none_set)(segment);
             },
                                    [](bool const val) {
                                        return val;

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -94,7 +94,7 @@ namespace dice::template_library {
                 offset  off;
 
                 reference(reference const&) = default;
-                reference const& operator=(reference const& other) const noexcept {
+                reference const& operator=(reference const &other) const noexcept {
                     return *this = static_cast<bool>(other);
                 }
 
@@ -121,10 +121,10 @@ namespace dice::template_library {
             using pointer           = void;
             using difference_type   = ptrdiff_t;
 
-            explicit bitset_iterator(std::conditional_t<is_const,bitset const&, bitset&> bitset) noexcept :
+            explicit bitset_iterator(std::conditional_t<is_const, bitset const&, bitset&> bitset) noexcept :
                 backing_bitset_{&bitset} {}
 
-            explicit bitset_iterator(bitset &bitset, offset const& o) :
+            explicit bitset_iterator(bitset &bitset, offset const &o) :
                 backing_bitset_{&bitset}{
                 if (o >= segment_size_in_bits) {
                     throw std::out_of_range{"bitset_iterator: o >= segment_size"};
@@ -132,7 +132,7 @@ namespace dice::template_library {
                 cur_offset_ = o;
             }
 
-            explicit bitset_iterator(bitset &bitset, offset const& o, segment const& s) :
+            explicit bitset_iterator(bitset &bitset, offset const &o, segment const &s) :
                 backing_bitset_{&bitset}{
                 if (o >= segment_size_in_bits) {
                     throw std::out_of_range{"bitset_iterator: o >= segment_size"};
@@ -262,7 +262,7 @@ namespace dice::template_library {
                 return tmp;
             }
 
-            difference_type operator-(bitset_iterator const& other) const noexcept {
+            difference_type operator-(bitset_iterator const &other) const noexcept {
                 return (**this).ix() - (*other).ix();
             }
 
@@ -274,17 +274,17 @@ namespace dice::template_library {
                 return *(backing_bitset_->inner_.data() + cur_segment_);
             }
 
-            friend bool operator==(bitset_iterator const& lhs, bitset_iterator const& rhs){
+            friend bool operator==(bitset_iterator const &lhs, bitset_iterator const &rhs){
                 return lhs.backing_bitset_ == rhs.backing_bitset_ &&
                        lhs.cur_segment_ == rhs.cur_segment_ &&
                        lhs.cur_offset_ == rhs.cur_offset_;
             }
 
-            friend bool operator==(std::default_sentinel_t, bitset_iterator const& it) {
+            friend bool operator==(std::default_sentinel_t, bitset_iterator const &it) {
                 return it == std::default_sentinel;
             }
 
-            friend bool operator==(bitset_iterator const& it, std::default_sentinel_t) {
+            friend bool operator==(bitset_iterator const &it, std::default_sentinel_t) {
                 return it.cur_segment_ >= it.backing_bitset_->size();
             }
         };
@@ -355,15 +355,15 @@ namespace dice::template_library {
                 return *it_;
             }
 
-            friend bool operator==(position_iterator const& lhs, position_iterator const& rhs){
+            friend bool operator==(position_iterator const &lhs, position_iterator const &rhs){
                 return lhs.it_ == rhs.it_;
             }
 
-            friend bool operator==(std::default_sentinel_t, position_iterator const& it) {
+            friend bool operator==(std::default_sentinel_t, position_iterator const &it) {
                 return it == std::default_sentinel;
             }
 
-            friend bool operator==(position_iterator const& it, std::default_sentinel_t) {
+            friend bool operator==(position_iterator const &it, std::default_sentinel_t) {
                 return it.it_ == std::default_sentinel;
             }
         };
@@ -526,7 +526,7 @@ namespace dice::template_library {
         }
 
         template<typename Ops>
-        void segment_handler(bitset const& other) {
+        void segment_handler(bitset const &other) {
             auto self_it = begin();
             auto outer_it = other.begin();
             auto ops = Ops{};
@@ -547,7 +547,7 @@ namespace dice::template_library {
         }
 
         template<typename F>
-        bool segment_handler(F &&handler, bitset const& other) {
+        bool segment_handler(F &&handler, bitset const &other) {
             auto self_it = begin();
             auto outer_it = other.begin();
 
@@ -568,7 +568,7 @@ namespace dice::template_library {
         }
 
         template<typename F>
-        bool segment_handler(F &&handler, bitset const& other) const {
+        bool segment_handler(F &&handler, bitset const &other) const {
             auto self_it = begin();
             auto outer_it = other.begin();
 
@@ -1082,7 +1082,7 @@ namespace dice::template_library {
             return size() * segment_size_in_bits;
         }
 
-        bool operator==(bitset const& alt_storage) const noexcept {
+        bool operator==(bitset const &alt_storage) const noexcept {
             return segment_handler([](const_reference segment_first, const_reference segment_second) {
                 return segment_first == segment_second;
             }, alt_storage);
@@ -1100,12 +1100,12 @@ namespace dice::template_library {
             return *this;
         }
 
-        bitset& operator&=(bitset const& alt_storage) noexcept {
+        bitset& operator&=(bitset const &alt_storage) noexcept {
             segment_handler<std::bit_and<T>>(alt_storage);
             return *this;
         }
 
-        bitset& operator|=(bitset const& alt_storage) noexcept {
+        bitset& operator|=(bitset const &alt_storage) noexcept {
             segment_handler<std::bit_or<T>>(alt_storage);
             return *this;
         }
@@ -1122,13 +1122,13 @@ namespace dice::template_library {
             return tmp;
         }
 
-        bitset operator&(bitset const& bitset_v_second) const noexcept {
+        bitset operator&(bitset const &bitset_v_second) const noexcept {
             bitset tmp = *this;
             tmp &= bitset_v_second;
             return tmp;
         }
 
-        bitset operator|(bitset const& bitset_v_second) const noexcept {
+        bitset operator|(bitset const &bitset_v_second) const noexcept {
             bitset tmp = *this;
             tmp |= bitset_v_second;
             return tmp;
@@ -1143,7 +1143,7 @@ struct std::formatter<dice::template_library::bitset<extent_, max_extent_, T>> {
     bool binary = false;
 
     ///> parse formatter context, only allowing hex, debug and binary symbol
-    constexpr auto parse(std::format_parse_context& ctx) {
+    constexpr auto parse(std::format_parse_context &ctx) {
         auto it = ctx.begin();
         while (it != ctx.end() && *it != '}') {
             if (*it != 'x' && *it != '?' && *it != 'b') {
@@ -1165,7 +1165,7 @@ struct std::formatter<dice::template_library::bitset<extent_, max_extent_, T>> {
         return it;
     }
 
-    auto format(dice::template_library::bitset<extent_, max_extent_, T> const& storage, std::format_context& ctx) const {
+    auto format(dice::template_library::bitset<extent_, max_extent_, T> const &storage, std::format_context &ctx) const {
         auto it = storage.begin();
         auto const end = storage.end();
         auto const total_bits = storage.size_in_bits();
@@ -1200,7 +1200,7 @@ struct std::formatter<dice::template_library::bitset<extent_, max_extent_, T>> {
         while (it != end) {
             *out++ = '[';
             if (hex) {
-                auto const& segment = it.get();
+                auto const &segment = it.get();
                 out = std::format_to(out, "{:#0{}x}", segment, sizeof(segment) * 2);
                 it = storage.advance_segment(it);
             }

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -695,15 +695,7 @@ namespace dice::template_library {
         template<typename F, typename Range>
         requires std::ranges::input_range<Range>
         void positions_cntl(Range &&positions, F &&pos_f) {
-            if constexpr (has_dynamic_extent) {
-                std::ranges::for_each(std::forward<Range>(positions), [pos_f = std::forward<F>(pos_f), this](auto pos) {
-                    expand_segments(pos);
-                    std::invoke(std::move(pos_f), pos);
-                });
-            }
-            else {
-                std::ranges::for_each(std::forward<Range>(positions), std::forward<F>(pos_f));
-            }
+            std::ranges::for_each(std::forward<Range>(positions), std::forward<F>(pos_f));
         }
 
     public:

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -449,7 +449,7 @@ namespace dice::template_library {
         }
 
         template<typename F>
-        auto bitset_mod_cntl(F&& ops, global_ix const ix) -> std::invoke_result_t<F, bitset*, size_t, size_t> {
+        auto bitset_mod_cntl(F &&ops, global_ix const ix) -> std::invoke_result_t<F, bitset*, size_t, size_t> {
             if (!fits_in_storage(ix)) {
                 throw std::out_of_range{"bitset::set: ix out of range"};
             }
@@ -647,7 +647,7 @@ namespace dice::template_library {
         }
 
         template<typename F>
-        void positions_cntl(std::ranges::input_range auto&& positions, F&& pos_f) {
+        void positions_cntl(std::ranges::input_range auto &&positions, F &&pos_f) {
             if constexpr (std::ranges::sized_range<decltype(positions)>) {
                 auto position_elements = std::ranges::size(positions);
                 if (position_elements >= storage_size_in_bits) {
@@ -934,7 +934,7 @@ namespace dice::template_library {
          *
          * @param positions input range of positions
          */
-        void set_positions(std::ranges::input_range auto&& positions) {
+        void set_positions(std::ranges::input_range auto &&positions) {
             positions_cntl(std::forward<decltype(positions)>(positions), [this](auto pos) {
                 this->set(pos);
             });
@@ -945,7 +945,7 @@ namespace dice::template_library {
          *
          * @param positions input range of positions
          */
-        void reset_positions(std::ranges::input_range auto&& positions) {
+        void reset_positions(std::ranges::input_range auto &&positions) {
             positions_cntl(std::forward<decltype(positions)>(positions), [this](auto pos) {
                 this->reset(pos);
             });

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -8,6 +8,7 @@
 #include <format>
 #include <iterator>
 #include <ranges>
+#include <compare>
 
 namespace dice::template_library {
     /**
@@ -121,6 +122,8 @@ namespace dice::template_library {
             using pointer           = void;
             using difference_type   = ptrdiff_t;
 
+            bitset_iterator() noexcept = default;
+
             explicit bitset_iterator(std::conditional_t<is_const, bitset const&, bitset&> bitset) noexcept :
                 backing_bitset_{&bitset} {}
 
@@ -152,6 +155,10 @@ namespace dice::template_library {
 
             reference operator*() const noexcept {
                 return reference {backing_bitset_, cur_segment_, cur_offset_};
+            }
+
+            reference operator[](size_t ix) const noexcept {
+                return *(*this + ix);
             }
 
             // shared iterator for mode=0 (bits) mode>=1 (segments)
@@ -272,6 +279,29 @@ namespace dice::template_library {
 
             [[nodiscard]] T& get() noexcept requires(!is_const){
                 return *(backing_bitset_->inner_.data() + cur_segment_);
+            }
+
+            friend bitset_iterator operator+(size_t lh_add, bitset_iterator const &rhs) noexcept {
+                return rhs + lh_add;
+            }
+
+            friend bitset_iterator operator-(size_t lh_sub, bitset_iterator const &rhs) noexcept {
+                return rhs - lh_sub;
+            }
+
+            friend std::strong_ordering operator<=>(bitset_iterator const &lhs, bitset_iterator const &rhs) noexcept {
+                if (lhs == rhs) {
+                    return std::strong_ordering::equal;
+                }
+
+                auto const lhs_ix = calc_global_idx(lhs.cur_segment_, lhs.cur_offset_);
+                auto const rhs_ix = calc_global_idx(rhs.cur_segment_, rhs.cur_offset_);
+
+                if (lhs_ix > rhs_ix) {
+                    return std::strong_ordering::greater;
+                }
+
+                return std::strong_ordering::less;
             }
 
             friend bool operator==(bitset_iterator const &lhs, bitset_iterator const &rhs){

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -986,7 +986,7 @@ namespace dice::template_library {
          *
          * @return input range containing the positions
          */
-        auto positions() const -> std::ranges::input_range auto {
+        std::ranges::input_range auto positions() const {
             return std::ranges::subrange(pbegin(), pend());
         }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -11,20 +11,12 @@
 
 namespace dice::template_library {
     /**
-     * The underlying mode to iterate over the storage
-     * Used within the **bitset_iterator**
-     */
-
-    /**
-     * A multi-type bitset supporting both dynamic and static growth.
+     * A bitset supporting both dynamic and static growth.
      * - Core operations: set(), test(), flip(), etc.
      * - Queries: any_set(), none_set(), etc.
      * - Standard bit operations
      * - Iteration at bit and segment granularity
      * - Positional Iteration
-     *
-     * The storage type isn't restricted to integral types — a custom type
-     * can be used as the internal storage representation.
      *
      * Examples:
      *
@@ -47,19 +39,19 @@ namespace dice::template_library {
      * bitset<10, 10> ...
      *
      * @tparam T value type : any type is allowed as representation of the underlying storage
-     * @tparam extent extent of the bitset
-     * @tparam bits minimal bits for the underlying bitset : use dynamic_extent to uncap limit
+     * @tparam bits extent of the bitset
+     * @tparam max_bits minimal bits for the underlying bitset : use dynamic_extent to uncap limit
      */
-    template<size_t extent, size_t bits, typename T = uint64_t>
+    template<size_t bits, size_t max_bits, typename T = uint64_t>
     requires std::unsigned_integral<T>
     struct bitset {
     private:
         static constexpr size_t segment_size = sizeof(T);
         static constexpr size_t segment_size_in_bits = segment_size * 8;
 
-        static constexpr size_t segments = bits != dynamic_extent ? (bits + segment_size_in_bits - 1) / segment_size_in_bits : dynamic_extent;
+        static constexpr size_t segments = max_bits != dynamic_extent ? (max_bits + segment_size_in_bits - 1) / segment_size_in_bits : dynamic_extent;
 
-        using storage   = flex_array<T, extent, segments>;
+        using storage   = flex_array<T, bits, segments>;
         using global_ix = size_t;
         using segment   = size_t;
         using offset    = size_t;
@@ -1208,19 +1200,9 @@ struct std::formatter<dice::template_library::bitset<extent_, max_extent_, T>> {
         while (it != end) {
             *out++ = '[';
             if (hex) {
-                auto const seg_end = storage.advance_segment(it);
                 auto const& segment = it.get();
-                if constexpr (std::integral<T>) {
-                   out = std::format_to(out, "{:#0{}x}", segment, sizeof(segment) * 2);
-                }
-                else {
-                    auto [word, word_end] = storage.segment_slots(segment);
-
-                    for (; word != word_end; ++word) {
-                        out = std::format_to(out, "{:#0{}x}", *word, sizeof(*word) * 2);
-                    }
-                }
-                it = seg_end;
+                out = std::format_to(out, "{:#0{}x}", segment, sizeof(segment) * 2);
+                it = storage.advance_segment(it);
             }
             else if (binary) {
                 auto const seg_end = storage.advance_segment(it);

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -302,7 +302,14 @@ namespace dice::template_library {
                 return rhs - lh_sub;
             }
 
+            friend bitset_iterator operator+(difference_type lh_add, bitset_iterator const &rhs) noexcept {
+                return rhs + lh_add;
+            }
+
             friend std::strong_ordering operator<=>(bitset_iterator const &lhs, bitset_iterator const &rhs) noexcept {
+                // UB comparing different bitsets
+                assert(lhs.backing_bitset_ == rhs.backing_bitset_);
+
                 if (lhs == rhs) {
                     return std::strong_ordering::equal;
                 }
@@ -554,7 +561,7 @@ namespace dice::template_library {
             auto outer_it = other.begin<bitset_mode::SegmentMode>();
             auto ops = Ops{};
 
-            assert(size() != other.size());
+            assert(size() == other.size());
 
             auto end_sentinel = end();
 
@@ -672,7 +679,7 @@ namespace dice::template_library {
             return std::popcount(segment) == 0x00;
         }
 
-        [[nodiscard]] bool size_match(bitset const& other) {
+        [[nodiscard]] bool size_match(bitset const& other) const noexcept {
             return size() == other.size();
         }
 
@@ -1038,7 +1045,7 @@ namespace dice::template_library {
         template<bitset_mode mode = bitset_mode::BitMode>
         constexpr reverse_iterator<mode> rbegin() noexcept {
             if constexpr (mode == bitset_mode::BitMode) {
-                return reverse_iterator<mode>{begin<mode>() + size_in_bits()};
+                return reverse_iterator<mode>{begin<mode>() + capacity_in_bits()};
             } else {
                 return reverse_iterator<mode>{begin<mode>() + size()};
             }
@@ -1047,7 +1054,7 @@ namespace dice::template_library {
         template<bitset_mode mode = bitset_mode::BitMode>
         constexpr const_reverse_iterator<mode> rbegin() const noexcept {
             if constexpr (mode == bitset_mode::BitMode) {
-                return const_reverse_iterator<mode>{begin<mode>() + size_in_bits()};
+                return const_reverse_iterator<mode>{begin<mode>() + capacity_in_bits()};
             } else {
                 return const_reverse_iterator<mode>{begin<mode>() + size()};
             }
@@ -1225,10 +1232,11 @@ struct std::formatter<dice::template_library::bitset<extent_, max_extent_, T>> {
         while (it != end) {
             *out++ = '[';
             if (binary) {
-                auto const seg_end = it + static_cast<ptrdiff_t>(sizeof(T) * 8);
-                for (; it != seg_end; ++it) {
-                    *out++ = *it ? '1' : '0';
+                auto const bits =  static_cast<ptrdiff_t>(sizeof(T) * 8);
+                for (auto const seg_end = it + bits; bool const b : std::ranges::subrange(it, seg_end) | std::views::reverse) {
+                    *out++ = b ? '1' : '0';
                 }
+                it += bits;
             } else { // default to hex
                 auto const &segment = it.get();
                 out = std::format_to(out, "{:#0{}x}", segment, sizeof(segment) * 2);

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -1105,38 +1105,16 @@ namespace dice::template_library {
                                    alt_storage);
         }
 
-        template<bitset_mode mode = bitset_mode::BitMode>
         bitset &operator<<=(size_t shift) {
-            if constexpr (mode == bitset_mode::SegmentMode) {
-                auto dest_it = std::move(begin<mode>() + shift, begin<mode>() + size(), begin<mode>());
-                std::fill(dest_it, begin<mode>() + size(), false);
-                return *this;
-            }
-            else if constexpr (mode == bitset_mode::BitMode){
-                auto dest_it = std::move(begin() + shift, begin() + size_in_bits(), begin());
-                std::fill(dest_it, begin() + size_in_bits(), false);
-                return *this;
-            }
-            else {
-                throw std::logic_error("bitset:: bitset mode not supported");
-            }
+            auto dest_it = std::move(begin() + shift, begin() + size_in_bits(), begin());
+            std::fill(dest_it, begin() + size_in_bits(), false);
+            return *this;
         }
 
-        template<bitset_mode mode = bitset_mode::BitMode>
         bitset &operator>>=(size_t shift) {
-            if constexpr (mode == bitset_mode::SegmentMode) {
-                auto dest_it = std::move_backward(begin<mode>(), begin<mode>() + size() - shift, begin<mode>() + size());
-                std::fill(dest_it, begin<mode>() + size(), false);
-                return *this;
-            }
-            else if constexpr (mode == bitset_mode::BitMode){
-                auto dest_it = std::move_backward(begin(), begin() + size_in_bits() - shift, begin() + size_in_bits());
-                std::fill(begin(), dest_it, false);
-                return *this;
-            }
-            else {
-                throw std::logic_error("bitset:: bitset mode not supported");
-            }
+            auto dest_it = std::move_backward(begin(), begin() + size_in_bits() - shift, begin() + size_in_bits());
+            std::fill(begin(), dest_it, false);
+            return *this;
         }
 
         bitset &operator&=(bitset const &alt_storage) {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -10,30 +10,6 @@
 #include <ranges>
 
 namespace dice::template_library {
-
-    ///> operation markers
-    struct bit_and_op{};
-    struct add_op{};
-    struct bit_or_op{};
-
-    /**
-     * merge functor: merging the results of two expressions together
-     */
-    template<typename Tp>
-    struct merge_functor {
-        Tp operator()(add_op, Tp const v1, Tp const v2) const noexcept {
-            return v1 + v2;
-        };
-
-        Tp operator()(bit_and_op, Tp const v1, Tp const v2) const noexcept {
-            return v1 & v2;
-        };
-
-        Tp operator()(bit_or_op, Tp const v1, Tp const v2) const noexcept {
-            return v1 | v2;
-        };
-    };
-
     /**
      * The underlying mode to iterate over the storage
      * Used within the **bitset_iterator**
@@ -544,13 +520,13 @@ namespace dice::template_library {
             return std::popcount(segment);
         }
 
-        template<typename F, typename M, typename Tp, typename Ops>
+        template<typename F, typename M, typename Tp>
         requires std::is_same_v<std::invoke_result_t<F, const_reference>, Tp> &&
-            std::invocable<M, Ops, Tp, Tp>
-        [[nodiscard]] Tp segment_handler(F &&handler, M &&merge, Tp initial, Ops ops=add_op{}) const {
+            std::invocable<M, Tp, Tp>
+        [[nodiscard]] Tp segment_handler(F &&handler, M &&merge, Tp initial) const {
             Tp merge_val{initial};
             for (auto const &segment : inner_) {
-                merge_val = std::invoke(std::forward<M>(merge), ops, merge_val,
+                merge_val = std::invoke(std::forward<M>(merge), merge_val,
                     std::invoke(std::forward<F>(handler), segment));
             }
 
@@ -634,8 +610,8 @@ namespace dice::template_library {
             return true;
         }
 
-        template<typename F, typename Pr, typename M, typename Tp, typename Ops>
-        Tp segment_handler(F &&handler, Pr &&pred, M &&merge, Tp initial, Ops ops=add_op{}) const {
+        template<typename F, typename Pr, typename M, typename Tp>
+        Tp segment_handler(F &&handler, Pr &&pred, M &&merge, Tp initial) const {
             auto self_it = begin();
             auto end_sentinel = end();
 
@@ -643,7 +619,7 @@ namespace dice::template_library {
 
             while (self_it != end_sentinel) {
                 Tp const val = std::invoke(std::forward<F>(handler), self_it.get());
-                merge_val = std::invoke(std::forward<M>(merge), ops, merge_val, val);
+                merge_val = std::invoke(std::forward<M>(merge), merge_val, val);
                 if (!std::invoke(std::forward<Pr>(pred), val)) {
                     return merge_val;
                 }
@@ -652,8 +628,8 @@ namespace dice::template_library {
             return merge_val;
         }
 
-        template<typename F, typename Pr, typename M, typename Tp, typename Ops>
-        Tp segment_handler_backwards(F &&handler, Pr &&pred, M &&merge, Tp initial, Ops ops=add_op{}) const {
+        template<typename F, typename Pr, typename M, typename Tp>
+        Tp segment_handler_backwards(F &&handler, Pr &&pred, M &&merge, Tp initial) const {
             auto self_it = begin() + size_in_bits();
             auto end_it = begin();
 
@@ -661,7 +637,7 @@ namespace dice::template_library {
 
             while (self_it != end_it) {
                 Tp const val = std::invoke(std::forward<F>(handler), (self_it-1).get());
-                merge_val = std::invoke(std::forward<M>(merge), ops, merge_val, val);
+                merge_val = std::invoke(std::forward<M>(merge), merge_val, val);
                 if (!std::invoke(std::forward<Pr>(pred), val)) {
                     return merge_val;
                 }
@@ -847,7 +823,7 @@ namespace dice::template_library {
         [[nodiscard]] size_t count() const {
             return segment_handler([this](const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_count, segment);
-            }, merge_functor<size_t>{}, 0uz, add_op{});
+            }, std::plus<size_t>{}, 0uz);
         }
 
         /**
@@ -897,7 +873,7 @@ namespace dice::template_library {
                 return bitset_op_cntl(&bitset::segment_countr_zero, segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;
-            }, merge_functor<size_t>{}, 0, add_op{});
+            }, std::plus<size_t>{}, 0uz);
         }
 
         /**
@@ -910,7 +886,7 @@ namespace dice::template_library {
                 return bitset_op_cntl(&bitset::segment_countl_zero, segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;
-            }, merge_functor<size_t>{}, 0, add_op{});
+            }, std::plus<size_t>{}, 0uz);
         }
 
         /**
@@ -923,7 +899,7 @@ namespace dice::template_library {
                 return bitset_op_cntl(&bitset::segment_countr_one, segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;
-            }, merge_functor<size_t>{}, 0, add_op{});
+            }, std::plus<size_t>{}, 0uz);
         }
 
         /**
@@ -936,7 +912,7 @@ namespace dice::template_library {
                 return bitset_op_cntl(&bitset::segment_countl_one, segment);
             }, [](size_t const val) {
                 return val == segment_size_in_bits;
-            }, merge_functor<size_t>{}, 0, add_op{});
+            }, std::plus<size_t>{}, 0uz);
         }
 
         /**
@@ -960,7 +936,7 @@ namespace dice::template_library {
         [[nodiscard]] bool any_set() const {
             return segment_handler([this](const_reference segment) {
                 return bitset_op_cntl(&bitset::segment_any_set, segment);
-            }, merge_functor<bool>{}, false, bit_or_op{});
+            }, std::bit_or<bool>{}, false);
         }
 
         /**
@@ -973,7 +949,7 @@ namespace dice::template_library {
                 return bitset_op_cntl(&bitset::segment_none_set, segment);
             }, [](bool const val) {
                 return val;
-            }, merge_functor<bool>{}, true, bit_and_op{});
+            }, std::bit_and<bool>{}, true);
         }
 
         /**

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -474,6 +474,14 @@ namespace dice::template_library {
             return true;
         }
 
+        [[nodiscard]] constexpr bool is_aligned() const noexcept {
+            return leftover_bits() == 0;
+        }
+
+        [[nodiscard]] constexpr size_t leftover_bits() const noexcept {
+            return logical_size() % segment_size_in_bits;
+        }
+
         [[nodiscard]] static constexpr segment calc_which_segment(global_ix const ix) noexcept {
             return ix >> std::countr_zero(segment_size_in_bits);
         }
@@ -545,9 +553,9 @@ namespace dice::template_library {
 
         ///> in-place unary transform
         template<typename Ops>
-        void segments_transform() {
+        void segments_transform(size_t stop=0) {
             auto self_it = begin<bitset_mode::SegmentMode>();
-            auto end_sentinel = end();
+            auto end_sentinel = begin<bitset_mode::SegmentMode>() + size() - stop;
 
             auto ops = Ops{};
 
@@ -560,7 +568,7 @@ namespace dice::template_library {
 
         ///> in-place binary transform
         template<typename Ops>
-        void segments_transform_with(bitset const &other) {
+        void segments_transform_with(bitset const &other, size_t stop=0) {
             auto self_it = begin<bitset_mode::SegmentMode>();
             auto outer_it = other.begin<bitset_mode::SegmentMode>();
             auto ops = Ops{};
@@ -569,7 +577,7 @@ namespace dice::template_library {
                 return;
             }
 
-            auto end_sentinel = end();
+            auto end_sentinel = begin<bitset_mode::SegmentMode>() + size() - stop;
 
             while (self_it != end_sentinel) {
                 auto &seg_this = self_it.get();
@@ -605,9 +613,9 @@ namespace dice::template_library {
 
         ///> true iff pred(handler(segment)) holds for every segment, early-exit on the first failure
         template<typename F, typename Pr>
-        bool segments_all_of(F &&handler, Pr &&pred) const {
+        bool segments_all_of(F &&handler, Pr &&pred, size_t stop=0) const {
             auto self_it = begin<bitset_mode::SegmentMode>();
-            auto end_sentinel = end();
+            auto end_sentinel = begin<bitset_mode::SegmentMode>() + size() - stop;
 
             while (self_it != end_sentinel) {
                 if (auto const val = std::invoke(std::forward<F>(handler), self_it.get()); !std::invoke(std::forward<Pr>(pred), val)) {
@@ -620,9 +628,9 @@ namespace dice::template_library {
 
         ///> folds handler(segment) across every segment, stopping early once pred(val) fails
         template<typename F, typename Pr, typename M, typename Tp>
-        Tp segments_reduce_while(F &&handler, Pr &&pred, M &&merge, Tp initial) const {
+        Tp segments_reduce_while(F &&handler, Pr &&pred, M &&merge, Tp initial, size_t stop=0) const {
             auto self_it = begin<bitset_mode::SegmentMode>();
-            auto end_sentinel = end();
+            auto end_sentinel = begin<bitset_mode::SegmentMode>() + size() - stop;
 
             Tp merge_val{initial};
 
@@ -639,8 +647,8 @@ namespace dice::template_library {
 
         ///> same as segments_reduce_while, but iterates segments in reverse order
         template<typename F, typename Pr, typename M, typename Tp>
-        Tp segments_reduce_while_reverse(F &&handler, Pr &&pred, M &&merge, Tp initial) const {
-            auto self_it = rbegin<bitset_mode::SegmentMode>();
+        Tp segments_reduce_while_reverse(F &&handler, Pr &&pred, M &&merge, Tp initial, size_t start=0) const {
+            auto self_it = rbegin<bitset_mode::SegmentMode>() + start;
             auto end_it = rend<bitset_mode::SegmentMode>();
 
             Tp merge_val{initial};
@@ -759,9 +767,13 @@ namespace dice::template_library {
             reset(ix);
         }
 
-        void set_all() requires (!has_dynamic_extent)
-        {
-            std::fill(inner_.begin(), inner_.end(), static_cast<T>(~T{}));
+        void set_all() {
+            if (is_aligned()) {
+                std::fill(inner_.begin(), inner_.end(), static_cast<T>(~T{}));
+                return;
+            }
+            std::fill(inner_.begin(), inner_.end() - 1, static_cast<T>(~T{}));
+            *(inner_.end() - 1) = static_cast<T>(static_cast<T>(~T{}) >> (segment_size_in_bits - leftover_bits()));
         }
 
         /**
@@ -782,8 +794,7 @@ namespace dice::template_library {
             bitset_mod_cntl(DICE_MEMFN(segment_unset), ix);
         }
 
-        void reset_all() requires (!has_dynamic_extent)
-        {
+        void reset_all() {
             std::fill(inner_.begin(), inner_.end(), T{});
         }
 
@@ -892,14 +903,37 @@ namespace dice::template_library {
          * @return ix to non-zero entry
          */
         [[nodiscard]] size_t countr_zero() const {
-            return segments_reduce_while([](segment_const_reference segment) {
-                return std::countr_zero(segment);
-            },
-                                   [](size_t const val) {
-                                       return val == segment_size_in_bits;
-                                   },
-                                   std::plus<size_t>{},
-                                   0uz);
+            if (is_aligned()) {
+                return segments_reduce_while([](segment_const_reference segment) {
+                        return std::countr_zero(segment);
+                    }, [](size_t const val) {
+                        return val == segment_size_in_bits;
+                    },
+                    std::plus<size_t>{},
+                    0uz);
+            }
+
+            auto const full_segments = size() - 1;
+            auto const full_bits = full_segments * segment_size_in_bits;
+
+            auto const full_count = segments_reduce_while([](segment_const_reference segment) {
+                    return std::countr_zero(segment);
+                }, [](size_t const val) {
+                    return val == segment_size_in_bits;
+                },
+                std::plus<size_t>{},
+                0uz,
+                1);
+
+            // if not fully consumed (all zeros) we can stop
+            if (full_count != full_bits) {
+                return full_count;
+            }
+
+            auto const leftover = leftover_bits();
+            auto const &last = *(begin<bitset_mode::SegmentMode>() + full_segments);
+            auto const padding_mask = static_cast<T>(~T{} << leftover);
+            return full_bits + static_cast<size_t>(std::countr_zero(static_cast<T>(last | padding_mask)));
         }
 
         /**
@@ -908,14 +942,36 @@ namespace dice::template_library {
          * @return ix to non-zero entry
          */
         [[nodiscard]] size_t countl_zero() const {
+            if (is_aligned()) {
+                return segments_reduce_while_reverse([](segment_const_reference segment) {
+                    return std::countl_zero(segment);
+                },
+                                                 [](size_t const val) {
+                                                     return val == segment_size_in_bits;
+                                                 },
+                                                 std::plus<size_t>{},
+                                                 0uz);
+            }
+            auto const full_segments = size() - 1;
+            auto const leftover = leftover_bits();
+            auto const fill_bits = segment_size_in_bits - leftover;
+
+            auto const &last = *(begin<bitset_mode::SegmentMode>() + full_segments);
+            auto const padding_mask = static_cast<T>(~T{} >> (segment_size_in_bits - fill_bits));
+            auto const zero_bits = static_cast<size_t>(std::countl_zero(static_cast<T>(static_cast<T>(last << fill_bits) | padding_mask)));
+
+            if (zero_bits != leftover) {
+                return zero_bits;
+            }
+
             return segments_reduce_while_reverse([](segment_const_reference segment) {
-                return std::countl_zero(segment);
-            },
-                                             [](size_t const val) {
-                                                 return val == segment_size_in_bits;
-                                             },
-                                             std::plus<size_t>{},
-                                             0uz);
+                    return std::countl_zero(segment);
+                },
+                                                 [](size_t const val) {
+                                                     return val == segment_size_in_bits;
+                                                 },
+                                                 std::plus<size_t>{},
+                                                 0uz, 1) + zero_bits;
         }
 
         /**
@@ -956,9 +1012,23 @@ namespace dice::template_library {
          * @return queried state
          */
         [[nodiscard]] bool all_set() const {
-            return std::ranges::all_of(std::ranges::subrange(begin<bitset_mode::SegmentMode>(), end()), [this](segment_const_reference segment) {
+            if (is_aligned()) {
+                return std::ranges::all_of(std::ranges::subrange(begin<bitset_mode::SegmentMode>(), end()), [this](segment_const_reference segment) {
+                    return DICE_MEMFN(segment_all_set)(segment);
+                });
+            }
+            auto const full_segments = size() - 1;
+
+            auto const all_set_high = std::ranges::all_of(std::ranges::subrange(begin<bitset_mode::SegmentMode>(), begin<bitset_mode::SegmentMode>() + size() - 1), [this](segment_const_reference segment) {
                 return DICE_MEMFN(segment_all_set)(segment);
             });
+
+            if (!all_set_high) {
+                return false;
+            }
+
+            auto const &last = (begin<bitset_mode::SegmentMode>() + full_segments).get();
+            return (std::popcount(last) == leftover_bits());
         }
 
         /**
@@ -1180,7 +1250,13 @@ namespace dice::template_library {
 
         bitset operator~() const {
             bitset tmp = *this;
-            tmp.segments_transform<std::negate<T>>();
+            tmp.segments_transform<std::bit_not<T>>();
+
+            if (!tmp.is_aligned()) {
+                auto &last = (tmp.begin<bitset_mode::SegmentMode>() + (tmp.size() - 1)).get();
+                last &= static_cast<T>(static_cast<T>(~T{}) >> (segment_size_in_bits - tmp.leftover_bits()));
+            }
+
             return tmp;
         }
     };

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -513,11 +513,6 @@ namespace dice::template_library {
             return std::invoke(std::forward<F>(ops), segment, offset);
         }
 
-        template<typename F>
-        auto bitset_op_cntl(F &&ops, const_reference segment) const -> std::invoke_result_t<F, const_reference> {
-            return
-        }
-
         [[nodiscard]] static size_t offset_in_chunk(offset const o) noexcept {
             return o % (segment_align * 8);
         }
@@ -527,19 +522,19 @@ namespace dice::template_library {
         }
 
         void segment_set(segment const s, offset const o) noexcept {
-            *(inner_.data() + s) |= 1uz << o;
+            *(inner_.data() + s) |= T{1} << o;
         }
 
         void segment_flip(segment const s, offset const o) noexcept {
-            *(inner_.data() + s) ^= 1uz << o;
+            *(inner_.data() + s) ^= T{1} << o;
         }
 
         void segment_unset(segment const s, offset const o) noexcept {
-            *(inner_.data() + s) &= ~(1uz << o);
+            *(inner_.data() + s) &= static_cast<T>(~(T{1} << o));
         }
 
         [[nodiscard]] bool segment_test(segment const s, offset const o) const noexcept {
-            return *(inner_.data() + s) & 1uz << o;
+            return *(inner_.data() + s) & T{1} << o;
         }
 
         template<typename F, typename M, typename Tp>

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -81,6 +81,7 @@ namespace dice::template_library {
         struct bitset_iterator {
         private:
             using bitset_pointer = std::conditional_t<is_const, bitset const*, bitset*>;
+            constexpr static bool using_bit_mode = mode == bitset_mode::BitMode;
 
             segment       cur_segment_{};
             offset        cur_offset_{};
@@ -103,12 +104,16 @@ namespace dice::template_library {
                 reference(bitset_pointer backing_bitset, segment const seg, offset const off) noexcept
                     : backing_bitset_{backing_bitset}, seg{seg}, off{off} {}
 
-                operator bool() const noexcept {
+                operator bool() const noexcept requires(using_bit_mode) {
                     return backing_bitset_->test(calc_global_idx(seg, off));
                 }
 
-                operator size_t() const noexcept {
+                operator size_t() const noexcept requires(using_bit_mode) {
                     return ix();
+                }
+
+                operator std::conditional_t<is_const, T const&, T&>() const noexcept requires(!using_bit_mode) {
+                    return *(backing_bitset_->inner_.data() + seg);
                 }
 
                 reference const& operator=(bool const b) const noexcept {
@@ -123,7 +128,7 @@ namespace dice::template_library {
 
             using iterator_category = std::random_access_iterator_tag;
             using iterator_concept  = std::random_access_iterator_tag;
-            using value_type        = bool;
+            using value_type        = std::conditional_t<using_bit_mode, bool, value_type>;
             using pointer           = void;
             using difference_type   = ptrdiff_t;
 
@@ -330,13 +335,14 @@ namespace dice::template_library {
             }
         };
 
-        template<bool is_const, bitset_mode mode>
+        ///> enforce only bit mode in the position iterator
+        template<bool is_const>
         struct position_iterator {
         private:
             using bitset_pointer = std::conditional_t<is_const, bitset const*, bitset*>;
             using reference = bitset_iterator<is_const>::reference;
 
-            bitset_iterator<is_const, mode> it_;
+            bitset_iterator<is_const> it_;
             bitset_pointer backing_bitset_ = nullptr;
 
             ///> add bool to allow setting a start point, without skipping the initial offset
@@ -664,7 +670,7 @@ namespace dice::template_library {
             Tp merge_val{initial};
 
             while (self_it != end_it) {
-                Tp const val = std::invoke(std::forward<F>(handler), (*self_it).get());
+                Tp const val = std::invoke(std::forward<F>(handler), *self_it);
                 merge_val = std::invoke(std::forward<M>(merge), merge_val, val);
                 if (!std::invoke(std::forward<Pr>(pred), val)) {
                     return merge_val;
@@ -705,11 +711,8 @@ namespace dice::template_library {
         template<bitset_mode mode>
         using const_reverse_iterator = std::reverse_iterator<const_iterator<mode>>;
 
-        template<bitset_mode mode>
-        using positional_iterator = position_iterator<false, mode>;
-
-        template<bitset_mode mode>
-        using const_positional_iterator = position_iterator<true, mode>;
+        using positional_iterator = position_iterator<false>;
+        using const_positional_iterator = position_iterator<true>;
 
         using bit_iterator     = iterator<bitset_mode::BitMode>;
         using segment_iterator = iterator<bitset_mode::SegmentMode>;
@@ -814,7 +817,7 @@ namespace dice::template_library {
             auto end = rend<bitset_mode::SegmentMode>();
 
             while (it != end) {
-                auto &segment = (*it).get();
+                T &segment = *it;
                 if (static_cast<value_type>(~segment) != 0x00) {
                     auto ptr_dist = std::distance(inner_.data(), &segment);
                     if constexpr (!has_max_extent) {
@@ -1013,36 +1016,42 @@ namespace dice::template_library {
 
         template<bitset_mode mode=bitset_mode::BitMode>
         constexpr reverse_iterator<mode> rbegin() noexcept {
-            return reverse_iterator<mode>{begin() + size_in_bits()};
+            if constexpr (mode == bitset_mode::BitMode) {
+                return reverse_iterator<mode>{begin<mode>() + size_in_bits()};
+            } else {
+                return reverse_iterator<mode>{begin<mode>() + size()};
+            }
         }
 
         template<bitset_mode mode=bitset_mode::BitMode>
         constexpr const_reverse_iterator<mode> rbegin() const noexcept {
-            return const_reverse_iterator<mode>{begin() + size_in_bits()};
+            if constexpr (mode == bitset_mode::BitMode) {
+                return const_reverse_iterator<mode>{begin<mode>() + size_in_bits()};
+            } else {
+                return const_reverse_iterator<mode>{begin<mode>() + size()};
+            }
         }
 
         template<bitset_mode mode=bitset_mode::BitMode>
         constexpr reverse_iterator<mode> rend() noexcept {
-            return reverse_iterator<mode>{begin()};
+            return reverse_iterator<mode>{begin<mode>()};
         }
 
         template<bitset_mode mode=bitset_mode::BitMode>
         constexpr const_reverse_iterator<mode> rend() const noexcept {
-            return const_reverse_iterator<mode>{begin()};
+            return const_reverse_iterator<mode>{begin<mode>()};
         }
 
         constexpr std::default_sentinel_t end() const noexcept {
             return std::default_sentinel;
         }
 
-        template<bitset_mode mode=bitset_mode::BitMode>
-        constexpr positional_iterator<mode> pbegin() noexcept {
-            return positional_iterator<mode>{*this};
+        constexpr positional_iterator pbegin() noexcept {
+            return positional_iterator{*this};
         }
 
-        template<bitset_mode mode=bitset_mode::BitMode>
-        constexpr const_positional_iterator<mode> pbegin() const noexcept {
-            return const_positional_iterator<mode>{*this};
+        constexpr const_positional_iterator pbegin() const noexcept {
+            return const_positional_iterator{*this};
         }
 
         constexpr std::default_sentinel_t pend() const noexcept {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -957,7 +957,7 @@ namespace dice::template_library {
             auto const fill_bits = segment_size_in_bits - leftover;
 
             auto const &last = *(begin<bitset_mode::SegmentMode>() + full_segments);
-            auto const padding_mask = static_cast<T>(~T{} >> (segment_size_in_bits - fill_bits));
+            auto const padding_mask = static_cast<T>(static_cast<T>(~T{}) >> (segment_size_in_bits - fill_bits));
             auto const zero_bits = static_cast<size_t>(std::countl_zero(static_cast<T>(static_cast<T>(last << fill_bits) | padding_mask)));
 
             if (zero_bits != leftover) {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -75,6 +75,7 @@ namespace dice::template_library {
      * @tparam bits minimal bits for the underlying bitset : use dynamic_extent to uncap limit
      */
     template<size_t extent, size_t bits, typename T = uint64_t>
+    requires std::unsigned_integral<T>
     struct bitset {
     private:
         static constexpr size_t segment_size = sizeof(T);
@@ -100,13 +101,6 @@ namespace dice::template_library {
 
         static constexpr size_t storage_size = !has_max_extent ? dynamic_extent : segment_size * segments;
         static constexpr size_t storage_size_in_bits = !has_max_extent ? dynamic_extent : storage_size * 8;
-        
-        ///> word used for traversing the inner segment, instead of forcing 1 byte loads
-        using storage_word = std::conditional_t<segment_align >= alignof(std::uint64_t), std::uint64_t,
-            std::conditional_t<segment_align >= alignof(std::uint32_t), std::uint32_t,
-            std::conditional_t<segment_align >= alignof(std::uint16_t), std::uint16_t, std::uint8_t>>>;
-        using storage_word_pointer = storage_word *;
-        using storage_word_const_pointer = storage_word const *;
 
         enum class bitset_mode : uint8_t {
             BitMode = 0x00,
@@ -341,67 +335,26 @@ namespace dice::template_library {
                 auto offset  = (*it_).off;
                 auto segment = it_.get();
 
-                if constexpr (std::integral<T>) {
-                    auto skip = include_current ? offset : offset + 1;
+                auto skip = include_current ? offset : offset + 1;
 
-                    while (true) {
-                        T const shifted = (skip >= inner_size_in_bits())
-                            ? T{}
-                            : static_cast<T>(segment >> skip);
+                while (true) {
+                    T const shifted = (skip >= inner_size_in_bits())
+                        ? T{}
+                        : static_cast<T>(segment >> skip);
 
-                        if (shifted != 0x00) {
-                            it_ += (skip + std::countr_zero(shifted)) - offset;
-                            break;
-                        }
-
-                        it_ += inner_size_in_bits() - offset;
-                        if (it_ == std::default_sentinel) {
-                            break;
-                        }
-
-                        offset = 0;
-                        skip = 0;
-                        segment = it_.get();
+                    if (shifted != 0x00) {
+                        it_ += (skip + std::countr_zero(shifted)) - offset;
+                        break;
                     }
-                }
-                else {
-                    constexpr size_t word_bits = sizeof(storage_word) * 8;
-                    auto word_ix   = offset / word_bits;
-                    auto word_skip = include_current ? (offset % word_bits) : (offset % word_bits) + 1;
 
-                    while (true) {
-                        auto [word, _] = backing_bitset_->segment_slots(segment);
-                        bool found = false;
-
-                        for (auto i{word_ix}; i < segment_steps; ++i) {
-                            auto const skip = (i == word_ix) ? word_skip : 0uz;
-                            storage_word const shifted = (skip >= word_bits)
-                                ? storage_word{0}
-                                : static_cast<storage_word>(word[i] >> skip);
-
-                            if (shifted == 0x00) {
-                                continue;
-                            }
-
-                            it_ += (i * word_bits + skip + std::countr_zero(shifted)) - offset;
-                            found = true;
-                            break;
-                        }
-
-                        if (found) {
-                            break;
-                        }
-
-                        it_ += inner_size_in_bits() - offset;
-                        if (it_ == std::default_sentinel) {
-                            break;
-                        }
-
-                        offset = 0;
-                        word_ix = 0;
-                        word_skip = 0;
-                        segment = it_.get();
+                    it_ += inner_size_in_bits() - offset;
+                    if (it_ == std::default_sentinel) {
+                        break;
                     }
+
+                    offset = 0;
+                    skip = 0;
+                    segment = it_.get();
                 }
             }
 
@@ -571,70 +524,24 @@ namespace dice::template_library {
             return o / (segment_align * 8);
         }
 
-        storage_word_pointer get_chunk_raw(segment const s, offset const o) noexcept {
-            return reinterpret_cast<storage_word_pointer>(inner_.data() + s) + which_chunk(o);
-        }
-
-        storage_word_const_pointer get_chunk_raw(segment const s, offset const o) const noexcept {
-            return reinterpret_cast<storage_word_const_pointer>(inner_.data() + s) + which_chunk(o);
-        }
-
         void segment_set(segment const s, offset const o) noexcept {
-            if constexpr (std::is_integral_v<T>) {
-                *(inner_.data() + s) |= 1uz << o;
-            }
-            else {
-                auto chunk_raw = get_chunk_raw(s, o);
-                *chunk_raw |= 1uz << offset_in_chunk(o);
-            }
+            *(inner_.data() + s) |= 1uz << o;
         }
 
         void segment_flip(segment const s, offset const o) noexcept {
-            if constexpr (std::is_integral_v<T>) {
-                *(inner_.data() + s) ^= 1uz << o;
-            }
-            else {
-                auto chunk_raw = get_chunk_raw(s, o);
-                *chunk_raw ^= 1uz << offset_in_chunk(o);
-            }
+            *(inner_.data() + s) ^= 1uz << o;
         }
 
         void segment_unset(segment const s, offset const o) noexcept {
-            if constexpr (std::is_integral_v<T>) {
-                *(inner_.data() + s) &= ~(1uz << o);
-            }
-            else {
-                auto chunk_raw = get_chunk_raw(s, o);
-                *chunk_raw &= ~(1uz << offset_in_chunk(o));
-            }
+            *(inner_.data() + s) &= ~(1uz << o);
         }
 
         [[nodiscard]] bool segment_test(segment const s, offset const o) const noexcept {
-            if constexpr (std::is_integral_v<T>) {
-                return *(inner_.data() + s) & 1uz << o;
-            }
-            else {
-                auto chunk_raw = get_chunk_raw(s, o);
-                return *chunk_raw & 1uz << offset_in_chunk(o);
-            }
+            return *(inner_.data() + s) & 1uz << o;
         }
 
         [[nodiscard]] size_t segment_count(const_reference segment) const noexcept {
-            if constexpr (std::integral<value_type>) {
-#ifdef __SIZEOF_INT128__
-                if constexpr (std::is_same_v<value_type, __uint128_t>) {
-                    uint64_t const lo = static_cast<uint64_t>(segment);
-                    uint64_t const hi = static_cast<uint64_t>(segment >> 64);
-
-                    return std::popcount(lo) + std::popcount(hi);
-                }
-#endif
-                return std::popcount(segment);
-            }
-
-            return slot_handler(segment, [](storage_word word) -> size_t {
-                return std::popcount(word);
-            }, merge_functor<storage_word>{}, 0uz, add_op{});
+            return std::popcount(segment);
         }
 
         template<typename F, typename M, typename Tp, typename Ops>
@@ -648,6 +555,27 @@ namespace dice::template_library {
             }
 
             return merge_val;
+        }
+
+        template<typename Ops>
+        void segment_handler(bitset const& other) {
+            auto self_it = begin();
+            auto outer_it = other.begin();
+            auto ops = Ops{};
+
+            if (size() != other.size()) {
+                return;
+            }
+
+            auto end_sentinel = end();
+
+            while (self_it != end_sentinel) {
+                auto &seg_this = self_it.get(); auto &seg_other = outer_it.get();
+                seg_this = ops(seg_this, seg_other);
+
+                self_it = advance_segment(self_it);
+                outer_it = advance_segment(outer_it);
+            }
         }
 
         template<typename F>
@@ -742,150 +670,24 @@ namespace dice::template_library {
             return merge_val;
         }
 
-        template<typename F, typename M, typename Tp, typename Ops>
-        [[nodiscard]] Tp slot_handler(const_reference segment, F &&f, M&& m, Tp initial, Ops ops=add_op{}) const {
-            Tp merge_val{initial};
-            auto [word, end] = segment_slots(segment);
-
-            for (; word != end; ++word) {
-                merge_val = std::invoke(std::forward<M>(m), ops, merge_val, std::invoke(std::forward<F>(f), *word));
-            }
-
-            return merge_val;
-        }
-
-        template<typename F, typename Pr, typename M, typename Tp, typename Ops>
-        [[nodiscard]] Tp slot_handler(const_reference segment, F &&f, Pr &&pred, M&& m, Tp initial, Ops ops=add_op{}) const {
-            Tp merge_val{initial};
-            auto [word, end] = segment_slots(segment);
-
-            for (; word != end; ++word) {
-                Tp const val = std::invoke(std::forward<F>(f), *word);
-                merge_val = std::invoke(std::forward<M>(m), ops, merge_val, val);
-                if (!std::invoke(std::forward<Pr>(pred), val)) {
-                    return merge_val;
-                }
-            }
-
-            return merge_val;
-        }
-
-        template<typename F, typename Pr, typename M, typename Tp, typename Ops>
-        [[nodiscard]] Tp slot_handler_backwards(const_reference segment, F &&f, Pr &&pred, M&& m, Tp initial, Ops ops=add_op{}) const {
-            Tp merge_val{initial};
-            auto [word, end] = segment_slots(segment);
-
-            for (; end != word; --end) {
-                Tp const val = std::invoke(std::forward<F>(f), *(end - 1));
-                merge_val = std::invoke(std::forward<M>(m), ops, merge_val, val);
-                if (!std::invoke(std::forward<Pr>(pred), val)) {
-                    return merge_val;
-                }
-            }
-
-            return merge_val;
-        }
-
-        template<typename Ops=add_op>
-        void slot_handler(reference segment, const_reference other) {
-            auto merge_func = dice::template_library::merge_functor<storage_word>{};
-            auto [word, end] = segment_slots(segment);
-            auto [word2, end2] = segment_slots(other);
-
-            for (; word != end && word2 != end2; ++word, ++word2) {
-                *word = merge_func(Ops{}, *word, *word2);
-            }
-        }
-
-        template<typename F>
-        void slot_handler(const_reference segment, F&& f) {
-            auto [word, end] = segment_slots(segment);
-
-            for (; word != end; ++word) {
-                std::invoke(std::forward<F>(f), *word);
-            }
-        }
-
-        void slot_handler(reference segment, storage_word val) {
-            auto [word, end] = segment_slots(segment);
-
-            for (; word != end; ++word) {
-                *word = val;
-            }
-        }
-
-        bool slot_handler(const_reference segment, const_reference other) const {
-            auto [word, end] = segment_slots(segment);
-            auto [word2, end2] = segment_slots(other);
-
-            for (; word != end && word2 != end2; ++word, ++word2) {
-                if (*word != *word2) {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
         [[nodiscard]] size_t segment_free(const_reference segment) const {
-            if constexpr (std::integral<value_type>) {
-                return std::countr_zero(static_cast<value_type>(~segment));
-            }
-
-            return slot_handler(segment, [](storage_word word) -> size_t {
-                auto const segment_free = static_cast<const storage_word>(~word);
-                return std::countr_zero(segment_free);
-            }, [](size_t const val) {
-                return val == sizeof(storage_word) * 8;
-            }, merge_functor<size_t>{}, 0uz, add_op{});
+            return std::countr_zero(static_cast<value_type>(~segment));
         }
 
         [[nodiscard]] size_t segment_countl_zero(const_reference segment) const noexcept {
-            if constexpr (std::integral<value_type>) {
-                return std::countl_zero(segment);
-            }
-
-            return slot_handler_backwards(segment, [](storage_word word) -> size_t {
-                return std::countl_zero(word);
-            }, [](size_t const val) {
-                return val == sizeof(storage_word) * 8;
-            }, merge_functor<size_t>{}, 0uz, add_op{});
+            return std::countl_zero(segment);
         }
 
         [[nodiscard]] size_t segment_countr_zero(const_reference segment) const noexcept {
-            if constexpr (std::integral<value_type>) {
-                return std::countr_zero(segment);
-            }
-
-            return slot_handler(segment, [](storage_word word) -> size_t {
-                return std::countr_zero(word);
-            }, [](size_t const val) {
-                return val == sizeof(storage_word) * 8;
-            }, merge_functor<size_t>{}, 0uz, add_op{});
+            return std::countr_zero(segment);
         }
 
         [[nodiscard]] size_t segment_countl_one(const_reference segment) const noexcept {
-            if constexpr (std::integral<value_type>) {
-                return std::countl_one(segment);
-            }
-
-            return slot_handler_backwards(segment, [](storage_word word) -> size_t {
-                return std::countl_one(word);
-            }, [](size_t const val) {
-                return val == sizeof(storage_word) * 8;
-            }, merge_functor<size_t>{}, 0uz, add_op{});
+            return std::countl_one(segment);
         }
 
         [[nodiscard]] size_t segment_countr_one(const_reference segment) const noexcept {
-            if constexpr (std::integral<value_type>) {
-                return std::countr_one(segment);
-            }
-
-            return slot_handler(segment, [](storage_word word) -> size_t {
-                return std::countr_one(word);
-            }, [](size_t const val) {
-                return val == sizeof(storage_word) * 8;
-            }, merge_functor<size_t>{}, 0uz, add_op{});
+            return std::countr_one(segment);
         }
 
         [[nodiscard]] bool segment_all_set(const_reference segment) const noexcept {
@@ -950,30 +752,6 @@ namespace dice::template_library {
         constexpr ~bitset() = default;
 
         /**
-         * Get word pointers for the corresponding segment
-         *
-         * @return a pair containing word pointers to both segment ends (start, end)
-         */
-        [[nodiscard]] std::pair<storage_word_const_pointer, storage_word_const_pointer> segment_slots(const_reference segment) const noexcept {
-            auto word = reinterpret_cast<storage_word_const_pointer>(&segment);
-            auto const end = word + segment_steps;
-
-            return std::pair{word, end};
-        }
-
-        /**
-         * Get word pointers for the corresponding segment
-         *
-         * @return a pair containing word pointers to both segment ends (start, end)
-         */
-        [[nodiscard]] std::pair<storage_word_pointer, storage_word_pointer> segment_slots(reference segment) const noexcept {
-            auto word = reinterpret_cast<storage_word_pointer>(&segment);
-            auto const end = word + segment_steps;
-
-            return std::pair{word, end};
-        }
-
-        /**
          * Set a bit high for offset ix
          *
          * @param ix offset to use
@@ -996,14 +774,7 @@ namespace dice::template_library {
         }
 
         void set_all() requires(!has_dynamic_extent) {
-            if constexpr (std::integral<value_type>) {
-                std::fill(inner_.begin(), inner_.end(), static_cast<value_type>(~value_type{0}));
-            }
-            else {
-                for (auto &segment : inner_) {
-                    slot_handler(segment, static_cast<storage_word>(~storage_word{0}));
-                }
-            }
+            std::fill(inner_.begin(), inner_.end(), static_cast<value_type>(~value_type{0}));
         }
 
         /**
@@ -1025,14 +796,7 @@ namespace dice::template_library {
         }
 
         void reset_all() requires(!has_dynamic_extent) {
-            if constexpr (std::integral<value_type>) {
-                std::fill(inner_.begin(), inner_.end(), value_type{});
-            }
-            else {
-                for (auto &segment : inner_) {
-                    slot_handler(segment, storage_word{});
-                }
-            }
+            std::fill(inner_.begin(), inner_.end(), value_type{});
         }
 
         /**
@@ -1059,33 +823,17 @@ namespace dice::template_library {
             auto it = begin() + size_in_bits();
             auto end = begin();
 
-            auto perform_shrink = [this](auto &segment) {
-                auto ptr_dist = std::distance(inner_.data(), &segment);
-                if constexpr (!has_max_extent) {
-                    inner_ = storage(inner_.data(), inner_.data() + ptr_dist);
-                }
-                else {
-                    inner_.resize(std::distance(inner_.data(), &segment));
-                }
-            };
-
             while (it != end) {
                 auto &segment = (it - 1).get();
-                if constexpr (std::integral<value_type>) {
-                    if (static_cast<value_type>(~segment) != 0x00) {
-                        perform_shrink(segment);
-                        return;
+                if (static_cast<value_type>(~segment) != 0x00) {
+                    auto ptr_dist = std::distance(inner_.data(), &segment);
+                    if constexpr (!has_max_extent) {
+                        inner_ = storage(inner_.data(), inner_.data() + ptr_dist);
                     }
-                }
-                else {
-                    auto has_bit = slot_handler(segment, [](storage_word word) {
-                        return static_cast<storage_word>(~word) != 0x00;
-                    }, merge_functor<bool>{}, false, bit_or_op{});
-
-                    if (has_bit) {
-                        perform_shrink(segment);
-                        return;
+                    else {
+                        inner_.resize(std::distance(inner_.data(), &segment));
                     }
+                    return;
                 }
                 it = advance_segment_backwards(it);
             }
@@ -1121,7 +869,7 @@ namespace dice::template_library {
             if constexpr (has_dynamic_extent) {
                 if constexpr (!has_max_extent) {
                     inner_.resize(inner_.size() + 1);
-                    *reinterpret_cast<storage_word_pointer>(inner_.end() - 1) = 0x01;
+                    *(inner_.end() - 1) = 0x01;
 
                     return calc_global_idx(size() - 1, 0);
                 }
@@ -1130,7 +878,7 @@ namespace dice::template_library {
                         return storage_size_in_bits;
                     }
                     inner_.resize(inner_.size() + 1);
-                    *reinterpret_cast<storage_word_pointer>(inner_.end() - 1) = 0x01;
+                    *(inner_.end() - 1) = 0x01;
 
                     return calc_global_idx(size() - 1, 0);
                 }
@@ -1367,8 +1115,8 @@ namespace dice::template_library {
         }
 
         bool operator==(bitset const& alt_storage) const noexcept {
-            return segment_handler([this](const_reference segment_first, const_reference segment_second) {
-                return slot_handler(segment_first, segment_second);
+            return segment_handler([](const_reference segment_first, const_reference segment_second) {
+                return segment_first == segment_second;
             }, alt_storage);
         }
 
@@ -1385,18 +1133,12 @@ namespace dice::template_library {
         }
 
         bitset& operator&=(bitset const& alt_storage) noexcept {
-            segment_handler([this](reference segment_first, const_reference segment_second) {
-                slot_handler<bit_and_op>(segment_first, segment_second);
-                return true;
-            }, alt_storage);
+            segment_handler<std::bit_and<T>>(alt_storage);
             return *this;
         }
 
         bitset& operator|=(bitset const& alt_storage) noexcept {
-            segment_handler([this](reference segment_first, const_reference segment_second) {
-                slot_handler<bit_or_op>(segment_first, segment_second);
-                return true;
-            }, alt_storage);
+            segment_handler<std::bit_or<T>>(alt_storage);
             return *this;
         }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -658,18 +658,18 @@ namespace dice::template_library {
 
         template<typename F, typename Pr, typename M, typename Tp>
         Tp segment_handler_backwards(F &&handler, Pr &&pred, M &&merge, Tp initial) const {
-            auto self_it = begin<bitset_mode::SegmentMode>() + size();
-            auto end_it = begin<bitset_mode::SegmentMode>();
+            auto self_it = rbegin<bitset_mode::SegmentMode>();
+            auto end_it = rend<bitset_mode::SegmentMode>();
 
             Tp merge_val{initial};
 
             while (self_it != end_it) {
-                Tp const val = std::invoke(std::forward<F>(handler), (self_it-1).get());
+                Tp const val = std::invoke(std::forward<F>(handler), (*self_it).get());
                 merge_val = std::invoke(std::forward<M>(merge), merge_val, val);
                 if (!std::invoke(std::forward<Pr>(pred), val)) {
                     return merge_val;
                 }
-                --self_it;
+                ++self_it;
             }
             return merge_val;
         }
@@ -810,11 +810,11 @@ namespace dice::template_library {
          * Compacts the underlying storage backend, if applicable
          */
         void shrink_to_fit() requires (has_dynamic_extent){
-            auto it = begin<bitset_mode::SegmentMode>() + size();
-            auto end = begin<bitset_mode::SegmentMode>();
+            auto it = rbegin<bitset_mode::SegmentMode>();
+            auto end = rend<bitset_mode::SegmentMode>();
 
             while (it != end) {
-                auto &segment = (it - 1).get();
+                auto &segment = (*it).get();
                 if (static_cast<value_type>(~segment) != 0x00) {
                     auto ptr_dist = std::distance(inner_.data(), &segment);
                     if constexpr (!has_max_extent) {
@@ -825,7 +825,7 @@ namespace dice::template_library {
                     }
                     return;
                 }
-                --it;
+                ++it;
             }
         }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -554,14 +554,26 @@ namespace dice::template_library {
         }
 
         template<typename Ops>
+        void segment_handler() {
+            auto self_it = begin<bitset_mode::SegmentMode>();
+            auto end_sentinel = end();
+
+            auto ops = Ops{};
+
+            while (self_it != end_sentinel) {
+                auto &seg_this = self_it.get();
+                seg_this = ops(seg_this);
+                ++self_it;
+            }
+        }
+
+        template<typename Ops>
         void segment_handler(bitset const &other) {
             auto self_it = begin<bitset_mode::SegmentMode>();
             auto outer_it = other.begin<bitset_mode::SegmentMode>();
             auto ops = Ops{};
 
-            if (size() != other.size()) {
-                return;
-            }
+            assert(size() != other.size());
 
             auto end_sentinel = end();
 
@@ -1140,7 +1152,7 @@ namespace dice::template_library {
             if (!size_match(alt_storage)) {
                 throw std::logic_error("bitset:: bitset size not match");
             }
-            
+
             segment_handler<std::bit_and<T>>(alt_storage);
             return *this;
         }
@@ -1151,6 +1163,15 @@ namespace dice::template_library {
             }
 
             segment_handler<std::bit_or<T>>(alt_storage);
+            return *this;
+        }
+
+        bitset &operator^=(bitset const &alt_storage) {
+            if (!size_match(alt_storage)) {
+                throw std::logic_error("bitset:: bitset size not match");
+            }
+
+            segment_handler<std::bit_xor<T>>(alt_storage);
             return *this;
         }
 
@@ -1183,6 +1204,22 @@ namespace dice::template_library {
 
             bitset tmp = *this;
             tmp |= bitset_v_second;
+            return tmp;
+        }
+
+        bitset operator^(bitset const &bitset_v_second) const {
+            if (!size_match(bitset_v_second)) {
+                throw std::logic_error("bitset:: bitset size not match");
+            }
+
+            bitset tmp = *this;
+            tmp ^= bitset_v_second;
+            return tmp;
+        }
+
+        bitset operator~() const {
+            bitset tmp = *this;
+            tmp.segment_handler<std::negate<T>>();
             return tmp;
         }
     };

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -1,10 +1,10 @@
 #ifndef DICE_TEMPLATELIBRARY_BITSET_HPP
 #define DICE_TEMPLATELIBRARY_BITSET_HPP
 
-#include <dice/template-library/memfn.hpp>
 #include <bit>
 #include <compare>
 #include <dice/template-library/flex_array.hpp>
+#include <dice/template-library/memfn.hpp>
 #include <format>
 #include <functional>
 #include <iterator>
@@ -52,14 +52,14 @@ namespace dice::template_library {
 
         static constexpr size_t segments = max_bits != dynamic_extent ? (max_bits + segment_size_in_bits - 1) / segment_size_in_bits : dynamic_extent;
 
-        using storage   = flex_array<T, bits, segments>;
+        using storage = flex_array<T, bits, segments>;
         using global_ix = size_t;
-        using segment   = size_t;
-        using offset    = size_t;
-        
+        using segment = size_t;
+        using offset = size_t;
+
     public:
         using value_type = storage::value_type;
-        using reference  = storage::reference;
+        using reference = storage::reference;
         using const_reference = storage::const_reference;
 
         ///> mode to be used for the underlying iterator - make caller enforce policy
@@ -69,10 +69,10 @@ namespace dice::template_library {
         };
 
     private:
-        static constexpr bool   has_max_extent = storage::has_max_extent;
-        static constexpr bool   has_dynamic_extent = storage::has_dynamic_extent;
+        static constexpr bool has_max_extent = storage::has_max_extent;
+        static constexpr bool has_dynamic_extent = storage::has_dynamic_extent;
         static constexpr size_t segment_align = alignof(T);
-        static constexpr size_t segment_steps = segment_size / segment_align; ///> how many chunks fit within one segment
+        static constexpr size_t segment_steps = segment_size / segment_align;  ///> how many chunks fit within one segment
 
         static constexpr size_t storage_size = !has_max_extent ? dynamic_extent : segment_size * segments;
         static constexpr size_t storage_size_in_bits = !has_max_extent ? dynamic_extent : storage_size * 8;
@@ -80,11 +80,11 @@ namespace dice::template_library {
         template<bool is_const, bitset_mode mode = bitset_mode::BitMode>
         struct bitset_iterator {
         private:
-            using bitset_pointer = std::conditional_t<is_const, bitset const*, bitset*>;
-            constexpr static bool using_bit_mode = mode == bitset_mode::BitMode;
+            using bitset_pointer = std::conditional_t<is_const, bitset const *, bitset *>;
+            static constexpr bool using_bit_mode = mode == bitset_mode::BitMode;
 
-            segment       cur_segment_{};
-            offset        cur_offset_{};
+            segment cur_segment_{};
+            offset cur_offset_{};
             bitset_pointer backing_bitset_ = nullptr;
 
         public:
@@ -92,31 +92,38 @@ namespace dice::template_library {
             struct reference {
             private:
                 bitset_pointer backing_bitset_;
+
             public:
                 segment seg;
-                offset  off;
+                offset off;
 
-                reference(reference const&) = default;
-                reference const& operator=(reference const &other) const noexcept {
+                reference(reference const &) = default;
+                reference const &operator=(reference const &other) const noexcept {
                     return *this = static_cast<bool>(other);
                 }
 
                 reference(bitset_pointer backing_bitset, segment const seg, offset const off) noexcept
-                    : backing_bitset_{backing_bitset}, seg{seg}, off{off} {}
+                    : backing_bitset_{backing_bitset},
+                      seg{seg},
+                      off{off} {
+                }
 
-                operator bool() const noexcept requires(using_bit_mode) {
+                operator bool() const noexcept requires (using_bit_mode)
+                {
                     return backing_bitset_->test(calc_global_idx(seg, off));
                 }
 
-                operator size_t() const noexcept requires(using_bit_mode) {
+                operator size_t() const noexcept requires (using_bit_mode)
+                {
                     return ix();
                 }
 
-                operator std::conditional_t<is_const, T const&, T&>() const noexcept requires(!using_bit_mode) {
+                operator std::conditional_t<is_const, T const &, T &>() const noexcept requires (!using_bit_mode)
+                {
                     return *(backing_bitset_->inner_.data() + seg);
                 }
 
-                reference const& operator=(bool const b) const noexcept {
+                reference const &operator=(bool const b) const noexcept {
                     backing_bitset_->set(calc_global_idx(seg, off), b);
                     return *this;
                 }
@@ -127,26 +134,27 @@ namespace dice::template_library {
             };
 
             using iterator_category = std::random_access_iterator_tag;
-            using iterator_concept  = std::random_access_iterator_tag;
-            using value_type        = std::conditional_t<using_bit_mode, bool, value_type>;
-            using pointer           = void;
-            using difference_type   = ptrdiff_t;
+            using iterator_concept = std::random_access_iterator_tag;
+            using value_type = std::conditional_t<using_bit_mode, bool, value_type>;
+            using pointer = void;
+            using difference_type = ptrdiff_t;
 
             bitset_iterator() noexcept = default;
 
-            explicit bitset_iterator(std::conditional_t<is_const, bitset const&, bitset&> bitset) noexcept :
-                backing_bitset_{&bitset} {}
+            explicit bitset_iterator(std::conditional_t<is_const, bitset const &, bitset &> bitset) noexcept
+                : backing_bitset_{&bitset} {
+            }
 
-            explicit bitset_iterator(bitset &bitset, offset const &o) :
-                backing_bitset_{&bitset}{
+            explicit bitset_iterator(bitset &bitset, offset const &o)
+                : backing_bitset_{&bitset} {
                 if (o >= segment_size_in_bits) {
                     throw std::out_of_range{"bitset_iterator: o >= segment_size"};
                 }
                 cur_offset_ = o;
             }
 
-            explicit bitset_iterator(bitset &bitset, offset const &o, segment const &s) :
-                backing_bitset_{&bitset}{
+            explicit bitset_iterator(bitset &bitset, offset const &o, segment const &s)
+                : backing_bitset_{&bitset} {
                 if (o >= segment_size_in_bits) {
                     throw std::out_of_range{"bitset_iterator: o >= segment_size"};
                 }
@@ -159,12 +167,13 @@ namespace dice::template_library {
                 cur_segment_ = s;
             }
 
-            void operator=(bool const b) const noexcept requires(!is_const) {
+            void operator=(bool const b) const noexcept requires (!is_const)
+            {
                 backing_bitset_->set(calc_global_idx(cur_segment_, cur_offset_), b);
             }
 
             reference operator*() const noexcept {
-                return reference {backing_bitset_, cur_segment_, cur_offset_};
+                return reference{backing_bitset_, cur_segment_, cur_offset_};
             }
 
             reference operator[](size_t ix) const noexcept {
@@ -172,7 +181,7 @@ namespace dice::template_library {
             }
 
             // shared iterator for mode=0 (bits) mode>=1 (segments)
-            bitset_iterator& operator++() noexcept {
+            bitset_iterator &operator++() noexcept {
                 if constexpr (mode == bitset_mode::BitMode) {
                     if (++cur_offset_ >= segment_size_in_bits) {
                         ++cur_segment_;
@@ -185,11 +194,11 @@ namespace dice::template_library {
                 return *this;
             }
 
-            bitset_iterator& operator--() noexcept {
+            bitset_iterator &operator--() noexcept {
                 if constexpr (mode == bitset_mode::BitMode) {
                     if (cur_offset_ == 0) {
                         --cur_segment_;
-                        cur_offset_ = segment_size_in_bits-1;
+                        cur_offset_ = segment_size_in_bits - 1;
                         return *this;
                     }
                     --cur_offset_;
@@ -211,7 +220,7 @@ namespace dice::template_library {
                 return tmp;
             }
 
-            bitset_iterator& operator+=(difference_type const skip) noexcept {
+            bitset_iterator &operator+=(difference_type const skip) noexcept {
                 if (skip < 0) {
                     return operator-=(-skip);
                 }
@@ -236,15 +245,14 @@ namespace dice::template_library {
 
                 if constexpr (mode == bitset_mode::BitMode) {
                     skip_handler(skip);
-                }
-                else {
+                } else {
                     skip_handler(skip * segment_size_in_bits);
                 }
 
                 return *this;
             }
 
-            bitset_iterator& operator-=(difference_type const skip) noexcept {
+            bitset_iterator &operator-=(difference_type const skip) noexcept {
                 if (skip < 0) {
                     return operator+=(-skip);
                 }
@@ -265,8 +273,7 @@ namespace dice::template_library {
 
                 if constexpr (mode == bitset_mode::BitMode) {
                     skip_handler(skip);
-                }
-                else {
+                } else {
                     skip_handler(skip * segment_size_in_bits);
                 }
 
@@ -289,11 +296,12 @@ namespace dice::template_library {
                 return (**this).ix() - (*other).ix();
             }
 
-            [[nodiscard]] T const& get() const noexcept {
+            [[nodiscard]] T const &get() const noexcept {
                 return *(backing_bitset_->inner_.data() + cur_segment_);
             }
 
-            [[nodiscard]] T& get() noexcept requires(!is_const){
+            [[nodiscard]] T &get() noexcept requires (!is_const)
+            {
                 return *(backing_bitset_->inner_.data() + cur_segment_);
             }
 
@@ -320,10 +328,8 @@ namespace dice::template_library {
                 return std::strong_ordering::less;
             }
 
-            friend bool operator==(bitset_iterator const &lhs, bitset_iterator const &rhs){
-                return lhs.backing_bitset_ == rhs.backing_bitset_ &&
-                       lhs.cur_segment_ == rhs.cur_segment_ &&
-                       lhs.cur_offset_ == rhs.cur_offset_;
+            friend bool operator==(bitset_iterator const &lhs, bitset_iterator const &rhs) {
+                return lhs.backing_bitset_ == rhs.backing_bitset_ && lhs.cur_segment_ == rhs.cur_segment_ && lhs.cur_offset_ == rhs.cur_offset_;
             }
 
             friend bool operator==(std::default_sentinel_t, bitset_iterator const &it) {
@@ -339,7 +345,7 @@ namespace dice::template_library {
         template<bool is_const>
         struct position_iterator {
         private:
-            using bitset_pointer = std::conditional_t<is_const, bitset const*, bitset*>;
+            using bitset_pointer = std::conditional_t<is_const, bitset const *, bitset *>;
             using reference = bitset_iterator<is_const>::reference;
 
             bitset_iterator<is_const> it_;
@@ -347,15 +353,15 @@ namespace dice::template_library {
 
             ///> add bool to allow setting a start point, without skipping the initial offset
             void seek(bool include_current) noexcept {
-                auto offset  = (*it_).off;
+                auto offset = (*it_).off;
                 auto segment = it_.get();
 
                 auto skip = include_current ? offset : offset + 1;
 
                 while (true) {
                     T const shifted = (skip >= inner_size_in_bits())
-                        ? T{}
-                        : static_cast<T>(segment >> skip);
+                                          ? T{}
+                                          : static_cast<T>(segment >> skip);
 
                     if (shifted != 0x00) {
                         it_ += (skip + std::countr_zero(shifted)) - offset;
@@ -375,19 +381,20 @@ namespace dice::template_library {
 
         public:
             using iterator_category = std::input_iterator_tag;
-            using iterator_concept  = std::input_iterator_tag;
-            using value_type        = size_t;
-            using pointer           = void;
-            using difference_type   = ptrdiff_t;
+            using iterator_concept = std::input_iterator_tag;
+            using value_type = size_t;
+            using pointer = void;
+            using difference_type = ptrdiff_t;
 
-            explicit position_iterator(std::conditional_t<is_const, bitset const&, bitset&> bitset) noexcept
-                : it_{bitset}, backing_bitset_{&bitset} {
+            explicit position_iterator(std::conditional_t<is_const, bitset const &, bitset &> bitset) noexcept
+                : it_{bitset},
+                  backing_bitset_{&bitset} {
                 if (it_ != std::default_sentinel) {
                     seek(true);
                 }
             }
 
-            position_iterator& operator++() noexcept {
+            position_iterator &operator++() noexcept {
                 seek(false);
                 return *this;
             }
@@ -398,11 +405,11 @@ namespace dice::template_library {
                 return tmp;
             }
 
-            reference operator* () const noexcept {
+            reference operator*() const noexcept {
                 return *it_;
             }
 
-            friend bool operator==(position_iterator const &lhs, position_iterator const &rhs){
+            friend bool operator==(position_iterator const &lhs, position_iterator const &rhs) {
                 return lhs.it_ == rhs.it_;
             }
 
@@ -417,7 +424,8 @@ namespace dice::template_library {
 
         storage inner_;
 
-        [[nodiscard]] constexpr size_t require_segments(global_ix const ix) const requires (has_dynamic_extent) {
+        [[nodiscard]] constexpr size_t require_segments(global_ix const ix) const requires (has_dynamic_extent)
+        {
             auto const bit_pos = bits_consumed();
             if (bit_pos > ix) {
                 return 0;
@@ -428,14 +436,14 @@ namespace dice::template_library {
             return [bit_off] {
                 if constexpr (std::has_single_bit(segment_size_in_bits)) {
                     return (bit_off >> std::countr_zero(segment_size_in_bits)) + 1;
-                }
-                else {
+                } else {
                     return bit_off / segment_size_in_bits + 1;
                 }
             }();
         }
 
-        void constexpr expand_segments(global_ix const ix) requires (has_dynamic_extent) {
+        constexpr void expand_segments(global_ix const ix) requires (has_dynamic_extent)
+        {
             auto const to_add = require_segments(ix);
             if (to_add == 0) {
                 return;
@@ -464,17 +472,15 @@ namespace dice::template_library {
         [[nodiscard]] static constexpr segment calc_which_segment(global_ix const ix) noexcept {
             if constexpr (std::has_single_bit(segment_size_in_bits)) {
                 return ix >> std::countr_zero(segment_size_in_bits);
-            }
-            else {
+            } else {
                 return ix / segment_size_in_bits;
             }
         }
 
         [[nodiscard]] static constexpr offset calc_which_offset(global_ix const ix) noexcept {
             if constexpr (std::has_single_bit(segment_size_in_bits)) {
-                return ix & (segment_size_in_bits-1);
-            }
-            else {
+                return ix & (segment_size_in_bits - 1);
+            } else {
                 return ix % segment_size_in_bits;
             }
         }
@@ -507,7 +513,7 @@ namespace dice::template_library {
             }
 
             auto const segment = calc_which_segment(ix);
-            auto const offset  = calc_which_offset(ix);
+            auto const offset = calc_which_offset(ix);
 
             return std::invoke(std::forward<F>(ops), segment, offset);
         }
@@ -542,13 +548,11 @@ namespace dice::template_library {
         }
 
         template<typename F, typename M, typename Tp>
-        requires std::is_same_v<std::invoke_result_t<F, const_reference>, Tp> &&
-            std::invocable<M, Tp, Tp>
+        requires std::is_same_v<std::invoke_result_t<F, const_reference>, Tp> && std::invocable<M, Tp, Tp>
         [[nodiscard]] Tp segment_handler(F &&handler, M &&merge, Tp initial) const {
             Tp merge_val{initial};
             for (auto const &segment : inner_) {
-                merge_val = std::invoke(std::forward<M>(merge), merge_val,
-                    std::invoke(std::forward<F>(handler), segment));
+                merge_val = std::invoke(std::forward<M>(merge), merge_val, std::invoke(std::forward<F>(handler), segment));
             }
 
             return merge_val;
@@ -567,7 +571,8 @@ namespace dice::template_library {
             auto end_sentinel = end();
 
             while (self_it != end_sentinel) {
-                auto &seg_this = self_it.get(); auto &seg_other = outer_it.get();
+                auto &seg_this = self_it.get();
+                auto &seg_other = outer_it.get();
                 seg_this = ops(seg_this, seg_other);
 
                 ++self_it;
@@ -701,19 +706,21 @@ namespace dice::template_library {
         using positional_iterator = position_iterator<false>;
         using const_positional_iterator = position_iterator<true>;
 
-        using bit_iterator     = iterator<bitset_mode::BitMode>;
+        using bit_iterator = iterator<bitset_mode::BitMode>;
         using segment_iterator = iterator<bitset_mode::SegmentMode>;
 
         using const_bit_iterator = const_iterator<bitset_mode::BitMode>;
         using const_segment_iterator = const_iterator<bitset_mode::SegmentMode>;
-        
+
 
         /**
          * Initializes the bitset using an initializer list
          *
          * @param segment_v initializer list of segment type
          */
-        constexpr bitset(std::initializer_list<T> const segment_v) : inner_{segment_v} {}
+        constexpr bitset(std::initializer_list<T> const segment_v)
+            : inner_{segment_v} {
+        }
 
         /**
          * Initializes the bitset using a given segment size
@@ -721,13 +728,14 @@ namespace dice::template_library {
          *
          * @param size segment size to set low
          */
-        explicit constexpr bitset(size_t const size) requires(!has_max_extent) : inner_{} {
+        explicit constexpr bitset(size_t const size) requires (!has_max_extent)
+            : inner_{} {
             inner_.resize(size);
         }
 
-        constexpr bitset(bitset const&) = default;
+        constexpr bitset(bitset const &) = default;
         constexpr bitset(bitset &&) = default;
-        constexpr bitset &operator=(bitset const&) = default;
+        constexpr bitset &operator=(bitset const &) = default;
         constexpr bitset &operator=(bitset &&) = default;
         constexpr ~bitset() = default;
 
@@ -748,12 +756,14 @@ namespace dice::template_library {
          */
         void set(global_ix const ix, bool const high) {
             if (high) {
-                set(ix); return;
+                set(ix);
+                return;
             }
             reset(ix);
         }
 
-        void set_all() requires(!has_dynamic_extent) {
+        void set_all() requires (!has_dynamic_extent)
+        {
             std::fill(inner_.begin(), inner_.end(), static_cast<value_type>(~value_type{0}));
         }
 
@@ -775,7 +785,8 @@ namespace dice::template_library {
             bitset_mod_cntl(DICE_MEMFN(segment_unset), ix);
         }
 
-        void reset_all() requires(!has_dynamic_extent) {
+        void reset_all() requires (!has_dynamic_extent)
+        {
             std::fill(inner_.begin(), inner_.end(), value_type{});
         }
 
@@ -792,14 +803,15 @@ namespace dice::template_library {
             }
 
             auto const segment = calc_which_segment(ix);
-            auto const offset  = calc_which_offset(ix);
+            auto const offset = calc_which_offset(ix);
             return segment_test(segment, offset);
         }
 
         /**
          * Compacts the underlying storage backend, if applicable
          */
-        void shrink_to_fit() requires (has_dynamic_extent){
+        void shrink_to_fit() requires (has_dynamic_extent)
+        {
             auto it = rbegin<bitset_mode::SegmentMode>();
             auto end = rend<bitset_mode::SegmentMode>();
 
@@ -809,8 +821,7 @@ namespace dice::template_library {
                     auto ptr_dist = std::distance(inner_.data(), &segment);
                     if constexpr (!has_max_extent) {
                         inner_ = storage(inner_.data(), inner_.data() + ptr_dist);
-                    }
-                    else {
+                    } else {
                         inner_.resize(std::distance(inner_.data(), &segment));
                     }
                     return;
@@ -827,7 +838,9 @@ namespace dice::template_library {
         [[nodiscard]] size_t count() const {
             return segment_handler([](const_reference segment) -> size_t {
                 return std::popcount(segment);
-            }, std::plus<size_t>{}, 0uz);
+            },
+                                   std::plus<size_t>{},
+                                   0uz);
         }
 
         /**
@@ -852,8 +865,7 @@ namespace dice::template_library {
                     *(inner_.end() - 1) = 0x01;
 
                     return calc_global_idx(size() - 1, 0);
-                }
-                else {
+                } else {
                     if (inner_.size() == inner_.max_size()) {
                         return storage_size_in_bits;
                     }
@@ -875,9 +887,12 @@ namespace dice::template_library {
         [[nodiscard]] size_t countr_zero() const {
             return segment_handler([](const_reference segment) {
                 return std::countr_zero(segment);
-            }, [](size_t const val) {
-                return val == segment_size_in_bits;
-            }, std::plus<size_t>{}, 0uz);
+            },
+                                   [](size_t const val) {
+                                       return val == segment_size_in_bits;
+                                   },
+                                   std::plus<size_t>{},
+                                   0uz);
         }
 
         /**
@@ -888,9 +903,12 @@ namespace dice::template_library {
         [[nodiscard]] size_t countl_zero() const {
             return segment_handler_backwards([](const_reference segment) {
                 return std::countl_zero(segment);
-            }, [](size_t const val) {
-                return val == segment_size_in_bits;
-            }, std::plus<size_t>{}, 0uz);
+            },
+                                             [](size_t const val) {
+                                                 return val == segment_size_in_bits;
+                                             },
+                                             std::plus<size_t>{},
+                                             0uz);
         }
 
         /**
@@ -901,9 +919,12 @@ namespace dice::template_library {
         [[nodiscard]] size_t countr_one() const {
             return segment_handler([](const_reference segment) {
                 return std::countr_one(segment);
-            }, [](size_t const val) {
-                return val == segment_size_in_bits;
-            }, std::plus<size_t>{}, 0uz);
+            },
+                                   [](size_t const val) {
+                                       return val == segment_size_in_bits;
+                                   },
+                                   std::plus<size_t>{},
+                                   0uz);
         }
 
         /**
@@ -914,9 +935,12 @@ namespace dice::template_library {
         [[nodiscard]] size_t countl_one() const {
             return segment_handler_backwards([](const_reference segment) {
                 return std::countl_one(segment);
-            }, [](size_t const val) {
-                return val == segment_size_in_bits;
-            }, std::plus<size_t>{}, 0uz);
+            },
+                                             [](size_t const val) {
+                                                 return val == segment_size_in_bits;
+                                             },
+                                             std::plus<size_t>{},
+                                             0uz);
         }
 
         /**
@@ -927,9 +951,10 @@ namespace dice::template_library {
         [[nodiscard]] bool all_set() const {
             return segment_handler([this](const_reference segment) {
                 return bitset_op_cntl(DICE_MEMFN(segment_all_set), segment);
-            }, [](bool const val) {
-                return val;
-            });
+            },
+                                   [](bool const val) {
+                                       return val;
+                                   });
         }
 
         /**
@@ -940,7 +965,9 @@ namespace dice::template_library {
         [[nodiscard]] bool any_set() const {
             return segment_handler([this](const_reference segment) {
                 return bitset_op_cntl(DICE_MEMFN(segment_any_set), segment);
-            }, std::bit_or<bool>{}, false);
+            },
+                                   std::bit_or<bool>{},
+                                   false);
         }
 
         /**
@@ -951,9 +978,12 @@ namespace dice::template_library {
         [[nodiscard]] bool none_set() const {
             return segment_handler([this](const_reference segment) {
                 return bitset_op_cntl(DICE_MEMFN(segment_none_set), segment);
-            }, [](bool const val) {
-                return val;
-            }, std::bit_and<bool>{}, true);
+            },
+                                   [](bool const val) {
+                                       return val;
+                                   },
+                                   std::bit_and<bool>{},
+                                   true);
         }
 
         /**
@@ -991,17 +1021,17 @@ namespace dice::template_library {
             });
         }
 
-        template<bitset_mode mode=bitset_mode::BitMode>
+        template<bitset_mode mode = bitset_mode::BitMode>
         constexpr iterator<mode> begin() noexcept {
             return iterator<mode>{*this};
         }
 
-        template<bitset_mode mode=bitset_mode::BitMode>
+        template<bitset_mode mode = bitset_mode::BitMode>
         constexpr const_iterator<mode> begin() const noexcept {
             return const_iterator<mode>{*this};
         }
 
-        template<bitset_mode mode=bitset_mode::BitMode>
+        template<bitset_mode mode = bitset_mode::BitMode>
         constexpr reverse_iterator<mode> rbegin() noexcept {
             if constexpr (mode == bitset_mode::BitMode) {
                 return reverse_iterator<mode>{begin<mode>() + size_in_bits()};
@@ -1010,7 +1040,7 @@ namespace dice::template_library {
             }
         }
 
-        template<bitset_mode mode=bitset_mode::BitMode>
+        template<bitset_mode mode = bitset_mode::BitMode>
         constexpr const_reverse_iterator<mode> rbegin() const noexcept {
             if constexpr (mode == bitset_mode::BitMode) {
                 return const_reverse_iterator<mode>{begin<mode>() + size_in_bits()};
@@ -1019,12 +1049,12 @@ namespace dice::template_library {
             }
         }
 
-        template<bitset_mode mode=bitset_mode::BitMode>
+        template<bitset_mode mode = bitset_mode::BitMode>
         constexpr reverse_iterator<mode> rend() noexcept {
             return reverse_iterator<mode>{begin<mode>()};
         }
 
-        template<bitset_mode mode=bitset_mode::BitMode>
+        template<bitset_mode mode = bitset_mode::BitMode>
         constexpr const_reverse_iterator<mode> rend() const noexcept {
             return const_reverse_iterator<mode>{begin<mode>()};
         }
@@ -1057,27 +1087,28 @@ namespace dice::template_library {
         bool operator==(bitset const &alt_storage) const noexcept {
             return segment_handler([](const_reference segment_first, const_reference segment_second) {
                 return segment_first == segment_second;
-            }, alt_storage);
+            },
+                                   alt_storage);
         }
 
-        bitset& operator<<=(size_t shift) {
+        bitset &operator<<=(size_t shift) {
             auto dest_it = std::move(begin() + shift, begin() + size_in_bits(), begin());
             std::fill(dest_it, begin() + size_in_bits(), false);
             return *this;
         }
 
-        bitset& operator>>=(size_t shift) {
+        bitset &operator>>=(size_t shift) {
             auto dest_it = std::move_backward(begin(), begin() + size_in_bits() - shift, begin() + size_in_bits());
             std::fill(begin(), dest_it, false);
             return *this;
         }
 
-        bitset& operator&=(bitset const &alt_storage) noexcept {
+        bitset &operator&=(bitset const &alt_storage) noexcept {
             segment_handler<std::bit_and<T>>(alt_storage);
             return *this;
         }
 
-        bitset& operator|=(bitset const &alt_storage) noexcept {
+        bitset &operator|=(bitset const &alt_storage) noexcept {
             segment_handler<std::bit_or<T>>(alt_storage);
             return *this;
         }
@@ -1106,7 +1137,7 @@ namespace dice::template_library {
             return tmp;
         }
     };
-}
+}  // namespace dice::template_library
 
 template<typename T, size_t extent_, size_t max_extent_>
 struct std::formatter<dice::template_library::bitset<extent_, max_extent_, T>> {
@@ -1128,8 +1159,7 @@ struct std::formatter<dice::template_library::bitset<extent_, max_extent_, T>> {
 
             if (*it == 'x') {
                 hex = true;
-            }
-            else if (*it == 'b'){
+            } else if (*it == 'b') {
                 binary = true;
             }
             ++it;
@@ -1162,8 +1192,7 @@ struct std::formatter<dice::template_library::bitset<extent_, max_extent_, T>> {
 
             if (hex) {
                 out = std::format_to(out, "Segment Representation -> Hex(0xFF)\n");
-            }
-            else {
+            } else {
                 out = std::format_to(out, "Segment Representation -> Bin(0b00)\n");
             }
             *out++ = '\n';
@@ -1175,14 +1204,12 @@ struct std::formatter<dice::template_library::bitset<extent_, max_extent_, T>> {
                 auto const &segment = it.get();
                 out = std::format_to(out, "{:#0{}x}", segment, sizeof(segment) * 2);
                 it += static_cast<ptrdiff_t>(sizeof(T) * 8);
-            }
-            else if (binary) {
+            } else if (binary) {
                 auto const seg_end = it + static_cast<ptrdiff_t>(sizeof(T) * 8);
                 for (; it != seg_end; ++it) {
                     *out++ = *it ? '1' : '0';
                 }
-            }
-            else {
+            } else {
                 // if no mode is supported and somehow it goes throught consider just to step through, for compatible
                 ++it;
             }
@@ -1196,4 +1223,4 @@ struct std::formatter<dice::template_library::bitset<extent_, max_extent_, T>> {
     }
 };
 
-#endif //DICE_TEMPLATELIBRARY_BITSET_HPP
+#endif  //DICE_TEMPLATELIBRARY_BITSET_HPP

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -223,7 +223,7 @@ namespace dice::template_library {
                 auto skip_handler = [this](size_t const skip_size) {
                     auto global_ix = calc_global_idx(cur_segment_, cur_offset_) + skip_size;
 
-                    if (global_ix >= backing_bitset_->size_in_bits()) {
+                    if (global_ix >= backing_bitset_->capacity_in_bits()) {
                         cur_segment_ = backing_bitset_->size();
                         cur_offset_ = 0;
                         return;
@@ -1080,12 +1080,22 @@ namespace dice::template_library {
         }
 
         /**
-         * Returns consumed bits in bits
+         * Returns total capacity bit size (rounded up)
          *
-         * @return consumed bits
+         * @return total capacity
          */
-        constexpr size_t size_in_bits() const noexcept {
+        constexpr size_t capacity_in_bits() const noexcept {
             return size() * segment_size_in_bits;
+        }
+
+        /**
+         * Returns logical bit size
+         *
+         * @return logical bits
+         */
+        static constexpr size_t size_in_bits() noexcept requires (has_max_extent)
+        {
+            return max_bits;
         }
 
         bool operator==(bitset const &alt_storage) const noexcept {
@@ -1096,13 +1106,13 @@ namespace dice::template_library {
         }
 
         bitset &operator<<=(size_t shift) {
-            auto dest_it = std::move(begin() + shift, begin() + size_in_bits(), begin());
-            std::fill(dest_it, begin() + size_in_bits(), false);
+            auto dest_it = std::move(begin() + shift, begin() + capacity_in_bits(), begin());
+            std::fill(dest_it, begin() + capacity_in_bits(), false);
             return *this;
         }
 
         bitset &operator>>=(size_t shift) {
-            auto dest_it = std::move_backward(begin(), begin() + size_in_bits() - shift, begin() + size_in_bits());
+            auto dest_it = std::move_backward(begin(), begin() + capacity_in_bits() - shift, begin() + capacity_in_bits());
             std::fill(begin(), dest_it, false);
             return *this;
         }

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -72,8 +72,6 @@ namespace dice::template_library {
     private:
         static constexpr bool has_max_extent = storage::has_max_extent;
         static constexpr bool has_dynamic_extent = storage::has_dynamic_extent;
-        static constexpr size_t segment_align = alignof(T);
-        static constexpr size_t segment_steps = segment_size / segment_align;  ///> how many chunks fit within one segment
 
         static constexpr size_t storage_size = !has_max_extent ? dynamic_extent : segment_size * max_segments;
         static constexpr size_t storage_size_in_bits = !has_max_extent ? dynamic_extent : storage_size * 8;
@@ -507,14 +505,6 @@ namespace dice::template_library {
             auto const offset = calc_which_offset(ix);
 
             return std::invoke(std::forward<F>(ops), segment, offset);
-        }
-
-        [[nodiscard]] static size_t offset_in_chunk(offset const o) noexcept {
-            return o % (segment_align * 8);
-        }
-
-        [[nodiscard]] static size_t which_chunk(offset const o) noexcept {
-            return o / (segment_align * 8);
         }
 
         void segment_set(segment const s, offset const o) noexcept {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -679,6 +679,10 @@ namespace dice::template_library {
             return std::popcount(segment) == 0x00;
         }
 
+        [[nodiscard]] bool size_match(bitset const& other) {
+            return size() == other.size();
+        }
+
         template<typename F, typename Range>
         requires std::ranges::input_range<Range>
         void positions_cntl(Range &&positions, F &&pos_f) {
@@ -707,6 +711,10 @@ namespace dice::template_library {
         using const_bit_iterator = const_iterator<bitset_mode::BitMode>;
         using const_segment_iterator = const_iterator<bitset_mode::SegmentMode>;
 
+        /**
+         * Empty bitset
+         */
+        constexpr bitset() = default;
 
         /**
          * Initializes the bitset using an initializer list
@@ -1094,47 +1102,85 @@ namespace dice::template_library {
                                    alt_storage);
         }
 
+        template<bitset_mode mode = bitset_mode::BitMode>
         bitset &operator<<=(size_t shift) {
-            auto dest_it = std::move(begin() + shift, begin() + size_in_bits(), begin());
-            std::fill(dest_it, begin() + size_in_bits(), false);
-            return *this;
+            if constexpr (mode == bitset_mode::SegmentMode) {
+                auto dest_it = std::move(begin<mode>() + shift, begin<mode>() + size(), begin<mode>());
+                std::fill(dest_it, begin<mode>() + size(), false);
+                return *this;
+            }
+            else if constexpr (mode == bitset_mode::BitMode){
+                auto dest_it = std::move(begin() + shift, begin() + size_in_bits(), begin());
+                std::fill(dest_it, begin() + size_in_bits(), false);
+                return *this;
+            }
+            else {
+                throw std::logic_error("bitset:: bitset mode not supported");
+            }
         }
 
+        template<bitset_mode mode = bitset_mode::BitMode>
         bitset &operator>>=(size_t shift) {
-            auto dest_it = std::move_backward(begin(), begin() + size_in_bits() - shift, begin() + size_in_bits());
-            std::fill(begin(), dest_it, false);
-            return *this;
+            if constexpr (mode == bitset_mode::SegmentMode) {
+                auto dest_it = std::move_backward(begin<mode>(), begin<mode>() + size() - shift, begin<mode>() + size());
+                std::fill(dest_it, begin<mode>() + size(), false);
+                return *this;
+            }
+            else if constexpr (mode == bitset_mode::BitMode){
+                auto dest_it = std::move_backward(begin(), begin() + size_in_bits() - shift, begin() + size_in_bits());
+                std::fill(begin(), dest_it, false);
+                return *this;
+            }
+            else {
+                throw std::logic_error("bitset:: bitset mode not supported");
+            }
         }
 
-        bitset &operator&=(bitset const &alt_storage) noexcept {
+        bitset &operator&=(bitset const &alt_storage) {
+            if (!size_match(alt_storage)) {
+                throw std::logic_error("bitset:: bitset size not match");
+            }
+            
             segment_handler<std::bit_and<T>>(alt_storage);
             return *this;
         }
 
-        bitset &operator|=(bitset const &alt_storage) noexcept {
+        bitset &operator|=(bitset const &alt_storage) {
+            if (!size_match(alt_storage)) {
+                throw std::logic_error("bitset:: bitset size not match");
+            }
+
             segment_handler<std::bit_or<T>>(alt_storage);
             return *this;
         }
 
-        bitset operator<<(size_t shift) const noexcept {
+        bitset operator<<(size_t shift) const {
             bitset tmp = *this;
             tmp <<= shift;
             return tmp;
         }
 
-        bitset operator>>(size_t shift) const noexcept {
+        bitset operator>>(size_t shift) const {
             bitset tmp = *this;
             tmp >>= shift;
             return tmp;
         }
 
-        bitset operator&(bitset const &bitset_v_second) const noexcept {
+        bitset operator&(bitset const &bitset_v_second) const {
+            if (!size_match(bitset_v_second)) {
+                throw std::logic_error("bitset:: bitset size not match");
+            }
+
             bitset tmp = *this;
             tmp &= bitset_v_second;
             return tmp;
         }
 
-        bitset operator|(bitset const &bitset_v_second) const noexcept {
+        bitset operator|(bitset const &bitset_v_second) const {
+            if (!size_match(bitset_v_second)) {
+                throw std::logic_error("bitset:: bitset size not match");
+            }
+
             bitset tmp = *this;
             tmp |= bitset_v_second;
             return tmp;

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -106,6 +106,10 @@ namespace dice::template_library {
                     return backing_bitset_->test(calc_global_idx(seg, off));
                 }
 
+                operator size_t() const noexcept {
+                    return ix();
+                }
+
                 reference const& operator=(bool const b) const noexcept {
                     backing_bitset_->set(calc_global_idx(seg, off), b);
                     return *this;
@@ -371,7 +375,7 @@ namespace dice::template_library {
         public:
             using iterator_category = std::input_iterator_tag;
             using iterator_concept  = std::input_iterator_tag;
-            using value_type        = bool;
+            using value_type        = size_t;
             using pointer           = void;
             using difference_type   = ptrdiff_t;
 
@@ -688,22 +692,18 @@ namespace dice::template_library {
             return std::popcount(segment) == 0x00;
         }
 
-        template<typename F>
-        void positions_cntl(std::ranges::input_range auto &&positions, F &&pos_f) {
-            if constexpr (std::ranges::sized_range<decltype(positions)>) {
-                auto position_elements = std::ranges::size(positions);
-                if (position_elements >= storage_size_in_bits) {
-                    throw std::range_error{"bitset::set_positions range out of bounds"};
-                }
+        template<typename F, typename Range>
+        requires std::ranges::input_range<Range>
+        void positions_cntl(Range &&positions, F &&pos_f) {
+            if constexpr (has_dynamic_extent) {
+                std::ranges::for_each(std::forward<Range>(positions), [pos_f = std::forward<F>(pos_f), this](auto pos) {
+                    expand_segments(pos);
+                    std::invoke(std::move(pos_f), pos);
+                });
             }
             else {
-                auto position_elements = std::ranges::distance(positions);
-                if (position_elements >= storage_size_in_bits) {
-                    throw std::range_error{"bitset::set_positions range out of bounds"};
-                }
+                std::ranges::for_each(std::forward<Range>(positions), std::forward<F>(pos_f));
             }
-
-            std::ranges::for_each(positions, std::forward<F>(pos_f));
         }
 
     public:
@@ -976,8 +976,10 @@ namespace dice::template_library {
          *
          * @param positions input range of positions
          */
-        void set_positions(std::ranges::input_range auto &&positions) {
-            positions_cntl(std::forward<decltype(positions)>(positions), [this](auto pos) {
+        template<typename Range>
+        requires std::ranges::input_range<Range>
+        void set_positions(Range &&positions) {
+            positions_cntl(std::forward<Range>(positions), [this](auto pos) {
                 this->set(pos);
             });
         }
@@ -987,8 +989,10 @@ namespace dice::template_library {
          *
          * @param positions input range of positions
          */
-        void reset_positions(std::ranges::input_range auto &&positions) {
-            positions_cntl(std::forward<decltype(positions)>(positions), [this](auto pos) {
+        template<typename Range>
+        requires std::ranges::input_range<Range>
+        void reset_positions(Range &&positions) {
+            positions_cntl(std::forward<Range>(positions), [this](auto pos) {
                 this->reset(pos);
             });
         }

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include <iterator>
 #include <ranges>
+#include <algorithm>
 
 namespace dice::template_library {
     /**
@@ -945,12 +946,9 @@ namespace dice::template_library {
          * @return queried state
          */
         [[nodiscard]] bool all_set() const {
-            return segments_all_of([this](segment_const_reference segment) {
+            return std::ranges::all_of(std::ranges::subrange(begin<bitset_mode::SegmentMode>(), end()), [this](segment_const_reference segment) {
                 return DICE_MEMFN(segment_all_set)(segment);
-            },
-                                   [](bool const val) {
-                                       return val;
-                                   });
+            });
         }
 
         /**
@@ -959,14 +957,9 @@ namespace dice::template_library {
          * @return queried state
          */
         [[nodiscard]] bool any_set() const {
-            return segments_reduce_while([this](segment_const_reference segment) {
+            return std::ranges::any_of(std::ranges::subrange(begin<bitset_mode::SegmentMode>(), end()), [this](segment_const_reference segment) {
                 return DICE_MEMFN(segment_any_set)(segment);
-            },
-                                   [](bool const val) { // only terminate if we find a bit set
-                                       return !val;
-                                   },
-                                   std::bit_or<bool>{},
-                                   false);
+            });
         }
 
         /**
@@ -975,14 +968,9 @@ namespace dice::template_library {
          * @return queried state
          */
         [[nodiscard]] bool none_set() const {
-            return segments_reduce_while([this](segment_const_reference segment) {
-                return DICE_MEMFN(segment_none_set)(segment);
-            },
-                                   [](bool const val) {
-                                       return val;
-                                   },
-                                   std::bit_and<bool>{},
-                                   true);
+            return std::ranges::none_of(std::ranges::subrange(begin<bitset_mode::SegmentMode>(), end()), [this](segment_const_reference segment) {
+                return !DICE_MEMFN(segment_none_set)(segment); // flip since none_of evaluates on false
+            });
         }
 
         /**
@@ -990,7 +978,7 @@ namespace dice::template_library {
          *
          * @return input range containing the positions
          */
-        std::ranges::input_range auto positions() const {
+        [[nodiscard]] std::ranges::input_range auto positions() const {
             return std::ranges::subrange(positions_begin(), positions_end());
         }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -300,10 +300,6 @@ namespace dice::template_library {
                 return *(backing_bitset_->inner_.data() + cur_segment_);
             }
 
-            friend bitset_iterator operator+(difference_type lh_add, bitset_iterator const &rhs) noexcept {
-                return rhs + lh_add;
-            }
-
             friend bitset_iterator operator-(difference_type lh_sub, bitset_iterator const &rhs) noexcept {
                 return rhs - lh_sub;
             }
@@ -1222,25 +1218,17 @@ namespace dice::template_library {
 
 template<typename T, size_t extent_, size_t max_extent_>
 struct std::formatter<dice::template_library::bitset<extent_, max_extent_, T>> {
-    bool hex = false;
-    bool debug = false;
     bool binary = false;
 
     ///> parse formatter context, only allowing hex, debug and binary symbol
     constexpr auto parse(std::format_parse_context &ctx) {
         auto it = ctx.begin();
         while (it != ctx.end() && *it != '}') {
-            if (*it != 'x' && *it != '?' && *it != 'b') {
+            if (*it != 'b') {
                 throw std::format_error("Invalid format args for dice::template_library::bitset.");
             }
 
-            if (*it == '?') {
-                debug = true;
-            }
-
-            if (*it == 'x') {
-                hex = true;
-            } else if (*it == 'b') {
+            if (*it == 'b') {
                 binary = true;
             }
             ++it;
@@ -1251,48 +1239,22 @@ struct std::formatter<dice::template_library::bitset<extent_, max_extent_, T>> {
     auto format(dice::template_library::bitset<extent_, max_extent_, T> const &storage, std::format_context &ctx) const {
         auto it = storage.begin();
         auto const end = storage.end();
-        auto const total_bits = storage.size_in_bits();
-
         auto out = ctx.out();
+
         *out++ = '[';
         *out++ = '\n';
 
-        if (debug) {
-            size_t segment_bits = 0;
-            if (it != end) {
-                auto const seg_end = it + static_cast<ptrdiff_t>(sizeof(T) * 8);
-                for (auto p = it; p != seg_end; ++p) {
-                    ++segment_bits;
-                }
-            }
-            auto const segments = (segment_bits == 0) ? 0uz : (total_bits / segment_bits);
-
-            out = std::format_to(out, "Segments : {}\n", segments);
-            out = std::format_to(out, "Segment size : {}\n", segment_bits);
-            out = std::format_to(out, "Storage size : {}\n", total_bits);
-
-            if (hex) {
-                out = std::format_to(out, "Segment Representation -> Hex(0xFF)\n");
-            } else {
-                out = std::format_to(out, "Segment Representation -> Bin(0b00)\n");
-            }
-            *out++ = '\n';
-        }
-
         while (it != end) {
             *out++ = '[';
-            if (hex) {
-                auto const &segment = it.get();
-                out = std::format_to(out, "{:#0{}x}", segment, sizeof(segment) * 2);
-                it += static_cast<ptrdiff_t>(sizeof(T) * 8);
-            } else if (binary) {
+            if (binary) {
                 auto const seg_end = it + static_cast<ptrdiff_t>(sizeof(T) * 8);
                 for (; it != seg_end; ++it) {
                     *out++ = *it ? '1' : '0';
                 }
-            } else {
-                // if no mode is supported and somehow it goes throught consider just to step through, for compatible
-                ++it;
+            } else { // default to hex
+                auto const &segment = it.get();
+                out = std::format_to(out, "{:#0{}x}", segment, sizeof(segment) * 2);
+                it += static_cast<ptrdiff_t>(sizeof(T) * 8);
             }
             *out++ = ']';
             *out++ = '\n';

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -58,11 +58,10 @@ namespace dice::template_library {
         using segment = size_t;
         using offset = size_t;
 
+        using segment_type = storage::value_type;
+        using segment_reference = storage::reference;
+        using segment_const_reference = storage::const_reference;
     public:
-        using value_type = storage::value_type;
-        using reference = storage::reference;
-        using const_reference = storage::const_reference;
-
         ///> mode to be used for the underlying iterator - make caller enforce policy
         enum struct bitset_mode : uint8_t {
             BitMode = 0x00,
@@ -129,7 +128,7 @@ namespace dice::template_library {
 
             using iterator_category = std::random_access_iterator_tag;
             using iterator_concept = std::random_access_iterator_tag;
-            using value_type = std::conditional_t<using_bit_mode, bool, value_type>;
+            using value_type = std::conditional_t<using_bit_mode, bool, segment_type>;
             using pointer = void;
             using difference_type = ptrdiff_t;
 
@@ -531,7 +530,7 @@ namespace dice::template_library {
         }
 
         template<typename F, typename M, typename Tp>
-        requires std::is_same_v<std::invoke_result_t<F, const_reference>, Tp> && std::invocable<M, Tp, Tp>
+        requires std::is_same_v<std::invoke_result_t<F, segment_const_reference>, Tp> && std::invocable<M, Tp, Tp>
         [[nodiscard]] Tp segment_handler(F &&handler, M &&merge, Tp initial) const {
             Tp merge_val{initial};
             for (auto const &segment : inner_) {
@@ -667,15 +666,15 @@ namespace dice::template_library {
             return merge_val;
         }
 
-        [[nodiscard]] bool segment_all_set(const_reference segment) const noexcept {
+        [[nodiscard]] bool segment_all_set(segment_const_reference segment) const noexcept {
             return std::popcount(segment) == segment_size_in_bits;
         }
 
-        [[nodiscard]] bool segment_any_set(const_reference segment) const noexcept {
+        [[nodiscard]] bool segment_any_set(segment_const_reference segment) const noexcept {
             return std::popcount(segment) != 0x00;
         }
 
-        [[nodiscard]] bool segment_none_set(const_reference segment) const noexcept {
+        [[nodiscard]] bool segment_none_set(segment_const_reference segment) const noexcept {
             return std::popcount(segment) == 0x00;
         }
 
@@ -710,6 +709,9 @@ namespace dice::template_library {
 
         using const_bit_iterator = const_iterator<bitset_mode::BitMode>;
         using const_segment_iterator = const_iterator<bitset_mode::SegmentMode>;
+
+        using reference = bit_iterator::reference;
+        using value_type = bit_iterator::value_type;
 
         /**
          * Empty bitset
@@ -767,7 +769,7 @@ namespace dice::template_library {
 
         void set_all() requires (!has_dynamic_extent)
         {
-            std::fill(inner_.begin(), inner_.end(), static_cast<value_type>(~value_type{0}));
+            std::fill(inner_.begin(), inner_.end(), static_cast<segment_type>(~segment_type{0}));
         }
 
         /**
@@ -790,7 +792,7 @@ namespace dice::template_library {
 
         void reset_all() requires (!has_dynamic_extent)
         {
-            std::fill(inner_.begin(), inner_.end(), value_type{});
+            std::fill(inner_.begin(), inner_.end(), segment_type{});
         }
 
         /**
@@ -825,7 +827,7 @@ namespace dice::template_library {
 
             while (it != end) {
                 T &segment = *it;
-                if (static_cast<value_type>(~segment) != 0x00) {
+                if (static_cast<segment_type>(~segment) != 0x00) {
                     auto ptr_dist = std::distance(inner_.data(), &segment);
                     if constexpr (!has_max_extent) {
                         inner_ = storage(inner_.data(), inner_.data() + ptr_dist);
@@ -844,7 +846,7 @@ namespace dice::template_library {
          * @return total bits set
          */
         [[nodiscard]] size_t count() const {
-            return segment_handler([](const_reference segment) -> size_t {
+            return segment_handler([](segment_const_reference segment) -> size_t {
                 return std::popcount(segment);
             },
                                    std::plus<size_t>{},
@@ -858,7 +860,7 @@ namespace dice::template_library {
          */
         [[nodiscard]] size_t set_first_free() {
             for (auto &segment : inner_) {
-                auto offset = std::countr_zero(static_cast<value_type>(~segment));
+                auto offset = std::countr_zero(static_cast<segment_type>(~segment));
 
                 if (offset != segment_size_in_bits) {
                     auto seg = std::distance(inner_.data(), &segment);
@@ -893,7 +895,7 @@ namespace dice::template_library {
          * @return ix to non-zero entry
          */
         [[nodiscard]] size_t countr_zero() const {
-            return segment_handler([](const_reference segment) {
+            return segment_handler([](segment_const_reference segment) {
                 return std::countr_zero(segment);
             },
                                    [](size_t const val) {
@@ -909,7 +911,7 @@ namespace dice::template_library {
          * @return ix to non-zero entry
          */
         [[nodiscard]] size_t countl_zero() const {
-            return segment_handler_backwards([](const_reference segment) {
+            return segment_handler_backwards([](segment_const_reference segment) {
                 return std::countl_zero(segment);
             },
                                              [](size_t const val) {
@@ -925,7 +927,7 @@ namespace dice::template_library {
          * @return ix to zero entry
          */
         [[nodiscard]] size_t countr_one() const {
-            return segment_handler([](const_reference segment) {
+            return segment_handler([](segment_const_reference segment) {
                 return std::countr_one(segment);
             },
                                    [](size_t const val) {
@@ -941,7 +943,7 @@ namespace dice::template_library {
          * @return ix to zero entry
          */
         [[nodiscard]] size_t countl_one() const {
-            return segment_handler_backwards([](const_reference segment) {
+            return segment_handler_backwards([](segment_const_reference segment) {
                 return std::countl_one(segment);
             },
                                              [](size_t const val) {
@@ -957,7 +959,7 @@ namespace dice::template_library {
          * @return queried state
          */
         [[nodiscard]] bool all_set() const {
-            return segment_handler([this](const_reference segment) {
+            return segment_handler([this](segment_const_reference segment) {
                 return DICE_MEMFN(segment_all_set)(segment);
             },
                                    [](bool const val) {
@@ -971,7 +973,7 @@ namespace dice::template_library {
          * @return queried state
          */
         [[nodiscard]] bool any_set() const {
-            return segment_handler([this](const_reference segment) {
+            return segment_handler([this](segment_const_reference segment) {
                 return DICE_MEMFN(segment_any_set)(segment);
             },
                                    [](bool const val) { // only terminate if we find a bit set
@@ -987,7 +989,7 @@ namespace dice::template_library {
          * @return queried state
          */
         [[nodiscard]] bool none_set() const {
-            return segment_handler([this](const_reference segment) {
+            return segment_handler([this](segment_const_reference segment) {
                 return DICE_MEMFN(segment_none_set)(segment);
             },
                                    [](bool const val) {
@@ -1106,7 +1108,7 @@ namespace dice::template_library {
         }
 
         bool operator==(bitset const &alt_storage) const noexcept {
-            return segment_handler([](const_reference segment_first, const_reference segment_second) {
+            return segment_handler([](segment_const_reference segment_first, segment_const_reference segment_second) {
                 return segment_first == segment_second;
             },
                                    alt_storage);

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -206,7 +206,13 @@ namespace dice::template_library {
             }
 
             template<bitset_mode mode = bitset_mode::BitMode>
-            bitset_iterator& operator+=(size_t const skip) noexcept {
+            bitset_iterator& operator+=(difference_type const skip) noexcept {
+                if (skip < 0) {
+                    return operator-=<mode>(-skip);
+                }
+
+                assert(skip >= 0);
+
                 auto skip_handler = [this](size_t const skip_size) {
                     auto global_ix = calc_global_idx(cur_segment_, cur_offset_) + skip_size;
 
@@ -234,7 +240,13 @@ namespace dice::template_library {
             }
 
             template<bitset_mode mode = bitset_mode::BitMode>
-            bitset_iterator& operator-=(size_t const skip) noexcept {
+            bitset_iterator& operator-=(difference_type const skip) noexcept {
+                if (skip < 0) {
+                    return operator+=<mode>(-skip);
+                }
+
+                assert(skip >= 0);
+
                 auto skip_handler = [this](size_t const skip_size) {
                     auto global_ix = calc_global_idx(cur_segment_, cur_offset_);
 
@@ -257,13 +269,13 @@ namespace dice::template_library {
                 return *this;
             }
 
-            bitset_iterator operator+(size_t rh_add) const noexcept {
+            bitset_iterator operator+(difference_type rh_add) const noexcept {
                 bitset_iterator tmp = *this;
                 tmp += rh_add;
                 return tmp;
             }
 
-            bitset_iterator operator-(size_t rh_sub) const noexcept {
+            bitset_iterator operator-(difference_type rh_sub) const noexcept {
                 bitset_iterator tmp = *this;
                 tmp -= rh_sub;
                 return tmp;
@@ -281,11 +293,11 @@ namespace dice::template_library {
                 return *(backing_bitset_->inner_.data() + cur_segment_);
             }
 
-            friend bitset_iterator operator+(size_t lh_add, bitset_iterator const &rhs) noexcept {
+            friend bitset_iterator operator+(difference_type lh_add, bitset_iterator const &rhs) noexcept {
                 return rhs + lh_add;
             }
 
-            friend bitset_iterator operator-(size_t lh_sub, bitset_iterator const &rhs) noexcept {
+            friend bitset_iterator operator-(difference_type lh_sub, bitset_iterator const &rhs) noexcept {
                 return rhs - lh_sub;
             }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -797,6 +797,11 @@ namespace dice::template_library {
                 throw std::out_of_range{"bitset::set: ix out of range"};
             }
 
+            // if the ix is not in the bits consumed range, return false
+            if (ix >= bits_consumed()) {
+                return false;
+            }
+
             auto const segment = calc_which_segment(ix);
             auto const offset = calc_which_offset(ix);
             return segment_test(segment, offset);

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -113,11 +113,6 @@ namespace dice::template_library {
                     return backing_bitset_->test(calc_global_idx(seg, off));
                 }
 
-                operator size_t() const noexcept requires (using_bit_mode)
-                {
-                    return ix();
-                }
-
                 operator std::conditional_t<is_const, T const &, T &>() const noexcept requires (!using_bit_mode)
                 {
                     return *(backing_bitset_->inner_.data() + seg);
@@ -405,8 +400,8 @@ namespace dice::template_library {
                 return tmp;
             }
 
-            reference operator*() const noexcept {
-                return *it_;
+            value_type operator*() const noexcept {
+                return (*it_).ix();
             }
 
             friend bool operator==(position_iterator const &lhs, position_iterator const &rhs) {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -129,7 +129,7 @@ namespace dice::template_library {
 
             using iterator_category = std::random_access_iterator_tag;
             using iterator_concept = std::random_access_iterator_tag;
-            using value_type = std::conditional_t<using_bit_mode, bool, segment_type>;
+            using value_type = std::conditional_t<using_bit_mode, bool, T>;
             using pointer = void;
             using difference_type = ptrdiff_t;
 
@@ -144,6 +144,11 @@ namespace dice::template_library {
                 if (o >= segment_size_in_bits) {
                     throw std::out_of_range{"bitset_iterator: o >= segment_size"};
                 }
+
+                if (calc_global_idx(cur_segment_, o) >= bitset.logical_size()) {
+                    throw std::out_of_range{"bitset_iterator: index out of bounds"};
+                }
+
                 cur_offset_ = o;
             }
 
@@ -155,6 +160,10 @@ namespace dice::template_library {
 
                 if (s >= bitset.size()) {
                     throw std::out_of_range{"bitset_iterator: segment out of bounds"};
+                }
+
+                if (calc_global_idx(s, o) >= bitset.logical_size()) {
+                    throw std::out_of_range{"bitset_iterator: index out of bounds"};
                 }
 
                 cur_offset_ = o;
@@ -176,7 +185,13 @@ namespace dice::template_library {
 
             bitset_iterator &operator++() noexcept {
                 if constexpr (mode == bitset_mode::BitMode) {
-                    if (++cur_offset_ >= segment_size_in_bits) {
+                    ++cur_offset_;
+                    if (calc_global_idx(cur_segment_, cur_offset_) >= backing_bitset_->logical_size()) {
+                        cur_segment_ = backing_bitset_->size();
+                        cur_offset_ = 0;
+                        return *this;
+                    }
+                    if (cur_offset_ >= segment_size_in_bits) {
                         ++cur_segment_;
                         cur_offset_ = 0;
                         return *this;
@@ -223,7 +238,7 @@ namespace dice::template_library {
                 auto skip_handler = [this](size_t const skip_size) {
                     auto global_ix = calc_global_idx(cur_segment_, cur_offset_) + skip_size;
 
-                    if (global_ix >= backing_bitset_->capacity_in_bits()) {
+                    if (global_ix >= backing_bitset_->logical_size()) {
                         cur_segment_ = backing_bitset_->size();
                         cur_offset_ = 0;
                         return;
@@ -333,7 +348,7 @@ namespace dice::template_library {
             }
 
             friend bool operator==(bitset_iterator const &it, std::default_sentinel_t) {
-                return it.cur_segment_ >= it.backing_bitset_->size();
+                return calc_global_idx(it.cur_segment_, it.cur_offset_) >= it.backing_bitset_->logical_size();
             }
         };
 
@@ -355,7 +370,7 @@ namespace dice::template_library {
                 auto skip = include_current ? offset : offset + 1;
 
                 while (true) {
-                    T const shifted = (skip >= inner_size_in_bits())
+                    T const shifted = (skip >= segment_size_in_bits)
                                           ? T{}
                                           : static_cast<T>(segment >> skip);
 
@@ -364,7 +379,7 @@ namespace dice::template_library {
                         break;
                     }
 
-                    it_ += inner_size_in_bits() - offset;
+                    it_ += segment_size_in_bits - offset;
                     if (it_ == std::default_sentinel) {
                         break;
                     }
@@ -419,23 +434,21 @@ namespace dice::template_library {
         };
 
         storage inner_;
+        mutable size_t bits_{};
 
         [[nodiscard]] constexpr size_t require_segments(global_ix const ix) const requires (has_dynamic_extent)
         {
-            auto const bit_pos = bits_consumed();
+            auto const bit_pos = logical_size();
             if (bit_pos > ix) {
                 return 0;
             }
+            bits_ = ix + 1;
 
-            auto const bit_off = ix - bit_pos;
+            if (ix < capacity_in_bits()) {
+                return 0; // fits within current segment
+            }
 
-            return [bit_off] {
-                if constexpr (std::has_single_bit(segment_size_in_bits)) {
-                    return (bit_off >> std::countr_zero(segment_size_in_bits)) + 1;
-                } else {
-                    return bit_off / segment_size_in_bits + 1;
-                }
-            }();
+            return calc_which_segment(ix) - size() + 1;
         }
 
         constexpr void expand_segments(global_ix const ix) requires (has_dynamic_extent)
@@ -453,48 +466,36 @@ namespace dice::template_library {
             }
         }
 
-        [[nodiscard]] constexpr size_t bits_consumed() const noexcept {
-            return inner_.size() * segment_size_in_bits;
-        }
-
         [[nodiscard]] static constexpr bool fits_in_storage(global_ix const ix) noexcept {
             if constexpr (has_max_extent) {
-                return ix < storage_size_in_bits;
+                return ix < max_bits;
             }
 
             return true;
         }
 
         [[nodiscard]] static constexpr segment calc_which_segment(global_ix const ix) noexcept {
-            if constexpr (std::has_single_bit(segment_size_in_bits)) {
-                return ix >> std::countr_zero(segment_size_in_bits);
-            } else {
-                return ix / segment_size_in_bits;
-            }
+            return ix >> std::countr_zero(segment_size_in_bits);
         }
 
         [[nodiscard]] static constexpr offset calc_which_offset(global_ix const ix) noexcept {
-            if constexpr (std::has_single_bit(segment_size_in_bits)) {
-                return ix & (segment_size_in_bits - 1);
-            } else {
-                return ix % segment_size_in_bits;
-            }
+            return ix & (segment_size_in_bits - 1);
         }
 
         [[nodiscard]] static constexpr global_ix calc_global_idx(segment const s, offset const o) noexcept {
             return s * segment_size_in_bits + o;
         }
 
+        [[nodiscard]] constexpr size_t logical_size() const noexcept {
+            if constexpr (!has_dynamic_extent) {
+                return max_bits;
+            } else {
+                return bits_;
+            }
+        }
+
         [[nodiscard]] constexpr size_t size() const noexcept {
             return inner_.size();
-        }
-
-        [[nodiscard]] static constexpr size_t inner_size() noexcept {
-            return segment_size;
-        }
-
-        [[nodiscard]] static constexpr size_t inner_size_in_bits() noexcept {
-            return segment_size_in_bits;
         }
 
         template<typename F>
@@ -564,7 +565,9 @@ namespace dice::template_library {
             auto outer_it = other.begin<bitset_mode::SegmentMode>();
             auto ops = Ops{};
 
-            assert(size() == other.size());
+            if (logical_size() != other.logical_size()) {
+                return;
+            }
 
             auto end_sentinel = end();
 
@@ -584,7 +587,7 @@ namespace dice::template_library {
             auto self_it = begin<bitset_mode::SegmentMode>();
             auto outer_it = other.begin<bitset_mode::SegmentMode>();
 
-            if (size() != other.size()) {
+            if (logical_size() != other.logical_size()) {
                 return false;
             }
 
@@ -666,7 +669,7 @@ namespace dice::template_library {
         }
 
         [[nodiscard]] bool size_match(bitset const& other) const noexcept {
-            return size() == other.size();
+            return logical_size() == other.logical_size();
         }
 
         template<typename F, typename Range>
@@ -711,7 +714,8 @@ namespace dice::template_library {
          * @param segment_v initializer list of segment type
          */
         constexpr bitset(std::initializer_list<T> const segment_v)
-            : inner_{segment_v} {
+            : inner_{segment_v},
+              bits_{segment_size_in_bits * segment_v.size()} {
         }
 
         /**
@@ -721,7 +725,8 @@ namespace dice::template_library {
          * @param size segment size to set low
          */
         explicit constexpr bitset(size_t const size) requires (!has_max_extent)
-            : inner_{} {
+            : inner_{},
+              bits_{segment_size_in_bits * size} {
             inner_.resize(size);
         }
 
@@ -756,7 +761,7 @@ namespace dice::template_library {
 
         void set_all() requires (!has_dynamic_extent)
         {
-            std::fill(inner_.begin(), inner_.end(), static_cast<segment_type>(~segment_type{0}));
+            std::fill(inner_.begin(), inner_.end(), static_cast<T>(~T{}));
         }
 
         /**
@@ -779,7 +784,7 @@ namespace dice::template_library {
 
         void reset_all() requires (!has_dynamic_extent)
         {
-            std::fill(inner_.begin(), inner_.end(), segment_type{});
+            std::fill(inner_.begin(), inner_.end(), T{});
         }
 
         /**
@@ -795,7 +800,7 @@ namespace dice::template_library {
             }
 
             // if the ix is not in the bits consumed range, return false
-            if (ix >= bits_consumed()) {
+            if (ix >= logical_size()) {
                 return false;
             }
 
@@ -814,13 +819,14 @@ namespace dice::template_library {
 
             while (it != end) {
                 T &segment = *it;
-                if (static_cast<segment_type>(~segment) != 0x00) {
+                if (static_cast<T>(~segment) != 0x00) {
                     auto ptr_dist = std::distance(inner_.data(), &segment);
                     if constexpr (!has_max_extent) {
                         inner_ = storage(inner_.data(), inner_.data() + ptr_dist);
                     } else {
-                        inner_.resize(std::distance(inner_.data(), &segment));
+                        inner_.resize(ptr_dist);
                     }
+                    bits_ = ptr_dist * segment_size_in_bits;
                     return;
                 }
                 ++it;
@@ -843,37 +849,41 @@ namespace dice::template_library {
         /**
          * Sets the first bit high, and returns the corresponding index
          *
-         * @return ix to first free index in bitset (if there is no free index, storage_size_in_bits is returned)
+         * @return ix to first free index in bitset (if there is no free index, max_bits is returned)
          */
         [[nodiscard]] size_t set_first_free() {
             for (auto &segment : inner_) {
-                auto offset = std::countr_zero(static_cast<segment_type>(~segment));
+                auto offset = std::countr_zero(static_cast<T>(~segment));
+                auto seg = std::distance(inner_.data(), &segment);
 
-                if (offset != segment_size_in_bits) {
-                    auto seg = std::distance(inner_.data(), &segment);
+                auto global_ix = calc_global_idx(seg, offset);
+
+                if (offset != segment_size_in_bits && global_ix < logical_size()) {
                     segment_set(seg, offset);
-                    return calc_global_idx(seg, offset);
+                    return global_ix;
+                }
+            }
+
+            auto const ext_ix = logical_size();
+
+            // can't grow in static mode
+            if constexpr (!has_dynamic_extent) {
+                return max_bits;
+            }
+
+            if constexpr (has_max_extent) {
+                if (!fits_in_storage(ext_ix)) {
+                    return max_bits;
                 }
             }
 
             if constexpr (has_dynamic_extent) {
-                if constexpr (!has_max_extent) {
-                    inner_.resize(inner_.size() + 1);
-                    *(inner_.end() - 1) = 0x01;
-
-                    return calc_global_idx(size() - 1, 0);
-                } else {
-                    if (inner_.size() == inner_.max_size()) {
-                        return storage_size_in_bits;
-                    }
-                    inner_.resize(inner_.size() + 1);
-                    *(inner_.end() - 1) = 0x01;
-
-                    return calc_global_idx(size() - 1, 0);
-                }
+                expand_segments(ext_ix);
             }
 
-            return storage_size_in_bits;
+            set(ext_ix);
+
+            return ext_ix;
         }
 
         /**
@@ -1021,7 +1031,7 @@ namespace dice::template_library {
         template<bitset_mode mode = bitset_mode::BitMode>
         constexpr reverse_iterator<mode> rbegin() noexcept {
             if constexpr (mode == bitset_mode::BitMode) {
-                return reverse_iterator<mode>{begin<mode>() + capacity_in_bits()};
+                return reverse_iterator<mode>{begin<mode>() + logical_size()};
             } else {
                 return reverse_iterator<mode>{begin<mode>() + size()};
             }
@@ -1030,7 +1040,7 @@ namespace dice::template_library {
         template<bitset_mode mode = bitset_mode::BitMode>
         constexpr const_reverse_iterator<mode> rbegin() const noexcept {
             if constexpr (mode == bitset_mode::BitMode) {
-                return const_reverse_iterator<mode>{begin<mode>() + capacity_in_bits()};
+                return const_reverse_iterator<mode>{begin<mode>() + logical_size()};
             } else {
                 return const_reverse_iterator<mode>{begin<mode>() + size()};
             }
@@ -1076,9 +1086,8 @@ namespace dice::template_library {
          *
          * @return logical bits
          */
-        static constexpr size_t size_in_bits() noexcept requires (has_max_extent)
-        {
-            return max_bits;
+        constexpr size_t size_in_bits() const noexcept {
+            return logical_size();
         }
 
         bool operator==(bitset const &alt_storage) const noexcept {
@@ -1089,13 +1098,13 @@ namespace dice::template_library {
         }
 
         bitset &operator<<=(size_t shift) {
-            auto dest_it = std::move(begin() + shift, begin() + capacity_in_bits(), begin());
-            std::fill(dest_it, begin() + capacity_in_bits(), false);
+            auto dest_it = std::move(begin() + shift, begin() + logical_size(), begin());
+            std::fill(dest_it, begin() + logical_size(), false);
             return *this;
         }
 
         bitset &operator>>=(size_t shift) {
-            auto dest_it = std::move_backward(begin(), begin() + capacity_in_bits() - shift, begin() + capacity_in_bits());
+            auto dest_it = std::move_backward(begin(), begin() + logical_size() - shift, begin() + logical_size());
             std::fill(begin(), dest_it, false);
             return *this;
         }

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -1,14 +1,17 @@
 #ifndef DICE_TEMPLATELIBRARY_BITSET_HPP
 #define DICE_TEMPLATELIBRARY_BITSET_HPP
 
-#include <dice/template-library/flex_array.hpp>
+#include "memfn.hpp"
+
+
 #include <bit>
-#include <functional>
-#include <numeric>
-#include <format>
-#include <iterator>
-#include <ranges>
 #include <compare>
+#include <dice/template-library/flex_array.hpp>
+#include <format>
+#include <functional>
+#include <iterator>
+#include <numeric>
+#include <ranges>
 
 namespace dice::template_library {
     /**
@@ -496,7 +499,7 @@ namespace dice::template_library {
         }
 
         template<typename F>
-        auto bitset_mod_cntl(F &&ops, global_ix const ix) -> std::invoke_result_t<F, bitset*, size_t, size_t> {
+        auto bitset_mod_cntl(F &&ops, global_ix const ix) -> std::invoke_result_t<F, size_t, size_t> {
             if (!fits_in_storage(ix)) {
                 throw std::out_of_range{"bitset::set: ix out of range"};
             }
@@ -509,25 +512,12 @@ namespace dice::template_library {
             auto const segment = calc_which_segment(ix);
             auto const offset  = calc_which_offset(ix);
 
-            using result_t = std::invoke_result_t<F, bitset*, size_t, size_t>;
-
-            if constexpr (std::is_void_v<result_t>) {
-                return std::invoke(std::forward<F>(ops), this, segment, offset);
-            }
-            else {
-                return std::invoke(std::forward<F>(ops), this, segment, offset);
-            }
+            return std::invoke(std::forward<F>(ops), segment, offset);
         }
 
         template<typename F>
-        auto bitset_op_cntl(F &&ops, const_reference segment) const -> std::invoke_result_t<F, bitset*, const_reference> {
-            if constexpr (std::is_void_v<std::invoke_result_t<F, bitset*, const_reference>>) {
-                std::invoke(std::forward<F>(ops), this, segment);
-                return;
-            }
-            else {
-                return std::invoke(std::forward<F>(ops), this, segment);
-            }
+        auto bitset_op_cntl(F &&ops, const_reference segment) const -> std::invoke_result_t<F, const_reference> {
+            return std::invoke(std::forward<F>(ops), segment);
         }
 
         [[nodiscard]] static size_t offset_in_chunk(offset const o) noexcept {
@@ -750,7 +740,7 @@ namespace dice::template_library {
          * @param ix offset to use
          */
         void set(global_ix const ix) {
-            bitset_mod_cntl(&bitset::segment_set, ix);
+            bitset_mod_cntl(DICE_MEMFN(segment_set), ix);
         }
 
         /**
@@ -776,7 +766,7 @@ namespace dice::template_library {
          * @param ix offset to use
          */
         void flip(global_ix const ix) {
-            bitset_mod_cntl(&bitset::segment_flip, ix);
+            bitset_mod_cntl(DICE_MEMFN(segment_flip), ix);
         }
 
         /**
@@ -785,7 +775,7 @@ namespace dice::template_library {
          * @param ix offset to use
          */
         void reset(global_ix const ix) {
-            bitset_mod_cntl(&bitset::segment_unset, ix);
+            bitset_mod_cntl(DICE_MEMFN(segment_unset), ix);
         }
 
         void reset_all() requires(!has_dynamic_extent) {
@@ -939,7 +929,7 @@ namespace dice::template_library {
          */
         [[nodiscard]] bool all_set() const {
             return segment_handler([this](const_reference segment) {
-                return bitset_op_cntl(&bitset::segment_all_set, segment);
+                return bitset_op_cntl(DICE_MEMFN(segment_all_set), segment);
             }, [](bool const val) {
                 return val;
             });
@@ -952,7 +942,7 @@ namespace dice::template_library {
          */
         [[nodiscard]] bool any_set() const {
             return segment_handler([this](const_reference segment) {
-                return bitset_op_cntl(&bitset::segment_any_set, segment);
+                return bitset_op_cntl(DICE_MEMFN(segment_any_set), segment);
             }, std::bit_or<bool>{}, false);
         }
 
@@ -963,7 +953,7 @@ namespace dice::template_library {
          */
         [[nodiscard]] bool none_set() const {
             return segment_handler([this](const_reference segment) {
-                return bitset_op_cntl(&bitset::segment_none_set, segment);
+                return bitset_op_cntl(DICE_MEMFN(segment_none_set), segment);
             }, [](bool const val) {
                 return val;
             }, std::bit_and<bool>{}, true);

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -1,16 +1,13 @@
 #ifndef DICE_TEMPLATELIBRARY_BITSET_HPP
 #define DICE_TEMPLATELIBRARY_BITSET_HPP
 
-#include "memfn.hpp"
-
-
+#include <dice/template-library/memfn.hpp>
 #include <bit>
 #include <compare>
 #include <dice/template-library/flex_array.hpp>
 #include <format>
 #include <functional>
 #include <iterator>
-#include <numeric>
 #include <ranges>
 
 namespace dice::template_library {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -50,9 +50,10 @@ namespace dice::template_library {
         static constexpr size_t segment_size = sizeof(T);
         static constexpr size_t segment_size_in_bits = segment_size * 8;
 
-        static constexpr size_t segments = max_bits != dynamic_extent ? (max_bits + segment_size_in_bits - 1) / segment_size_in_bits : dynamic_extent;
+        static constexpr size_t segments = bits; // just forward this value
+        static constexpr size_t max_segments = max_bits != dynamic_extent ? (max_bits + segment_size_in_bits - 1) / segment_size_in_bits : dynamic_extent;
 
-        using storage = flex_array<T, bits, segments>;
+        using storage = flex_array<T, segments, max_segments>;
         using global_ix = size_t;
         using segment = size_t;
         using offset = size_t;
@@ -74,7 +75,7 @@ namespace dice::template_library {
         static constexpr size_t segment_align = alignof(T);
         static constexpr size_t segment_steps = segment_size / segment_align;  ///> how many chunks fit within one segment
 
-        static constexpr size_t storage_size = !has_max_extent ? dynamic_extent : segment_size * segments;
+        static constexpr size_t storage_size = !has_max_extent ? dynamic_extent : segment_size * max_segments;
         static constexpr size_t storage_size_in_bits = !has_max_extent ? dynamic_extent : storage_size * 8;
 
         template<bool is_const, bitset_mode mode = bitset_mode::BitMode>
@@ -175,7 +176,6 @@ namespace dice::template_library {
                 return *(*this + ix);
             }
 
-            // shared iterator for mode=0 (bits) mode>=1 (segments)
             bitset_iterator &operator++() noexcept {
                 if constexpr (mode == bitset_mode::BitMode) {
                     if (++cur_offset_ >= segment_size_in_bits) {

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -991,7 +991,7 @@ namespace dice::template_library {
          * @return input range containing the positions
          */
         std::ranges::input_range auto positions() const {
-            return std::ranges::subrange(pbegin(), pend());
+            return std::ranges::subrange(positions_begin(), positions_end());
         }
 
         /**
@@ -1062,15 +1062,15 @@ namespace dice::template_library {
             return std::default_sentinel;
         }
 
-        constexpr positional_iterator pbegin() noexcept {
+        constexpr positional_iterator positions_begin() noexcept {
             return positional_iterator{*this};
         }
 
-        constexpr const_positional_iterator pbegin() const noexcept {
+        constexpr const_positional_iterator positions_begin() const noexcept {
             return const_positional_iterator{*this};
         }
 
-        constexpr std::default_sentinel_t pend() const noexcept {
+        constexpr std::default_sentinel_t positions_end() const noexcept {
             return std::default_sentinel;
         }
 

--- a/include/dice/template-library/bitset.hpp
+++ b/include/dice/template-library/bitset.hpp
@@ -63,7 +63,7 @@ namespace dice::template_library {
         using const_reference = storage::const_reference;
 
         ///> mode to be used for the underlying iterator - make caller enforce policy
-        enum class bitset_mode : uint8_t {
+        enum struct bitset_mode : uint8_t {
             BitMode = 0x00,
             SegmentMode = 0x01,
         };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,3 +129,6 @@ custom_add_test(tests_exchange_channel)
 
 add_executable(tests_sandbox tests_sandbox.cpp)
 custom_add_test(tests_sandbox)
+
+add_executable(tests_bitset tests_bitset.cpp)
+custom_add_test(tests_bitset)

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -101,25 +101,46 @@ TEST_SUITE("bitset") {
 		SUBCASE("dynamic size, dynamic capacity, size_t segments") {
 			auto b = create_bitset({0b101uz, 0b010uz});
 			static_assert(std::is_same_v<decltype(b), bitset<std::size_t, dynamic_extent, dynamic_extent>>);
+			REQUIRE_EQ(b.size(), 2);
 			CHECK_EQ(b.count(), 3);
+			CHECK(b.test(0));
+			CHECK_FALSE(b.test(1));
+			CHECK(b.test(2));
+			CHECK(b.test(decltype(b)::segment_size_in_bits + 1)); // segment 1, bit 1 (value 0b010)
 		}
 
 		SUBCASE("dynamic size, bounded capacity, size_t segments") {
 			auto b = create_bitset<4>({0b101uz, 0b010uz});
 			static_assert(std::is_same_v<decltype(b), bitset<std::size_t, dynamic_extent, 4>>);
+			REQUIRE_EQ(b.size(), 2);
 			CHECK_EQ(b.count(), 3);
+			CHECK(b.test(0));
+			CHECK(b.test(2));
+			CHECK(b.test(decltype(b)::segment_size_in_bits + 1));
+
+			CHECK_THROWS_AS((create_bitset<4>({0uz, 0uz, 0uz, 0uz, 0uz})), std::length_error);
 		}
 
 		SUBCASE("dynamic size, bounded capacity, custom segment type") {
 			auto b = create_bitset<std::uint8_t, 4>({0b101, 0b010});
 			static_assert(std::is_same_v<decltype(b), bitset<std::uint8_t, dynamic_extent, 4>>);
+			REQUIRE_EQ(b.size(), 2);
 			CHECK_EQ(b.count(), 3);
+			CHECK(b.test(0));
+			CHECK(b.test(2));
+			CHECK(b.test(decltype(b)::segment_size_in_bits + 1)); // segment 1, bit 1
+
+			CHECK_THROWS_AS((create_bitset<std::uint8_t, 4>({0, 0, 0, 0, 0})), std::length_error);
 		}
 
 		SUBCASE("dynamic size, dynamic capacity, custom segment type") {
 			auto b = create_bitset<std::uint8_t>({0b101, 0b010});
 			static_assert(std::is_same_v<decltype(b), bitset<std::uint8_t, dynamic_extent, dynamic_extent>>);
+			REQUIRE_EQ(b.size(), 2);
 			CHECK_EQ(b.count(), 3);
+			CHECK(b.test(0));
+			CHECK(b.test(2));
+			CHECK(b.test(decltype(b)::segment_size_in_bits + 1));
 		}
 	}
 

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -26,7 +26,7 @@ TEST_SUITE("bitset") {
 
 	using dyn64 = bitset<dynamic_extent, dynamic_extent>;
 	using dyn8 = bitset<std::dynamic_extent, dynamic_extent, uint8_t>;
-	using bounded64 = bitset<dynamic_extent, 4>; // capacity: 4 segments = 256 bits
+	using bounded64 = bitset<dynamic_extent, 4 * 64>; // capacity: 4 segments = 256 bits (2nd param is now a bit count)
 
 	// segment_size_in_bits/storage_size_in_bits etc. are implementation details and are private,
 	// so shape constants that used to come straight from the class are now hardcoded/derived here
@@ -178,7 +178,7 @@ TEST_SUITE("bitset") {
 	}
 
 	TEST_CASE("fully static capacity (extent == segments)") {
-		using fixed64 = bitset<4, 4>;
+		using fixed64 = bitset<4, 4 * 64>; // extent stays in segments; 2nd param is now a bit count
 		constexpr size_t fixed64_capacity_bits = 4 * 64;
 
 		SUBCASE("initializer list must match extent exactly") {
@@ -665,7 +665,7 @@ TEST_SUITE("bitset") {
 	}
 
 	TEST_CASE("fixed and bounded capacity - equality, bitwise ops and shifts") {
-		using fixed64 = bitset<4, 4>;
+		using fixed64 = bitset<4, 4 * 64>; // extent stays in segments; 2nd param is now a bit count
 
 		SUBCASE("fully static capacity supports equality and bitwise combination") {
 			fixed64 a{0b1100, 0, 0, 0};
@@ -903,7 +903,7 @@ TEST_SUITE("bitset") {
 	TEST_CASE("set_all / reset_all (fully static capacity only)") {
 		// set_all()/reset_all() require !has_dynamic_extent, i.e. extent == segments - neither
 		// dyn8/dyn64 (fully dynamic) nor bounded64 (dynamic size, bounded capacity) qualify.
-		using fixed64 = bitset<4, 4>;
+		using fixed64 = bitset<4, 4 * 64>; // extent stays in segments; 2nd param is now a bit count
 		constexpr size_t fixed64_capacity_bits = 4 * 64;
 
 		SUBCASE("set_all sets every bit") {
@@ -921,7 +921,7 @@ TEST_SUITE("bitset") {
 		}
 
 		SUBCASE("set_all on a multi-word segment type sets every bit in every word") {
-			using fixed_wide = bitset<2, 2, wide_word>;
+			using fixed_wide = bitset<2, 2 * 128, wide_word>; // extent stays in segments; 2nd param is now a bit count
 			constexpr size_t fixed_wide_capacity_bits = 2 * 128;
 
 			fixed_wide b{wide_word{}, wide_word{}};
@@ -931,7 +931,7 @@ TEST_SUITE("bitset") {
 		}
 
 		SUBCASE("reset_all on a multi-word segment type clears every bit in every word") {
-			using fixed_wide = bitset<2, 2, wide_word>;
+			using fixed_wide = bitset<2, 2 * 128, wide_word>; // extent stays in segments; 2nd param is now a bit count
 			wide_word full{};
 			full.lo = ~0ull;
 			full.hi = ~0ull;
@@ -1248,6 +1248,58 @@ TEST_SUITE("bitset") {
 				++i;
 			}
 			CHECK_EQ(i, expected.size());
+		}
+	}
+
+	TEST_CASE("bit count that isn't a multiple of the segment width rounds up to a whole segment") {
+		// the 2nd template parameter is a bit count; internally it's converted to a segment count via
+		// ceil(bits / segment_size_in_bits). These use bit counts that deliberately don't divide evenly
+		// by the segment width, to verify the *actual* capacity is rounded up to cover them, not
+		// truncated down to fewer segments and not left as some other unrelated fixed value.
+
+		SUBCASE("bounded (dynamic size, capped) capacity: uint64_t segments") {
+			// 200 bits doesn't divide evenly by 64 -> needs ceil(200/64) = 4 segments = 256 bits capacity
+			using bounded_odd = bitset<dynamic_extent, 200>;
+			constexpr size_t expected_capacity_bits = 4 * 64;
+
+			bounded_odd b{};
+			CHECK_NOTHROW(b.set(expected_capacity_bits - 1)); // last bit of the 4th (rounded-up) segment
+			REQUIRE_EQ(b.size_in_bits(), expected_capacity_bits); // grew to a whole segment, not just to 200 bits
+			CHECK_THROWS_AS(b.set(expected_capacity_bits), std::out_of_range); // truly out of capacity
+		}
+
+		SUBCASE("fully static capacity: uint64_t segments") {
+			// extent must equal the segment count derived from bits (4) for the fully-static flex_array
+			// specialization to apply; using 200 (not 256) here is what actually exercises the rounding
+			using fixed_odd = bitset<4, 200>;
+			constexpr size_t expected_capacity_bits = 4 * 64;
+
+			fixed_odd b{0, 0, 0, 0};
+			CHECK_NOTHROW(b.set(expected_capacity_bits - 1));
+			CHECK_THROWS_AS(b.set(expected_capacity_bits), std::out_of_range);
+		}
+
+		SUBCASE("bounded capacity: narrow (uint8_t) segments") {
+			// 20 bits doesn't divide evenly by 8 -> needs ceil(20/8) = 3 segments = 24 bits capacity
+			using bounded_odd8 = bitset<dynamic_extent, 20, uint8_t>;
+			constexpr size_t expected_capacity_bits = 3 * 8;
+
+			bounded_odd8 b{};
+			CHECK_NOTHROW(b.set(expected_capacity_bits - 1));
+			REQUIRE_EQ(b.size_in_bits(), expected_capacity_bits);
+			CHECK_THROWS_AS(b.set(expected_capacity_bits), std::out_of_range);
+		}
+
+		SUBCASE("bounded capacity: multi-word (non-integral) segments") {
+			// wide_word segments are 128 bits wide; 130 bits doesn't divide evenly -> ceil(130/128) = 2
+			// segments = 256 bits capacity
+			using bounded_odd_wide = bitset<dynamic_extent, 130, wide_word>;
+			constexpr size_t expected_capacity_bits = 2 * 128;
+
+			bounded_odd_wide b{};
+			CHECK_NOTHROW(b.set(expected_capacity_bits - 1));
+			REQUIRE_EQ(b.size_in_bits(), expected_capacity_bits);
+			CHECK_THROWS_AS(b.set(expected_capacity_bits), std::out_of_range);
 		}
 	}
 }

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -183,7 +183,7 @@ TEST_SUITE("bitset") {
 		SUBCASE("out_of_range when index exceeds a fixed capacity") {
 			bounded64 b{};
 			REQUIRE_THROWS_AS(b.set(bounded64::storage_size_in_bits), std::out_of_range);
-			REQUIRE_THROWS_AS(b.test(bounded64::storage_size_in_bits), std::out_of_range);
+			REQUIRE_THROWS_AS((void)b.test(bounded64::storage_size_in_bits), std::out_of_range);
 			CHECK_EQ(b.size(), 0); // rejected out-of-range set() must not have grown anything
 			CHECK_NOTHROW(b.set(bounded64::storage_size_in_bits - 1));
 		}
@@ -585,7 +585,7 @@ TEST_SUITE("bitset") {
 			int global_ix = 15;
 			for (auto it = b.rbegin(); it != b.rend(); ++it, --global_ix) {
 				bool const expected = (global_ix == 0 || global_ix == 15);
-				CHECK_EQ(*it, expected);
+				CHECK_EQ(static_cast<bool>(*it), expected);
 				++visited;
 			}
 			CHECK_EQ(visited, b.size_in_bits());

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -428,6 +428,105 @@ TEST_SUITE("bitset") {
 			it3.operator+=<bitset_const::segment_mode>(1);
 			CHECK_EQ(it3.get(), 0b00000010);
 		}
+
+		SUBCASE("operator-- / operator--(int) walk backwards, wrapping across segments") {
+			dyn8 b{0b00000001, 0b10000000};
+
+			auto it = b.begin() + 9; // segment 1, offset 1
+			--it;                    // segment 1, offset 0
+			CHECK_EQ(it.get(), 0b10000000);
+
+			--it; // wraps back into segment 0, offset 7 (top bit of segment 0)
+			CHECK_EQ(it.get(), 0b00000001);
+			CHECK_FALSE(*it); // offset 7 of segment 0 is unset
+
+			auto it2 = b.begin() + 3;
+			auto const prev = it2--;
+			CHECK(prev == b.begin() + 3);
+			CHECK(it2 == b.begin() + 2);
+		}
+
+		SUBCASE("operator-= / operator- walk backwards by bits or by segments") {
+			dyn8 b{0b00000000, 0b00000010};
+
+			auto it = b.begin() + 9;
+			it -= 9;
+			CHECK_FALSE(*it);
+			CHECK(it == b.begin());
+
+			auto const it2 = (b.begin() + 9) - 9;
+			CHECK(it2 == b.begin());
+
+			dyn8 b2{0xAA, 0xBB};
+			auto it3 = b2.begin();
+			it3.operator++<bitset_const::segment_mode>();
+			CHECK_EQ(it3.get(), 0xBB);
+			it3.operator--<bitset_const::segment_mode>();
+			CHECK_EQ(it3.get(), 0xAA);
+		}
+
+		SUBCASE("const bitset yields a const_iterator with read access") {
+			dyn8 const b{0b00000101};
+			auto it = b.begin();
+			CHECK(*it);
+			CHECK_EQ(it.get(), 0b00000101);
+		}
+
+		SUBCASE("bit_ref proxy assignment (through operator*, not just the iterator itself)") {
+			dyn8 b{0x00};
+			auto it = b.begin();
+			*it = true;
+			CHECK(b.test(0));
+
+			++it;
+			*it = true;
+			CHECK(b.test(1));
+
+			*it = false;
+			CHECK_FALSE(b.test(1));
+		}
+
+		SUBCASE("explicit iterator construction with an offset validates the offset") {
+			dyn8 b{0x00};
+			CHECK_NOTHROW((dyn8::iterator{b, 7}));
+			CHECK_THROWS_AS((dyn8::iterator{b, 8}), std::out_of_range); // segment_size_in_bits == 8
+
+			dyn8::iterator it{b, 3};
+			CHECK(it == b.begin() + 3);
+		}
+
+		SUBCASE("explicit iterator construction with an offset and segment validates both") {
+			dyn8 b{0x00, 0x00};
+			CHECK_NOTHROW((dyn8::iterator{b, 0, 1}));
+			CHECK_THROWS_AS((dyn8::iterator{b, 8, 0}), std::out_of_range);  // bad offset
+			CHECK_THROWS_AS((dyn8::iterator{b, 0, 2}), std::out_of_range); // segment out of bounds, size() == 2
+
+			dyn8::iterator it{b, 2, 1};
+			CHECK(it == b.begin() + 10);
+		}
+
+		/*SUBCASE("reverse iteration (rbegin/rend) visits every bit in reverse order exactly once") {
+			dyn8 b{0b00000001, 0b10000000};
+
+			size_t visited = 0;
+			int global_ix = 15;
+			for (auto it = b.rbegin(); it != b.rend(); ++it, --global_ix) {
+				bool const expected = (global_ix == 0 || global_ix == 15);
+				CHECK_EQ(*it, expected);
+				++visited;
+			}
+			CHECK_EQ(visited, b.size_in_bits());
+			CHECK_EQ(global_ix, -1);
+		}
+
+		SUBCASE("reverse iteration on a const bitset") {
+			dyn8 const b{0b00000001, 0b10000000};
+			size_t visited = 0;
+			for (auto it = b.rbegin(); it != b.rend(); ++it) {
+				++visited;
+			}
+			CHECK_EQ(visited, b.size_in_bits());
+		} */
 	}
 
 	TEST_CASE("shifts") {
@@ -466,17 +565,183 @@ TEST_SUITE("bitset") {
 			CHECK(b.test(1));
 			CHECK_FALSE(b.test(2));
 		}
+
+		SUBCASE("shift by 0 is a no-op") {
+			dyn8 b{0b10110011};
+			b <<= 0;
+			CHECK_EQ(b.count(), 5);
+			CHECK(b.test(0));
+			CHECK(b.test(7));
+
+			b >>= 0;
+			CHECK_EQ(b.count(), 5);
+		}
+
+		SUBCASE("shift by exactly size_in_bits() clears everything") {
+			dyn8 b{0xFF, 0xFF};
+			b <<= b.size_in_bits();
+			CHECK_EQ(b.count(), 0);
+
+			dyn8 b2{0xFF, 0xFF};
+			b2 >>= b2.size_in_bits();
+			CHECK_EQ(b2.count(), 0);
+		}
+
+		SUBCASE("shift by more than size_in_bits() clears everything (regression: used to hang)") {
+			// previously, shifting by more bits than the bitset holds caused the internal
+			// iterator arithmetic to compare against the static storage capacity instead of
+			// the bitset's actual size, so the move/fill loop in operator<<=/>>= never
+			// terminated for bitsets whose size() can be less than their max capacity.
+			dyn8 b{0xFF, 0xFF};
+			b <<= b.size_in_bits() + 5;
+			CHECK_EQ(b.count(), 0);
+
+			dyn8 b2{0xFF, 0xFF};
+			b2 >>= b2.size_in_bits() + 5;
+			CHECK_EQ(b2.count(), 0);
+
+			bounded64 b3{~0ull, ~0ull}; // size() == 2 segments, capacity 4 segments
+			b3 <<= b3.size_in_bits() + 30; // within capacity, beyond current size
+			CHECK_EQ(b3.count(), 0);
+
+			bounded64 b4{~0ull, ~0ull};
+			b4 <<= bounded64::storage_size_in_bits + 100; // beyond even the max capacity
+			CHECK_EQ(b4.count(), 0);
+		}
+
+		SUBCASE("shift crossing multiple segment boundaries") {
+			dyn8 left{0x00, 0x00, 0xFF}; // bits 16..23 set (top segment)
+			left <<= 10;                 // pulls the high segment's bits down across a boundary
+			CHECK_FALSE(left.test(5));
+			CHECK(left.test(6));
+			CHECK(left.test(13));
+			CHECK_FALSE(left.test(14));
+
+			dyn8 right{0xFF, 0x00, 0x00}; // bits 0..7 set (bottom segment)
+			right >>= 10;                 // pushes the low segment's bits up across a boundary
+			CHECK_FALSE(right.test(9));
+			CHECK(right.test(10));
+			CHECK(right.test(17));
+			CHECK_FALSE(right.test(18));
+		}
+	}
+
+	TEST_CASE("all_set / any_set / none_set on an empty bitset") {
+		dyn8 b{};
+		REQUIRE_EQ(b.size(), 0);
+		CHECK(b.all_set());   // vacuously true: no bit fails to be set
+		CHECK_FALSE(b.any_set());
+		CHECK(b.none_set());  // vacuously true: no bit is set
+	}
+
+	TEST_CASE("bitwise combination with mismatched sizes leaves the receiver untouched") {
+		// segment_handler(bitset const&) bails out (returns false) as soon as it sees a size
+		// mismatch, before touching any segment - documenting that &=/|= are silent no-ops here
+		// rather than throwing, unlike e.g. set()/test() which throw on out-of-range access.
+		SUBCASE("operator&= with a differently-sized operand") {
+			dyn8 a{0xFF, 0xFF};
+			dyn8 b{0xFF};
+			a &= b;
+			CHECK_EQ(a.count(), 16);
+		}
+
+		SUBCASE("operator|= with a differently-sized operand") {
+			dyn8 a{0x00, 0x00};
+			dyn8 b{0xFF};
+			a |= b;
+			CHECK_EQ(a.count(), 0);
+		}
+	}
+
+	TEST_CASE("fixed and bounded capacity - equality, bitwise ops and shifts") {
+		using fixed64 = bitset<std::uint64_t, 4, 4>;
+
+		SUBCASE("fully static capacity supports equality and bitwise combination") {
+			fixed64 a{0b1100, 0, 0, 0};
+			fixed64 b{0b1010, 0, 0, 0};
+
+			auto const c = a & b;
+			CHECK_EQ(c.count(), 1);
+			auto const d = a | b;
+			CHECK_EQ(d.count(), 3);
+			CHECK_FALSE(a == b);
+
+			fixed64 a_copy = a;
+			CHECK(a == a_copy);
+		}
+
+		SUBCASE("fully static capacity supports shifting") {
+			fixed64 a{0b1100, 0, 0, 0};
+			a <<= 1;
+			CHECK_FALSE(a.test(0));
+			CHECK(a.test(1));
+			CHECK(a.test(2));
+			CHECK_FALSE(a.test(3));
+		}
+
+		SUBCASE("bounded capacity supports equality and bitwise combination") {
+			bounded64 a{0b1100, 0};
+			bounded64 b{0b1010, 0};
+
+			auto const c = a & b;
+			CHECK_EQ(c.count(), 1);
+			auto const d = a | b;
+			CHECK_EQ(d.count(), 3);
+			CHECK_FALSE(a == b);
+		}
+
+		SUBCASE("bounded capacity initializer list exceeding max_size throws length_error") {
+			CHECK_THROWS_AS((bounded64{1, 2, 3, 4, 5}), std::length_error);
+			CHECK_NOTHROW((bounded64{1, 2, 3, 4}));
+		}
+
+		SUBCASE("bounded capacity set_first_free grows by one segment without hitting the limit") {
+			bounded64 b{~0ull, ~0ull}; // 2 of 4 segments used, both full
+			auto const ix = b.set_first_free();
+			CHECK_EQ(ix, bounded64::segment_size_in_bits * 2); // first bit of the freshly grown 3rd segment
+			REQUIRE_EQ(b.size(), 3);
+			CHECK(b.test(ix));
+		}
 	}
 
 	TEST_CASE("formatting") {
 		// the formatter's output isn't specified/stable enough to assert on - just make sure the
 		// various format specs run without throwing, and print the result for a human to eyeball.
 		dyn8 b{0b10110011, 0x00};
-		MESSAGE("default: ", std::format("{}", b));
 		MESSAGE("hex: ", std::format("{:x}", b));
 		MESSAGE("binary: ", std::format("{:b}", b));
 		MESSAGE("debug+hex: ", std::format("{:?x}", b));
 		MESSAGE("debug+binary: ", std::format("{:?b}", b));
+	}
+
+    TEST_CASE("formatting long") {
+	    dyn64 b_long{dyn64::mode_unset, 32};
+	    MESSAGE("hex: ", std::format("{:x}", b_long));
+	    MESSAGE("binary: ", std::format("{:b}", b_long));
+	    MESSAGE("debug+hex: ", std::format("{:?x}", b_long));
+	    MESSAGE("debug+binary: ", std::format("{:?b}", b_long));
+	}
+
+	TEST_CASE("formatting edge cases") {
+		SUBCASE("no format spec just steps through without hex/binary rendering") {
+			dyn8 b{0b10110011};
+			std::string s;
+			CHECK_NOTHROW(s = std::format("{}", b));
+		}
+
+		SUBCASE("debug spec alone (no hex/binary) is accepted") {
+			dyn8 b{0b10110011};
+			std::string s;
+			CHECK_NOTHROW(s = std::format("{:?}", b));
+		}
+
+		SUBCASE("an unrecognized format spec character throws format_error") {
+			// the spec is validated at compile time for a literal format string, so a runtime
+			// format string is used here to actually exercise the throwing parse() path.
+			dyn8 b{0x00};
+			std::string s;
+			CHECK_THROWS_AS(s = std::vformat("{:z}", std::make_format_args(b)), std::format_error);
+		}
 	}
 
 	TEST_CASE("multi-word (non-integral) segment type") {
@@ -514,5 +779,99 @@ TEST_SUITE("bitset") {
 			CHECK(b.any_set());
 			CHECK_FALSE(b.none_set());
 		}
+
+		SUBCASE("bit counting spans multiple multi-word segments") {
+			// segment 0 (lowest) is fully set, segment 1 (highest) is fully zero - mirrors the
+			// "bit counting across multiple segments" integral tests, but for a segment type
+			// wide enough to need segment_slots/slot_handler internally.
+			wide_word full{};
+			full.lo = ~0ull;
+			full.hi = ~0ull;
+			wide_word zero{};
+
+			wide_bitset b{full, zero};
+			CHECK_FALSE(b.all_set());
+			CHECK_EQ(b.countr_one(), 128);
+			CHECK_EQ(b.countl_zero(), 128);
+			CHECK_EQ(b.countl_one(), 0);
+
+			wide_bitset all_full{full, full};
+			CHECK(all_full.all_set());
+		}
+
+		SUBCASE("operator&= / operator|= / operator== on multi-word segments") {
+			wide_word a_word{};
+			a_word.lo = 0b1100;
+			wide_word b_word{};
+			b_word.lo = 0b1010;
+
+			wide_bitset a{a_word};
+			wide_bitset b{b_word};
+
+			auto const conjunction = a & b;
+			CHECK_EQ(conjunction.count(), 1);
+			auto const disjunction = a | b;
+			CHECK_EQ(disjunction.count(), 3);
+
+			CHECK(a == a);
+			CHECK_FALSE(a == b);
+
+			a &= b;
+			CHECK(a == conjunction);
+		}
+
+		SUBCASE("segment_slots exposes every word making up one segment") {
+			wide_word w{};
+			w.lo = 5;
+			w.hi = 9;
+
+			wide_bitset b{w};
+			auto it = b.begin();
+			auto [word, end] = b.segment_slots(it.get());
+			CHECK_EQ(std::distance(word, end), wide_bitset::segment_steps);
+			CHECK_EQ(*word, 5);
+			CHECK_EQ(*(word + 1), 9);
+		}
+
+		SUBCASE("formatting does not throw for a multi-word segment type") {
+			wide_word w{};
+			w.lo = 0x1234;
+			w.hi = 0x5678;
+			wide_bitset b{w};
+			std::string s;
+			CHECK_NOTHROW(s = std::format("{:x}", b));
+			CHECK_NOTHROW(s = std::format("{:?x}", b));
+		}
+	}
+
+	TEST_CASE("integral segment width coverage") {
+		// verifies storage_word selection (and the derived set/test/count/countr_zero paths)
+		// across differently-sized plain integral segment types, not just uint8_t/uint64_t.
+		auto const check_widths = []<typename T>() {
+			using B = bitset<T, dynamic_extent, dynamic_extent>;
+			B b{};
+			b.set(3);
+			b.set(B::segment_size_in_bits + 1); // force growth into a 2nd segment
+
+			CHECK_EQ(b.size(), 2);
+			CHECK_EQ(b.count(), 2);
+			CHECK(b.test(3));
+			CHECK(b.test(B::segment_size_in_bits + 1));
+			CHECK_EQ(b.countr_zero(), 3);
+		};
+
+		SUBCASE("uint16_t segments") {
+			check_widths.operator()<std::uint16_t>();
+		}
+
+		SUBCASE("uint32_t segments") {
+			check_widths.operator()<std::uint32_t>();
+		}
+
+#ifdef __SIZEOF_INT128__
+		SUBCASE("__uint128_t segments") {
+			check_widths.operator()<__uint128_t>();
+		}
+#endif
 	}
 }

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -578,7 +578,7 @@ TEST_SUITE("bitset") {
 			CHECK(it == b.begin() + 10);
 		}
 
-		/*SUBCASE("reverse iteration (rbegin/rend) visits every bit in reverse order exactly once") {
+		SUBCASE("reverse iteration (rbegin/rend) visits every bit in reverse order exactly once") {
 			dyn8 b{0b00000001, 0b10000000};
 
 			size_t visited = 0;
@@ -599,7 +599,7 @@ TEST_SUITE("bitset") {
 				++visited;
 			}
 			CHECK_EQ(visited, b.size_in_bits());
-		} */
+		}
 	}
 
 	TEST_CASE("shifts") {

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -5,6 +5,8 @@
 
 #include <array>
 #include <cstdint>
+#include <iterator>
+#include <ranges>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -1003,7 +1005,7 @@ TEST_SUITE("bitset") {
 			size_t i = 0;
 			for (auto pos : b.positions()) {
 				REQUIRE_LT(i, expected.size());
-				CHECK_EQ(pos.seg * 64 + pos.off, expected[i]);
+				CHECK_EQ(pos.ix(), expected[i]);
 				CHECK(static_cast<bool>(pos));
 				++i;
 			}
@@ -1017,7 +1019,7 @@ TEST_SUITE("bitset") {
 			size_t i = 0;
 			for (auto pos : b.positions()) {
 				REQUIRE_LT(i, expected.size());
-				CHECK_EQ(pos.seg * 64 + pos.off, expected[i]);
+				CHECK_EQ(pos.ix(), expected[i]);
 				++i;
 			}
 			CHECK_EQ(i, expected.size());
@@ -1037,7 +1039,7 @@ TEST_SUITE("bitset") {
 			size_t i = 0;
 			for (auto pos : b.positions()) {
 				REQUIRE_LT(i, expected.size());
-				CHECK_EQ(pos.seg * 128 + pos.off, expected[i]);
+				CHECK_EQ(pos.ix(), expected[i]);
 				++i;
 			}
 			CHECK_EQ(i, expected.size());
@@ -1059,6 +1061,193 @@ TEST_SUITE("bitset") {
 			CHECK_FALSE(b.test(5));
 			CHECK_FALSE(b.test(127));
 			CHECK_EQ(b.count(), 128 - 3);
+		}
+	}
+
+	TEST_CASE("position_iterator behavior") {
+		SUBCASE("satisfies std::input_iterator and positions() satisfies std::ranges::input_range") {
+			// compile-time only: if these ever regress, this is where it should surface, rather
+			// than as a cryptic "no viable constructor/deduction guide" deep inside <ranges>.
+			static_assert(std::input_iterator<dyn64::positional_iterator>);
+			static_assert(std::input_iterator<dyn64::const_positional_iterator>);
+			static_assert(std::sentinel_for<std::default_sentinel_t, dyn64::positional_iterator>);
+			static_assert(std::sentinel_for<std::default_sentinel_t, dyn64::const_positional_iterator>);
+			static_assert(std::ranges::input_range<decltype(std::declval<dyn64 const&>().positions())>);
+			CHECK(true);
+		}
+
+		SUBCASE("empty bitset: pbegin() equals pend() immediately") {
+			dyn64 b{};
+			CHECK(b.pbegin() == b.pend());
+			CHECK(b.pend() == b.pbegin());
+		}
+
+		SUBCASE("pbegin()/pend() walked directly (without positions()) on a non-const bitset") {
+			dyn64 b{0b10101, 0b1}; // segment 0: bits 0,2,4 set; segment 1: bit 0 set
+			std::array<size_t, 4> const expected{0, 2, 4, 64};
+
+			size_t i = 0;
+			for (auto it = b.pbegin(); it != b.pend(); ++it) {
+				REQUIRE_LT(i, expected.size());
+				CHECK_EQ((*it).ix(), expected[i]);
+				CHECK(static_cast<bool>(*it));
+				++i;
+			}
+			CHECK_EQ(i, expected.size());
+		}
+
+		SUBCASE("pbegin()/pend() on a const bitset yield a const_positional_iterator") {
+			dyn64 const b{0b10101, 0b1};
+			static_assert(std::is_same_v<decltype(b.pbegin()), dyn64::const_positional_iterator>);
+
+			std::array<size_t, 4> const expected{0, 2, 4, 64};
+			size_t i = 0;
+			for (auto it = b.pbegin(); it != b.pend(); ++it) {
+				REQUIRE_LT(i, expected.size());
+				CHECK_EQ((*it).ix(), expected[i]);
+				++i;
+			}
+			CHECK_EQ(i, expected.size());
+		}
+
+		SUBCASE("postfix increment returns the pre-increment position; prefix returns *this by reference") {
+			dyn64 b{0b101}; // bits 0 and 2 set
+			auto it = b.pbegin();
+
+			auto const before = it++;
+			CHECK_EQ((*before).ix(), 0);
+			CHECK_EQ((*it).ix(), 2);
+
+			auto &ref = ++it;
+			CHECK_EQ(&ref, &it); // weakly_incrementable requires "{ ++i } -> same_as<I&>"
+			CHECK(it == b.pend());
+		}
+
+		SUBCASE("copies are independent") {
+			dyn64 b{0b101}; // bits 0 and 2 set
+			auto it1 = b.pbegin();
+			auto it2 = it1;
+			++it1;
+
+			CHECK(it1 != it2);
+			CHECK_EQ((*it2).ix(), 0);
+			CHECK_EQ((*it1).ix(), 2);
+
+			it2 = it1;
+			CHECK(it1 == it2);
+		}
+
+		SUBCASE("dereferencing yields the same writable proxy as the bit-mode iterator") {
+			dyn64 b{0b1};
+			auto it = b.pbegin();
+			CHECK(static_cast<bool>(*it));
+			*it = false;
+			CHECK_FALSE(b.test(0));
+		}
+
+		SUBCASE("multi-word (non-integral) segment type walked directly") {
+			using wide_bitset = bitset<dynamic_extent, dynamic_extent, wide_word>;
+			wide_word w0{};
+			w0.lo = 0b101; // bits 0 and 2 of the low word
+			wide_word w1{};
+			w1.hi = 1; // bit 0 of the high word -> segment-local offset 64
+
+			wide_bitset b{w0, w1};
+			std::array<size_t, 3> const expected{0, 2, 128 + 64}; // 128 bits per wide_word segment
+
+			size_t i = 0;
+			for (auto it = b.pbegin(); it != b.pend(); ++it) {
+				REQUIRE_LT(i, expected.size());
+				CHECK_EQ((*it).ix(), expected[i]);
+				++i;
+			}
+			CHECK_EQ(i, expected.size());
+		}
+
+		SUBCASE("pbegin() skips forward when bit 0 of segment 0 is not actually set") {
+			dyn64 b{0b100}; // bit 2 set, bit 0 NOT set
+			auto it = b.pbegin();
+			CHECK(static_cast<bool>(*it));
+			CHECK_EQ((*it).ix(), 2);
+		}
+
+		SUBCASE("multiple jumps within one segment: bits at its beginning, middle and end") {
+			dyn64 b{(1ull << 0) | (1ull << 30) | (1ull << 63)};
+			std::array<size_t, 3> const expected{0, 30, 63};
+
+			size_t i = 0;
+			for (auto pos : b.positions()) {
+				REQUIRE_LT(i, expected.size());
+				CHECK_EQ(pos.ix(), expected[i]);
+				++i;
+			}
+			CHECK_EQ(i, expected.size());
+		}
+
+		SUBCASE("multiple jumps across several segments, interleaved with single-segment gaps") {
+			dyn64 b{
+				(1ull << 0) | (1ull << 30) | (1ull << 63), // segment 0: beginning, middle, end
+				0,                                          // segment 1: empty (single-segment gap)
+				(1ull << 0) | (1ull << 40),                 // segment 2: beginning, middle
+				0,                                          // segment 3: empty
+				0,                                          // segment 4: empty (two in a row -> larger jump)
+				(1ull << 63),                                // segment 5: only the last bit
+			};
+			std::array<size_t, 6> const expected{
+				0, 30, 63,               // segment 0
+				2 * 64 + 0, 2 * 64 + 40, // segment 2, after skipping segment 1
+				5 * 64 + 63,             // segment 5, after skipping segments 3 and 4
+			};
+
+			size_t i = 0;
+			for (auto pos : b.positions()) {
+				REQUIRE_LT(i, expected.size());
+				CHECK_EQ(pos.ix(), expected[i]);
+				++i;
+			}
+			CHECK_EQ(i, expected.size());
+		}
+
+		SUBCASE("large jump: several consecutive fully-zero segments between two set bits") {
+			dyn64 b{1ull, 0, 0, 0, 0, 0, (1ull << 5)}; // 5 empty segments in a row between the two bits
+			std::array<size_t, 2> const expected{0, 6 * 64 + 5};
+
+			size_t i = 0;
+			for (auto pos : b.positions()) {
+				REQUIRE_LT(i, expected.size());
+				CHECK_EQ(pos.ix(), expected[i]);
+				++i;
+			}
+			CHECK_EQ(i, expected.size());
+		}
+
+		SUBCASE("multi-word segment: beginning/middle/end of each word, crossing both a word and a segment boundary") {
+			using wide_bitset = bitset<dynamic_extent, dynamic_extent, wide_word>;
+
+			wide_word w0{};
+			w0.lo = (1ull << 0) | (1ull << 32) | (1ull << 63); // low word: beginning, middle, end
+			w0.hi = (1ull << 0) | (1ull << 32) | (1ull << 63); // high word: beginning, middle, end
+
+			wide_word const empty1{};
+			wide_word const empty2{}; // two consecutive empty segments -> large jump for the multi-word case too
+
+			wide_word w3{};
+			w3.hi = (1ull << 63); // only the very last bit of the segment
+
+			wide_bitset b{w0, empty1, empty2, w3};
+			std::array<size_t, 7> const expected{
+				0, 32, 63,     // segment 0, low word: beginning, middle, end
+				64, 96, 127,   // segment 0, high word: beginning, middle, end (64 crosses the word boundary)
+				3 * 128 + 127, // segment 3, after skipping segments 1 and 2 entirely
+			};
+
+			size_t i = 0;
+			for (auto pos : b.positions()) {
+				REQUIRE_LT(i, expected.size());
+				CHECK_EQ(pos.ix(), expected[i]);
+				++i;
+			}
+			CHECK_EQ(i, expected.size());
 		}
 	}
 }

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -1,0 +1,9 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include <doctest/doctest.h>
+#include <dice/template-library/bitset.hpp>
+
+TEST_SUITE("") {
+
+}
+

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -22,26 +22,19 @@ namespace {
 TEST_SUITE("bitset") {
 	using namespace dice::template_library;
 
-	using dyn64 = bitset<std::uint64_t, dynamic_extent, dynamic_extent>;
-	using dyn8 = bitset<std::uint8_t, dynamic_extent, dynamic_extent>;
-	using bounded64 = bitset<std::uint64_t, dynamic_extent, 4>; // capacity: 4 segments = 256 bits
+	using dyn64 = bitset<dynamic_extent, dynamic_extent>;
+	using dyn8 = bitset<std::dynamic_extent, dynamic_extent, uint8_t>;
+	using bounded64 = bitset<dynamic_extent, 4>; // capacity: 4 segments = 256 bits
 
-	TEST_CASE("static properties") {
-		static_assert(!dyn64::has_storage_limit);
-		static_assert(dyn64::segment_size == sizeof(std::uint64_t));
-		static_assert(dyn64::segment_size_in_bits == 64);
-
-		static_assert(bounded64::has_storage_limit);
-		static_assert(bounded64::storage_size == 4 * sizeof(std::uint64_t));
-		static_assert(bounded64::storage_size_in_bits == 4 * 64);
-	}
+	// segment_size_in_bits/storage_size_in_bits etc. are implementation details and are private,
+	// so shape constants that used to come straight from the class are now hardcoded/derived here
+	// from the known template arguments instead.
+	constexpr size_t bounded64_segment_bits  = 64;
+	constexpr size_t bounded64_capacity_bits = 4 * bounded64_segment_bits;
 
 	TEST_CASE("construction") {
 		SUBCASE("initializer list") {
 			dyn8 b{0b00000001, 0b10000000};
-			REQUIRE_EQ(b.size(), 2);
-			REQUIRE_EQ(b.inner_size(), sizeof(std::uint8_t));
-			REQUIRE_EQ(b.inner_size_in_bits(), 8);
 			REQUIRE_EQ(b.size_in_bits(), 16);
 
 			CHECK(b.test(0));
@@ -55,28 +48,17 @@ TEST_SUITE("bitset") {
 			CHECK(b.test(15));
 		}
 
-		SUBCASE("Set fill constructor sets every bit") {
-			dyn64 b{dyn64::mode_set, 3};
-			REQUIRE_EQ(b.size(), 3);
-			for (size_t i = 0; i < b.size_in_bits(); ++i) {
-				CHECK(b.test(i));
-			}
-		}
-
-		SUBCASE("Unset fill constructor clears every bit") {
-			dyn64 b{dyn64::mode_unset, 3};
-			REQUIRE_EQ(b.size(), 3);
+		SUBCASE("size constructor zero-fills every segment") {
+			// per the ctor's doc comment ("size to set low"), this only grows storage - it does
+			// not set any bits, unlike the old mode_set-based constructor it replaced.
+			// NOTE: must use parens, not braces - dyn64{3} would list-initialize a single
+			// segment holding the value 3 instead of calling the explicit size_t constructor,
+			// since a viable initializer_list constructor always wins list-initialization.
+			dyn64 b(3);
+			REQUIRE_EQ(b.size_in_bits(), 3 * 64);
 			for (size_t i = 0; i < b.size_in_bits(); ++i) {
 				CHECK_FALSE(b.test(i));
 			}
-		}
-
-		SUBCASE("create_bitset helper") {
-			auto b = create_bitset({0b101uz, 0b010uz});
-			CHECK(b.test(0));
-			CHECK_FALSE(b.test(1));
-			CHECK(b.test(2));
-			CHECK_EQ(b.count(), 3);
 		}
 
 		SUBCASE("copy/move construction and assignment are independent of the source") {
@@ -93,68 +75,21 @@ TEST_SUITE("bitset") {
 			dyn8 d{0xFF};
 			d = a;
 			CHECK_FALSE(d.test(3));
-			CHECK_EQ(d.size(), 2);
-		}
-	}
-
-	TEST_CASE("create_bitset overloads") {
-		SUBCASE("dynamic size, dynamic capacity, size_t segments") {
-			auto b = create_bitset({0b101uz, 0b010uz});
-			static_assert(std::is_same_v<decltype(b), bitset<std::size_t, dynamic_extent, dynamic_extent>>);
-			REQUIRE_EQ(b.size(), 2);
-			CHECK_EQ(b.count(), 3);
-			CHECK(b.test(0));
-			CHECK_FALSE(b.test(1));
-			CHECK(b.test(2));
-			CHECK(b.test(decltype(b)::segment_size_in_bits + 1)); // segment 1, bit 1 (value 0b010)
-		}
-
-		SUBCASE("dynamic size, bounded capacity, size_t segments") {
-			auto b = create_bitset<4>({0b101uz, 0b010uz});
-			static_assert(std::is_same_v<decltype(b), bitset<std::size_t, dynamic_extent, 4>>);
-			REQUIRE_EQ(b.size(), 2);
-			CHECK_EQ(b.count(), 3);
-			CHECK(b.test(0));
-			CHECK(b.test(2));
-			CHECK(b.test(decltype(b)::segment_size_in_bits + 1));
-
-			CHECK_THROWS_AS((create_bitset<4>({0uz, 0uz, 0uz, 0uz, 0uz})), std::length_error);
-		}
-
-		SUBCASE("dynamic size, bounded capacity, custom segment type") {
-			auto b = create_bitset<std::uint8_t, 4>({0b101, 0b010});
-			static_assert(std::is_same_v<decltype(b), bitset<std::uint8_t, dynamic_extent, 4>>);
-			REQUIRE_EQ(b.size(), 2);
-			CHECK_EQ(b.count(), 3);
-			CHECK(b.test(0));
-			CHECK(b.test(2));
-			CHECK(b.test(decltype(b)::segment_size_in_bits + 1)); // segment 1, bit 1
-
-			CHECK_THROWS_AS((create_bitset<std::uint8_t, 4>({0, 0, 0, 0, 0})), std::length_error);
-		}
-
-		SUBCASE("dynamic size, dynamic capacity, custom segment type") {
-			auto b = create_bitset<std::uint8_t>({0b101, 0b010});
-			static_assert(std::is_same_v<decltype(b), bitset<std::uint8_t, dynamic_extent, dynamic_extent>>);
-			REQUIRE_EQ(b.size(), 2);
-			CHECK_EQ(b.count(), 3);
-			CHECK(b.test(0));
-			CHECK(b.test(2));
-			CHECK(b.test(decltype(b)::segment_size_in_bits + 1));
+			CHECK_EQ(d.size_in_bits(), 2 * 8);
 		}
 	}
 
 	TEST_CASE("bit manipulation across segments") {
-		SUBCASE("set/unset/flip/test grows storage automatically") {
+		SUBCASE("set/reset/flip/test grows storage automatically") {
 			dyn64 b{};
 			b.set(5);
-			REQUIRE_EQ(b.size(), 1);
+			REQUIRE_EQ(b.size_in_bits(), 64);
 			CHECK(b.test(5));
 			CHECK_FALSE(b.test(0));
 			CHECK_FALSE(b.test(63));
 
 			b.set(130); // segment 2, offset 2 -> needs 3 segments total
-			REQUIRE_EQ(b.size(), 3);
+			REQUIRE_EQ(b.size_in_bits(), 3 * 64);
 			CHECK(b.test(130));
 
 			b.flip(130);
@@ -162,9 +97,9 @@ TEST_SUITE("bitset") {
 			b.flip(130);
 			CHECK(b.test(130));
 
-			b.unset(130);
+			b.reset(130);
 			CHECK_FALSE(b.test(130));
-			b.unset(5);
+			b.reset(5);
 			CHECK_FALSE(b.test(5));
 		}
 
@@ -174,7 +109,7 @@ TEST_SUITE("bitset") {
 			// the fact that bit index 64 needs capacity > 64 bits, not merely >= 64 bits.
 			dyn64 b{};
 			b.set(64);
-			REQUIRE_EQ(b.size(), 2);
+			REQUIRE_EQ(b.size_in_bits(), 2 * 64);
 			CHECK(b.test(64));
 			CHECK_FALSE(b.test(0));
 			CHECK_FALSE(b.test(63));
@@ -182,10 +117,10 @@ TEST_SUITE("bitset") {
 
 		SUBCASE("out_of_range when index exceeds a fixed capacity") {
 			bounded64 b{};
-			REQUIRE_THROWS_AS(b.set(bounded64::storage_size_in_bits), std::out_of_range);
-			REQUIRE_THROWS_AS((void)b.test(bounded64::storage_size_in_bits), std::out_of_range);
-			CHECK_EQ(b.size(), 0); // rejected out-of-range set() must not have grown anything
-			CHECK_NOTHROW(b.set(bounded64::storage_size_in_bits - 1));
+			REQUIRE_THROWS_AS(b.set(bounded64_capacity_bits), std::out_of_range);
+			REQUIRE_THROWS_AS((void)b.test(bounded64_capacity_bits), std::out_of_range);
+			CHECK_EQ(b.size_in_bits(), 0); // rejected out-of-range set() must not have grown anything
+			CHECK_NOTHROW(b.set(bounded64_capacity_bits - 1));
 		}
 
 		SUBCASE("a large global index computes the exact number of segments needed and zero-fills the rest") {
@@ -193,7 +128,7 @@ TEST_SUITE("bitset") {
 			// more than one extra segment), not just the "next segment" case exercised above.
 			dyn64 b{};
 			b.set(1000); // segment 15 (1000 / 64), so 16 segments are required in total
-			REQUIRE_EQ(b.size(), 16);
+			REQUIRE_EQ(b.size_in_bits(), 16 * 64);
 			CHECK(b.test(1000));
 
 			for (size_t i = 0; i < b.size_in_bits(); ++i) {
@@ -206,10 +141,10 @@ TEST_SUITE("bitset") {
 		SUBCASE("setting a lower index after a large-index growth does not grow further") {
 			dyn64 b{};
 			b.set(1000);
-			REQUIRE_EQ(b.size(), 16);
+			REQUIRE_EQ(b.size_in_bits(), 16 * 64);
 
 			b.set(0);
-			CHECK_EQ(b.size(), 16); // already had enough room, must not have resized again
+			CHECK_EQ(b.size_in_bits(), 16 * 64); // already had enough room, must not have resized again
 			CHECK(b.test(0));
 			CHECK(b.test(1000));
 		}
@@ -219,10 +154,10 @@ TEST_SUITE("bitset") {
 			// growing size(), so test() would report the bit as set while count()/iteration/
 			// all_set()/etc (which all iterate up to size()) stayed blind to it entirely.
 			bounded64 b{};
-			REQUIRE_EQ(b.size(), 0);
+			REQUIRE_EQ(b.size_in_bits(), 0);
 
 			b.set(5);
-			CHECK_EQ(b.size(), 1);
+			CHECK_EQ(b.size_in_bits(), 64);
 			CHECK(b.test(5));
 			CHECK_EQ(b.count(), 1);
 
@@ -233,19 +168,20 @@ TEST_SUITE("bitset") {
 
 		SUBCASE("bounded capacity growth stops exactly at its static maximum and stays zero-filled") {
 			bounded64 b{};
-			b.set(bounded64::storage_size_in_bits - 1); // last valid bit, far beyond current size()
-			REQUIRE_EQ(b.size(), 4);
-			CHECK(b.test(bounded64::storage_size_in_bits - 1));
+			b.set(bounded64_capacity_bits - 1); // last valid bit, far beyond current size()
+			REQUIRE_EQ(b.size_in_bits(), 4 * 64);
+			CHECK(b.test(bounded64_capacity_bits - 1));
 			CHECK_EQ(b.count(), 1); // every other (newly exposed) bit must be zero, not garbage
 		}
 	}
 
 	TEST_CASE("fully static capacity (extent == segments)") {
-		using fixed64 = bitset<std::uint64_t, 4, 4>;
+		using fixed64 = bitset<4, 4>;
+		constexpr size_t fixed64_capacity_bits = 4 * 64;
 
 		SUBCASE("initializer list must match extent exactly") {
 			fixed64 b{1, 2, 3, 4};
-			REQUIRE_EQ(b.size(), 4);
+			REQUIRE_EQ(b.size_in_bits(), 4 * 64);
 			CHECK(b.test(0));   // segment 0, value 1
 			CHECK(b.test(65));  // segment 1, offset 1, value 2
 			CHECK(b.test(129)); // segment 2, offset 1, value 3
@@ -257,13 +193,13 @@ TEST_SUITE("bitset") {
 
 		SUBCASE("out_of_range at the fixed capacity boundary") {
 			fixed64 b{0, 0, 0, 0};
-			REQUIRE_THROWS_AS(b.set(fixed64::storage_size_in_bits), std::out_of_range);
-			CHECK_NOTHROW(b.set(fixed64::storage_size_in_bits - 1));
+			REQUIRE_THROWS_AS(b.set(fixed64_capacity_bits), std::out_of_range);
+			CHECK_NOTHROW(b.set(fixed64_capacity_bits - 1));
 		}
 
 		SUBCASE("set_first_free reports full once every bit is set") {
 			fixed64 b{~0ull, ~0ull, ~0ull, ~0ull};
-			CHECK_EQ(b.set_first_free(), fixed64::storage_size_in_bits);
+			CHECK_EQ(b.set_first_free(), fixed64_capacity_bits);
 		}
 	}
 
@@ -292,7 +228,7 @@ TEST_SUITE("bitset") {
 			case_t{0b00000000, 8, 8, 0, 0},
 			case_t{0b11111111, 0, 0, 8, 8},
 			case_t{0b00001000, 3, 4, 0, 0},
-			case_t{0b11110111, 0, 0, 3, 4}, // bit 3 unset: 3 trailing ones, 4 leading ones
+			case_t{0b11110111, 0, 0, 3, 4}, // bit 3 reset: 3 trailing ones, 4 leading ones
 		};
 
 		for (auto const &c : cases) {
@@ -361,7 +297,7 @@ TEST_SUITE("bitset") {
 		}
 
 		SUBCASE("any_set true when only a non-zero-offset bit is set") {
-			// bit 0 is unset but bit 1 is set - any_set must still report true
+			// bit 0 is reset but bit 1 is set - any_set must still report true
 			dyn8 b{0b00000010};
 			CHECK(b.any_set());
 		}
@@ -378,7 +314,7 @@ TEST_SUITE("bitset") {
 	}
 
 	TEST_CASE("set_first_free") {
-		SUBCASE("finds first unset bit within existing segments") {
+		SUBCASE("finds first reset bit within existing segments") {
 			dyn8 b{0xFF, 0b00000001};
 			auto const ix = b.set_first_free();
 			CHECK_EQ(ix, 9); // segment 1, offset 1 -> global index 8 + 1
@@ -389,13 +325,13 @@ TEST_SUITE("bitset") {
 			dyn8 b{0xFF};
 			auto const ix = b.set_first_free();
 			CHECK_EQ(ix, 8); // new segment appended, first bit of it
-			REQUIRE_EQ(b.size(), 2);
+			REQUIRE_EQ(b.size_in_bits(), 2 * 8);
 			CHECK(b.test(8));
 		}
 
 		SUBCASE("reports storage_size_in_bits once a fixed-capacity bitset is full") {
 			bounded64 b{~0ull, ~0ull, ~0ull, ~0ull};
-			CHECK_EQ(b.set_first_free(), bounded64::storage_size_in_bits);
+			CHECK_EQ(b.set_first_free(), bounded64_capacity_bits);
 		}
 	}
 
@@ -483,7 +419,7 @@ TEST_SUITE("bitset") {
 			dyn8 b{0xAA, 0xBB};
 			auto it = b.begin();
 			CHECK_EQ(it.get(), 0xAA);
-			it.operator++<bitset_const::segment_mode>();
+			it = b.advance_segment(it); // advance_segment takes/returns by value - capture the result
 			CHECK_EQ(it.get(), 0xBB);
 		}
 
@@ -498,7 +434,7 @@ TEST_SUITE("bitset") {
 			CHECK(*it2);
 
 			auto it3 = b.begin();
-			it3.operator+=<bitset_const::segment_mode>(1);
+			it3 = b.advance_segment(it3, 1);
 			CHECK_EQ(it3.get(), 0b00000010);
 		}
 
@@ -511,7 +447,7 @@ TEST_SUITE("bitset") {
 
 			--it; // wraps back into segment 0, offset 7 (top bit of segment 0)
 			CHECK_EQ(it.get(), 0b00000001);
-			CHECK_FALSE(*it); // offset 7 of segment 0 is unset
+			CHECK_FALSE(*it); // offset 7 of segment 0 is reset
 
 			auto it2 = b.begin() + 3;
 			auto const prev = it2--;
@@ -532,9 +468,9 @@ TEST_SUITE("bitset") {
 
 			dyn8 b2{0xAA, 0xBB};
 			auto it3 = b2.begin();
-			it3.operator++<bitset_const::segment_mode>();
+			it3 = b2.advance_segment(it3);
 			CHECK_EQ(it3.get(), 0xBB);
-			it3.operator--<bitset_const::segment_mode>();
+			it3 = b2.advance_segment_backwards(it3);
 			CHECK_EQ(it3.get(), 0xAA);
 		}
 
@@ -562,7 +498,7 @@ TEST_SUITE("bitset") {
 		SUBCASE("explicit iterator construction with an offset validates the offset") {
 			dyn8 b{0x00};
 			CHECK_NOTHROW((dyn8::iterator{b, 7}));
-			CHECK_THROWS_AS((dyn8::iterator{b, 8}), std::out_of_range); // segment_size_in_bits == 8
+			CHECK_THROWS_AS((dyn8::iterator{b, 8}), std::out_of_range); // dyn8's segment width is 8 bits
 
 			dyn8::iterator it{b, 3};
 			CHECK(it == b.begin() + 3);
@@ -571,8 +507,8 @@ TEST_SUITE("bitset") {
 		SUBCASE("explicit iterator construction with an offset and segment validates both") {
 			dyn8 b{0x00, 0x00};
 			CHECK_NOTHROW((dyn8::iterator{b, 0, 1}));
-			CHECK_THROWS_AS((dyn8::iterator{b, 8, 0}), std::out_of_range);  // bad offset
-			CHECK_THROWS_AS((dyn8::iterator{b, 0, 2}), std::out_of_range); // segment out of bounds, size() == 2
+			CHECK_THROWS_AS((dyn8::iterator{b, 8, 0}), std::out_of_range); // bad offset
+			CHECK_THROWS_AS((dyn8::iterator{b, 0, 2}), std::out_of_range); // segment out of bounds (only 2 segments exist)
 
 			dyn8::iterator it{b, 2, 1};
 			CHECK(it == b.begin() + 10);
@@ -678,7 +614,7 @@ TEST_SUITE("bitset") {
 			CHECK_EQ(b3.count(), 0);
 
 			bounded64 b4{~0ull, ~0ull};
-			b4 <<= bounded64::storage_size_in_bits + 100; // beyond even the max capacity
+			b4 <<= bounded64_capacity_bits + 100; // beyond even the max capacity
 			CHECK_EQ(b4.count(), 0);
 		}
 
@@ -701,7 +637,7 @@ TEST_SUITE("bitset") {
 
 	TEST_CASE("all_set / any_set / none_set on an empty bitset") {
 		dyn8 b{};
-		REQUIRE_EQ(b.size(), 0);
+		REQUIRE_EQ(b.size_in_bits(), 0);
 		CHECK(b.all_set());   // vacuously true: no bit fails to be set
 		CHECK_FALSE(b.any_set());
 		CHECK(b.none_set());  // vacuously true: no bit is set
@@ -727,7 +663,7 @@ TEST_SUITE("bitset") {
 	}
 
 	TEST_CASE("fixed and bounded capacity - equality, bitwise ops and shifts") {
-		using fixed64 = bitset<std::uint64_t, 4, 4>;
+		using fixed64 = bitset<4, 4>;
 
 		SUBCASE("fully static capacity supports equality and bitwise combination") {
 			fixed64 a{0b1100, 0, 0, 0};
@@ -771,8 +707,8 @@ TEST_SUITE("bitset") {
 		SUBCASE("bounded capacity set_first_free grows by one segment without hitting the limit") {
 			bounded64 b{~0ull, ~0ull}; // 2 of 4 segments used, both full
 			auto const ix = b.set_first_free();
-			CHECK_EQ(ix, bounded64::segment_size_in_bits * 2); // first bit of the freshly grown 3rd segment
-			REQUIRE_EQ(b.size(), 3);
+			CHECK_EQ(ix, bounded64_segment_bits * 2); // first bit of the freshly grown 3rd segment
+			REQUIRE_EQ(b.size_in_bits(), 3 * bounded64_segment_bits);
 			CHECK(b.test(ix));
 		}
 	}
@@ -788,7 +724,7 @@ TEST_SUITE("bitset") {
 	}
 
     TEST_CASE("formatting long") {
-	    dyn64 b_long{dyn64::mode_unset, 32};
+	    dyn64 b_long(32); // parens - see the "size constructor zero-fills every segment" note above
 	    MESSAGE("hex: ", std::format("{:x}", b_long));
 	    MESSAGE("binary: ", std::format("{:b}", b_long));
 	    MESSAGE("debug+hex: ", std::format("{:?x}", b_long));
@@ -818,7 +754,7 @@ TEST_SUITE("bitset") {
 	}
 
 	TEST_CASE("multi-word (non-integral) segment type") {
-		using wide_bitset = bitset<wide_word, dynamic_extent, dynamic_extent>;
+		using wide_bitset = bitset<dynamic_extent, dynamic_extent, wide_word>;
 
 		SUBCASE("single-bit addressing within a multi-word segment") {
 			// bit 10 belongs to the low 64-bit word of the segment and must read back as set.
@@ -901,7 +837,7 @@ TEST_SUITE("bitset") {
 			wide_bitset b{w};
 			auto it = b.begin();
 			auto [word, end] = b.segment_slots(it.get());
-			CHECK_EQ(std::distance(word, end), wide_bitset::segment_steps);
+			CHECK_EQ(std::distance(word, end), 2); // wide_word packs two 64-bit words per segment
 			CHECK_EQ(*word, 5);
 			CHECK_EQ(*(word + 1), 9);
 		}
@@ -921,15 +857,17 @@ TEST_SUITE("bitset") {
 		// verifies storage_word selection (and the derived set/test/count/countr_zero paths)
 		// across differently-sized plain integral segment types, not just uint8_t/uint64_t.
 		auto const check_widths = []<typename T>() {
-			using B = bitset<T, dynamic_extent, dynamic_extent>;
+			using B = bitset<dynamic_extent, dynamic_extent, T>;
+			constexpr size_t segment_bits = sizeof(T) * 8;
+
 			B b{};
 			b.set(3);
-			b.set(B::segment_size_in_bits + 1); // force growth into a 2nd segment
+			b.set(segment_bits + 1); // force growth into a 2nd segment
 
-			CHECK_EQ(b.size(), 2);
+			CHECK_EQ(b.size_in_bits(), 2 * segment_bits);
 			CHECK_EQ(b.count(), 2);
 			CHECK(b.test(3));
-			CHECK(b.test(B::segment_size_in_bits + 1));
+			CHECK(b.test(segment_bits + 1));
 			CHECK_EQ(b.countr_zero(), 3);
 		};
 
@@ -946,5 +884,181 @@ TEST_SUITE("bitset") {
 			check_widths.operator()<__uint128_t>();
 		}
 #endif
+	}
+
+	TEST_CASE("set with an explicit high/low state") {
+		dyn8 b{0x00};
+		b.set(3, true);
+		CHECK(b.test(3));
+		b.set(3, false);
+		CHECK_FALSE(b.test(3));
+
+		b.set(3, true);
+		b.set(3, true); // setting an already-set bit high again is a no-op
+		CHECK(b.test(3));
+	}
+
+	TEST_CASE("set_all / reset_all (fully static capacity only)") {
+		// set_all()/reset_all() require !has_dynamic_extent, i.e. extent == segments - neither
+		// dyn8/dyn64 (fully dynamic) nor bounded64 (dynamic size, bounded capacity) qualify.
+		using fixed64 = bitset<4, 4>;
+		constexpr size_t fixed64_capacity_bits = 4 * 64;
+
+		SUBCASE("set_all sets every bit") {
+			fixed64 b{0, 0, 0, 0};
+			b.set_all();
+			CHECK(b.all_set());
+			CHECK_EQ(b.count(), fixed64_capacity_bits);
+		}
+
+		SUBCASE("reset_all clears every bit") {
+			fixed64 b{~0ull, ~0ull, ~0ull, ~0ull};
+			b.reset_all();
+			CHECK(b.none_set());
+			CHECK_EQ(b.count(), 0);
+		}
+
+		SUBCASE("set_all on a multi-word segment type sets every bit in every word") {
+			using fixed_wide = bitset<2, 2, wide_word>;
+			constexpr size_t fixed_wide_capacity_bits = 2 * 128;
+
+			fixed_wide b{wide_word{}, wide_word{}};
+			b.set_all();
+			CHECK(b.all_set());
+			CHECK_EQ(b.count(), fixed_wide_capacity_bits);
+		}
+
+		SUBCASE("reset_all on a multi-word segment type clears every bit in every word") {
+			using fixed_wide = bitset<2, 2, wide_word>;
+			wide_word full{};
+			full.lo = ~0ull;
+			full.hi = ~0ull;
+
+			fixed_wide b{full, full};
+			b.reset_all();
+			CHECK(b.none_set());
+			CHECK_EQ(b.count(), 0);
+		}
+	}
+
+	TEST_CASE("shrink_to_fit") {
+		SUBCASE("drops a trailing not-fully-set segment") {
+			dyn8 b{0xFF, 0xFF, 0x0F};
+			b.shrink_to_fit();
+			REQUIRE_EQ(b.size_in_bits(), 2 * 8);
+			for (size_t i = 0; i < b.size_in_bits(); ++i) {
+				CHECK(b.test(i));
+			}
+		}
+
+		SUBCASE("skips over fully-set trailing segments to find the first non-full one") {
+			// scanning from the end: segments 3 and 2 are fully set (0xFF) and get skipped over;
+			// segment 1 (0x0F) is the first not-fully-set segment found, so storage is truncated
+			// to exclude it and everything after it, keeping only segment 0.
+			dyn8 b{0xFF, 0x0F, 0xFF, 0xFF};
+			b.shrink_to_fit();
+			REQUIRE_EQ(b.size_in_bits(), 1 * 8);
+			for (size_t i = 0; i < b.size_in_bits(); ++i) {
+				CHECK(b.test(i));
+			}
+		}
+
+		SUBCASE("no shrink happens when every segment is fully set") {
+			dyn8 b{0xFF, 0xFF, 0xFF};
+			b.shrink_to_fit();
+			CHECK_EQ(b.size_in_bits(), 3 * 8);
+			CHECK_EQ(b.count(), 24);
+		}
+
+		SUBCASE("bounded (max-extent) capacity uses resize instead of storage reconstruction") {
+			bounded64 b{~0ull, 0x0Full};
+			b.shrink_to_fit();
+			REQUIRE_EQ(b.size_in_bits(), bounded64_segment_bits);
+			CHECK_EQ(b.count(), 64);
+		}
+
+		SUBCASE("multi-word (non-integral) segment type") {
+			using wide_bitset = bitset<dynamic_extent, dynamic_extent, wide_word>;
+
+			wide_word full{};
+			full.lo = ~0ull;
+			full.hi = ~0ull;
+
+			wide_word partial{};
+			partial.lo = ~0ull;
+			partial.hi = 0x0Full; // not fully set -> gets dropped by shrink_to_fit
+
+			wide_bitset b{full, partial};
+			b.shrink_to_fit();
+			REQUIRE_EQ(b.size_in_bits(), 128);
+			CHECK(b.all_set());
+		}
+	}
+
+	TEST_CASE("positions / set_positions / reset_positions") {
+		SUBCASE("positions() yields exactly the set bit positions, including multiple bits per segment") {
+			dyn64 b{0b10101, 0b1}; // segment 0: bits 0,2,4 set; segment 1: bit 0 set
+			std::array<size_t, 4> const expected{0, 2, 4, 64};
+
+			size_t i = 0;
+			for (auto pos : b.positions()) {
+				REQUIRE_LT(i, expected.size());
+				CHECK_EQ(pos.seg * 64 + pos.off, expected[i]);
+				CHECK(static_cast<bool>(pos));
+				++i;
+			}
+			CHECK_EQ(i, expected.size());
+		}
+
+		SUBCASE("positions() correctly skips across multiple fully-zero segments") {
+			dyn64 b{0b1, 0, 0, 0b1}; // segment 0 and segment 3 each have bit 0 set, 1-2 are empty
+			std::array<size_t, 2> const expected{0, 3 * 64};
+
+			size_t i = 0;
+			for (auto pos : b.positions()) {
+				REQUIRE_LT(i, expected.size());
+				CHECK_EQ(pos.seg * 64 + pos.off, expected[i]);
+				++i;
+			}
+			CHECK_EQ(i, expected.size());
+		}
+
+		SUBCASE("positions() spans both words of a multi-word segment type") {
+			using wide_bitset = bitset<dynamic_extent, dynamic_extent, wide_word>;
+
+			wide_word w0{};
+			w0.lo = 0b101; // bits 0 and 2 of the low word
+			wide_word w1{};
+			w1.hi = 1; // bit 0 of the high word -> segment-local offset 64
+
+			wide_bitset b{w0, w1};
+			std::array<size_t, 3> const expected{0, 2, 128 + 64}; // 128 bits per wide_word segment
+
+			size_t i = 0;
+			for (auto pos : b.positions()) {
+				REQUIRE_LT(i, expected.size());
+				CHECK_EQ(pos.seg * 128 + pos.off, expected[i]);
+				++i;
+			}
+			CHECK_EQ(i, expected.size());
+		}
+
+		SUBCASE("set_positions sets exactly the given bits") {
+			dyn64 b(2); // parens - see the "size constructor zero-fills every segment" note above
+			b.set_positions(std::array{0uz, 5uz, 127uz});
+			CHECK(b.test(0));
+			CHECK(b.test(5));
+			CHECK(b.test(127));
+			CHECK_EQ(b.count(), 3);
+		}
+
+		SUBCASE("reset_positions clears exactly the given bits") {
+			dyn64 b{~0ull, ~0ull};
+			b.reset_positions(std::array{0uz, 5uz, 127uz});
+			CHECK_FALSE(b.test(0));
+			CHECK_FALSE(b.test(5));
+			CHECK_FALSE(b.test(127));
+			CHECK_EQ(b.count(), 128 - 3);
+		}
 	}
 }

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -3,7 +3,516 @@
 #include <doctest/doctest.h>
 #include <dice/template-library/bitset.hpp>
 
-TEST_SUITE("") {
+#include <array>
+#include <cstdint>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
 
+namespace {
+	// non-integral, multi-word segment type (two 64-bit words per segment) used to exercise the
+	// code paths that only trigger for T where alignof(T) < sizeof(T), e.g. segment_slots /
+	// slot_handler / get_chunk_raw, alongside the plain-integral segment tests below.
+	struct wide_word {
+		std::uint64_t lo{};
+		std::uint64_t hi{};
+	};
+} // namespace
+
+TEST_SUITE("bitset") {
+	using namespace dice::template_library;
+
+	using dyn64 = bitset<std::uint64_t, dynamic_extent, dynamic_extent>;
+	using dyn8 = bitset<std::uint8_t, dynamic_extent, dynamic_extent>;
+	using bounded64 = bitset<std::uint64_t, dynamic_extent, 4>; // capacity: 4 segments = 256 bits
+
+	TEST_CASE("static properties") {
+		static_assert(!dyn64::has_storage_limit);
+		static_assert(dyn64::segment_size == sizeof(std::uint64_t));
+		static_assert(dyn64::segment_size_in_bits == 64);
+
+		static_assert(bounded64::has_storage_limit);
+		static_assert(bounded64::storage_size == 4 * sizeof(std::uint64_t));
+		static_assert(bounded64::storage_size_in_bits == 4 * 64);
+	}
+
+	TEST_CASE("construction") {
+		SUBCASE("initializer list") {
+			dyn8 b{0b00000001, 0b10000000};
+			REQUIRE_EQ(b.size(), 2);
+			REQUIRE_EQ(b.inner_size(), sizeof(std::uint8_t));
+			REQUIRE_EQ(b.inner_size_in_bits(), 8);
+			REQUIRE_EQ(b.size_in_bits(), 16);
+
+			CHECK(b.test(0));
+			for (size_t i = 1; i < 7; ++i) {
+				CHECK_FALSE(b.test(i));
+			}
+			CHECK_FALSE(b.test(7));
+			for (size_t i = 8; i < 15; ++i) {
+				CHECK_FALSE(b.test(i));
+			}
+			CHECK(b.test(15));
+		}
+
+		SUBCASE("Set fill constructor sets every bit") {
+			dyn64 b{dyn64::mode_set, 3};
+			REQUIRE_EQ(b.size(), 3);
+			for (size_t i = 0; i < b.size_in_bits(); ++i) {
+				CHECK(b.test(i));
+			}
+		}
+
+		SUBCASE("Unset fill constructor clears every bit") {
+			dyn64 b{dyn64::mode_unset, 3};
+			REQUIRE_EQ(b.size(), 3);
+			for (size_t i = 0; i < b.size_in_bits(); ++i) {
+				CHECK_FALSE(b.test(i));
+			}
+		}
+
+		SUBCASE("create_bitset helper") {
+			auto b = create_bitset({0b101uz, 0b010uz});
+			CHECK(b.test(0));
+			CHECK_FALSE(b.test(1));
+			CHECK(b.test(2));
+			CHECK_EQ(b.count(), 3);
+		}
+
+		SUBCASE("copy/move construction and assignment are independent of the source") {
+			dyn8 a{0x00, 0x00};
+
+			dyn8 b{a};
+			b.set(3);
+			CHECK_FALSE(a.test(3));
+			CHECK(b.test(3));
+
+			dyn8 c{std::move(b)};
+			CHECK(c.test(3));
+
+			dyn8 d{0xFF};
+			d = a;
+			CHECK_FALSE(d.test(3));
+			CHECK_EQ(d.size(), 2);
+		}
+	}
+
+	TEST_CASE("create_bitset overloads") {
+		SUBCASE("dynamic size, dynamic capacity, size_t segments") {
+			auto b = create_bitset({0b101uz, 0b010uz});
+			static_assert(std::is_same_v<decltype(b), bitset<std::size_t, dynamic_extent, dynamic_extent>>);
+			CHECK_EQ(b.count(), 3);
+		}
+
+		SUBCASE("dynamic size, bounded capacity, size_t segments") {
+			auto b = create_bitset<4>({0b101uz, 0b010uz});
+			static_assert(std::is_same_v<decltype(b), bitset<std::size_t, dynamic_extent, 4>>);
+			CHECK_EQ(b.count(), 3);
+		}
+
+		SUBCASE("dynamic size, bounded capacity, custom segment type") {
+			auto b = create_bitset<std::uint8_t, 4>({0b101, 0b010});
+			static_assert(std::is_same_v<decltype(b), bitset<std::uint8_t, dynamic_extent, 4>>);
+			CHECK_EQ(b.count(), 3);
+		}
+
+		SUBCASE("dynamic size, dynamic capacity, custom segment type") {
+			auto b = create_bitset<std::uint8_t>({0b101, 0b010});
+			static_assert(std::is_same_v<decltype(b), bitset<std::uint8_t, dynamic_extent, dynamic_extent>>);
+			CHECK_EQ(b.count(), 3);
+		}
+	}
+
+	TEST_CASE("bit manipulation across segments") {
+		SUBCASE("set/unset/flip/test grows storage automatically") {
+			dyn64 b{};
+			b.set(5);
+			REQUIRE_EQ(b.size(), 1);
+			CHECK(b.test(5));
+			CHECK_FALSE(b.test(0));
+			CHECK_FALSE(b.test(63));
+
+			b.set(130); // segment 2, offset 2 -> needs 3 segments total
+			REQUIRE_EQ(b.size(), 3);
+			CHECK(b.test(130));
+
+			b.flip(130);
+			CHECK_FALSE(b.test(130));
+			b.flip(130);
+			CHECK(b.test(130));
+
+			b.unset(130);
+			CHECK_FALSE(b.test(130));
+			b.unset(5);
+			CHECK_FALSE(b.test(5));
+		}
+
+		SUBCASE("growing to exactly a segment boundary") {
+			// setting bit 64 (the first bit of the 2nd 64-bit segment) on an empty bitset must
+			// grow storage to 2 segments, not 1 - the required segment count needs to account for
+			// the fact that bit index 64 needs capacity > 64 bits, not merely >= 64 bits.
+			dyn64 b{};
+			b.set(64);
+			REQUIRE_EQ(b.size(), 2);
+			CHECK(b.test(64));
+			CHECK_FALSE(b.test(0));
+			CHECK_FALSE(b.test(63));
+		}
+
+		SUBCASE("out_of_range when index exceeds a fixed capacity") {
+			bounded64 b{};
+			REQUIRE_THROWS_AS(b.set(bounded64::storage_size_in_bits), std::out_of_range);
+			REQUIRE_THROWS_AS(b.test(bounded64::storage_size_in_bits), std::out_of_range);
+			CHECK_NOTHROW(b.set(bounded64::storage_size_in_bits - 1));
+		}
+	}
+
+	TEST_CASE("fully static capacity (extent == segments)") {
+		using fixed64 = bitset<std::uint64_t, 4, 4>;
+
+		SUBCASE("initializer list must match extent exactly") {
+			fixed64 b{1, 2, 3, 4};
+			REQUIRE_EQ(b.size(), 4);
+			CHECK(b.test(0));   // segment 0, value 1
+			CHECK(b.test(65));  // segment 1, offset 1, value 2
+			CHECK(b.test(129)); // segment 2, offset 1, value 3
+		}
+
+		SUBCASE("mismatched initializer list size throws") {
+			CHECK_THROWS_AS((fixed64{1, 2, 3}), std::length_error);
+		}
+
+		SUBCASE("out_of_range at the fixed capacity boundary") {
+			fixed64 b{0, 0, 0, 0};
+			REQUIRE_THROWS_AS(b.set(fixed64::storage_size_in_bits), std::out_of_range);
+			CHECK_NOTHROW(b.set(fixed64::storage_size_in_bits - 1));
+		}
+
+		SUBCASE("set_first_free reports full once every bit is set") {
+			fixed64 b{~0ull, ~0ull, ~0ull, ~0ull};
+			CHECK_EQ(b.set_first_free(), fixed64::storage_size_in_bits);
+		}
+	}
+
+	TEST_CASE("count") {
+		SUBCASE("popcount across multiple segments") {
+			dyn8 b{0xFF, 0x0F, 0x00, 0x01};
+			CHECK_EQ(b.count(), 8 + 4 + 0 + 1);
+		}
+
+		SUBCASE("empty bitset has count zero") {
+			dyn8 b{};
+			CHECK_EQ(b.count(), 0);
+		}
+	}
+
+	TEST_CASE("bit counting within a single segment") {
+		struct case_t {
+			std::uint8_t value;
+			std::size_t countr_zero;
+			std::size_t countl_zero;
+			std::size_t countr_one;
+			std::size_t countl_one;
+		};
+
+		std::array<case_t, 4> const cases{
+			case_t{0b00000000, 8, 8, 0, 0},
+			case_t{0b11111111, 0, 0, 8, 8},
+			case_t{0b00001000, 3, 4, 0, 0},
+			case_t{0b11110111, 0, 0, 3, 4}, // bit 3 unset: 3 trailing ones, 4 leading ones
+		};
+
+		for (auto const &c : cases) {
+			CAPTURE(static_cast<unsigned>(c.value));
+			dyn8 b{c.value};
+			CHECK_EQ(b.countr_zero(), c.countr_zero);
+			CHECK_EQ(b.countl_zero(), c.countl_zero);
+			CHECK_EQ(b.countr_one(), c.countr_one);
+			CHECK_EQ(b.countl_one(), c.countl_one);
+		}
+	}
+
+	TEST_CASE("bit counting across multiple segments") {
+		// segment index order is low-to-high; global bit index 0 (segment 0, offset 0) is the
+		// least-significant end (segment_set uses "1 << offset", i.e. offset 0 is the LSB within
+		// a segment) and the highest segment holds the most-significant bits.
+
+		SUBCASE("countr_zero accumulates over fully-zero low segments") {
+			dyn8 b{0x00, 0x00, 0b00000100};
+			CHECK_EQ(b.countr_zero(), 8 + 8 + 2);
+		}
+
+		SUBCASE("countr_one accumulates over fully-one low segments") {
+			dyn8 b{0xFF, 0xFF, 0b11111011};
+			CHECK_EQ(b.countr_one(), 8 + 8 + 2);
+		}
+
+		SUBCASE("countl_zero accumulates over fully-zero high segments") {
+			// segment 0 has its top bit set (no leading zeros locally); segments 1 and 2 sit at
+			// the high/most-significant end and are fully zero, so the global leading-zero count
+			// must include both of them before reaching segment 0's own contribution of 0.
+			dyn8 b{0b10000000, 0x00, 0x00};
+			CHECK_EQ(b.countl_zero(), 8 + 8 + 0);
+		}
+
+		SUBCASE("countl_one accumulates over fully-one high segments") {
+			dyn8 b{0b01111111, 0xFF, 0xFF};
+			CHECK_EQ(b.countl_one(), 8 + 8 + 0);
+		}
+	}
+
+	TEST_CASE("all_set / any_set / none_set") {
+		SUBCASE("all_set true only when every bit is 1") {
+			dyn8 full{0xFF, 0xFF};
+			dyn8 partial{0xFF, 0xFE};
+			dyn8 empty_bits{0x00, 0x00};
+
+			CHECK(full.all_set());
+			CHECK_FALSE(partial.all_set());
+			CHECK_FALSE(empty_bits.all_set());
+		}
+
+		SUBCASE("none_set true only when every bit is 0") {
+			dyn8 empty_bits{0x00, 0x00};
+			dyn8 partial{0x00, 0x01};
+			dyn8 full{0xFF, 0xFF};
+
+			CHECK(empty_bits.none_set());
+			CHECK_FALSE(partial.none_set());
+			CHECK_FALSE(full.none_set());
+		}
+
+		SUBCASE("any_set true when a fully-set segment is present") {
+			dyn8 b{0xFF, 0x00};
+			CHECK(b.any_set());
+		}
+
+		SUBCASE("any_set true when only a non-zero-offset bit is set") {
+			// bit 0 is unset but bit 1 is set - any_set must still report true
+			dyn8 b{0b00000010};
+			CHECK(b.any_set());
+		}
+
+		SUBCASE("any_set false for a fully empty bitset") {
+			dyn8 b{0x00, 0x00};
+			CHECK_FALSE(b.any_set());
+		}
+
+		SUBCASE("any_set true for a fully mixed bitset") {
+			dyn8 b{0b01010101};
+			CHECK(b.any_set());
+		}
+	}
+
+	TEST_CASE("set_first_free") {
+		SUBCASE("finds first unset bit within existing segments") {
+			dyn8 b{0xFF, 0b00000001};
+			auto const ix = b.set_first_free();
+			CHECK_EQ(ix, 9); // segment 1, offset 1 -> global index 8 + 1
+			CHECK(b.test(9));
+		}
+
+		SUBCASE("grows storage when all existing segments are full") {
+			dyn8 b{0xFF};
+			auto const ix = b.set_first_free();
+			CHECK_EQ(ix, 8); // new segment appended, first bit of it
+			REQUIRE_EQ(b.size(), 2);
+			CHECK(b.test(8));
+		}
+
+		SUBCASE("reports storage_size_in_bits once a fixed-capacity bitset is full") {
+			bounded64 b{~0ull, ~0ull, ~0ull, ~0ull};
+			CHECK_EQ(b.set_first_free(), bounded64::storage_size_in_bits);
+		}
+	}
+
+	TEST_CASE("equality") {
+		SUBCASE("equal bitsets compare equal") {
+			dyn8 a{0x12, 0x34};
+			dyn8 b{0x12, 0x34};
+			CHECK(a == b);
+		}
+
+		SUBCASE("differing content compares unequal") {
+			dyn8 a{0x12, 0x34};
+			dyn8 b{0x12, 0x35};
+			CHECK_FALSE(a == b);
+		}
+
+		SUBCASE("differing size compares unequal") {
+			dyn8 a{0x12};
+			dyn8 b{0x12, 0x00};
+			CHECK_FALSE(a == b);
+		}
+	}
+
+	TEST_CASE("bitwise combination") {
+		SUBCASE("operator&= / operator&") {
+			dyn8 a{0b11001100};
+			dyn8 b{0b10101010};
+			auto const c = a & b; // -> 0b10001000
+
+			CHECK_EQ(c.count(), 2);
+			a &= b;
+			CHECK(a == c);
+		}
+
+		SUBCASE("operator|= / operator|") {
+			dyn8 a{0b11001100};
+			dyn8 b{0b10101010};
+			auto const c = a | b; // -> 0b11101110
+
+			CHECK_EQ(c.count(), 6);
+			a |= b;
+			CHECK(a == c);
+		}
+	}
+
+	TEST_CASE("iteration") {
+		SUBCASE("bit-mode iteration visits every bit exactly once") {
+			dyn8 b{0x00, 0x00};
+			auto it = b.begin();
+			auto const sentinel = b.end();
+
+			size_t visited = 0;
+			while (it != sentinel) {
+				++visited;
+				++it;
+			}
+			CHECK_EQ(visited, b.size_in_bits());
+		}
+
+		SUBCASE("operator* reads the bit at the iterator's current position") {
+			dyn8 b{0b00000101};
+			auto it = b.begin();
+			CHECK(*it); // bit 0
+			++it;
+			CHECK_FALSE(*it); // bit 1
+			++it;
+			CHECK(*it); // bit 2
+		}
+
+		SUBCASE("writing through the iterator itself (not *it) sets the underlying bit") {
+			dyn8 b{0x00};
+			auto it = b.begin();
+			it = true;
+			CHECK(b.test(0));
+
+			++it;
+			it = true;
+			CHECK(b.test(1));
+
+			it = false;
+			CHECK_FALSE(b.test(1));
+		}
+
+		SUBCASE("segment-mode increment advances by a whole segment") {
+			dyn8 b{0xAA, 0xBB};
+			auto it = b.begin();
+			CHECK_EQ(it.get(), 0xAA);
+			it.operator++<bitset_const::segment_mode>();
+			CHECK_EQ(it.get(), 0xBB);
+		}
+
+		SUBCASE("operator+= / operator+ skip ahead by bits or by segments") {
+			dyn8 b{0b00000000, 0b00000010};
+
+			auto it = b.begin();
+			it += 9; // segment 1, offset 1
+			CHECK(*it);
+
+			auto const it2 = b.begin() + 9;
+			CHECK(*it2);
+
+			auto it3 = b.begin();
+			it3.operator+=<bitset_const::segment_mode>(1);
+			CHECK_EQ(it3.get(), 0b00000010);
+		}
+	}
+
+	TEST_CASE("shifts") {
+		SUBCASE("operator<<= moves bits toward lower indices and clears vacated bits") {
+			dyn8 b{0b10110011}; // bit(i): 1,1,0,0,1,1,0,1 for i = 0..7
+			b <<= 2;
+			bool const expected[8] = {false, false, true, true, false, true, false, false};
+			for (size_t i = 0; i < 8; ++i) {
+				CHECK_EQ(b.test(i), expected[i]);
+			}
+		}
+
+		SUBCASE("operator>>= moves bits toward higher indices and clears vacated bits") {
+			dyn8 b{0b10110011};
+			b >>= 2;
+			bool const expected[8] = {false, false, true, true, false, false, true, true};
+			for (size_t i = 0; i < 8; ++i) {
+				CHECK_EQ(b.test(i), expected[i]);
+			}
+		}
+
+		SUBCASE("operator<< / operator>> produce a shifted copy, leaving the original untouched") {
+			dyn8 b{0b10110011}; // bit(i): 1,1,0,0,1,1,0,1 for i = 0..7
+			auto const left = b << 2;
+			auto const right = b >> 2;
+
+			bool const expected_left[8] = {false, false, true, true, false, true, false, false};
+			bool const expected_right[8] = {false, false, true, true, false, false, true, true};
+			for (size_t i = 0; i < 8; ++i) {
+				CHECK_EQ(left.test(i), expected_left[i]);
+				CHECK_EQ(right.test(i), expected_right[i]);
+			}
+
+			// original untouched by either shift
+			CHECK(b.test(0));
+			CHECK(b.test(1));
+			CHECK_FALSE(b.test(2));
+		}
+	}
+
+	TEST_CASE("formatting") {
+		// the formatter's output isn't specified/stable enough to assert on - just make sure the
+		// various format specs run without throwing, and print the result for a human to eyeball.
+		dyn8 b{0b10110011, 0x00};
+		MESSAGE("default: ", std::format("{}", b));
+		MESSAGE("hex: ", std::format("{:x}", b));
+		MESSAGE("binary: ", std::format("{:b}", b));
+		MESSAGE("debug+hex: ", std::format("{:?x}", b));
+		MESSAGE("debug+binary: ", std::format("{:?b}", b));
+	}
+
+	TEST_CASE("multi-word (non-integral) segment type") {
+		using wide_bitset = bitset<wide_word, dynamic_extent, dynamic_extent>;
+
+		SUBCASE("single-bit addressing within a multi-word segment") {
+			// bit 10 belongs to the low 64-bit word of the segment and must read back as set.
+			// (chosen small enough that a wrong chunk computation still lands in-bounds instead
+			// of reading/writing past the segment.)
+			wide_word w{};
+			w.lo = 1ull << 10;
+
+			wide_bitset b{w};
+			CHECK(b.test(10));
+		}
+
+		SUBCASE("count / countr_zero span both 64-bit words") {
+			wide_word w{};
+			w.lo = 0b1011;                // 3 bits set in the low word
+			w.hi = 0x8000000000000000ull; // top bit of the high word set
+
+			wide_bitset b{w};
+			CHECK_EQ(b.count(), 4);
+			CHECK_EQ(b.countr_zero(), 0); // bit 0 of the low word is already set
+		}
+
+		SUBCASE("segment_free based queries (any_set / none_set)") {
+			wide_bitset empty_b{wide_word{}};
+			CHECK(empty_b.none_set());
+			CHECK_FALSE(empty_b.any_set());
+
+			wide_word w{};
+			w.hi = 1; // only bit 64 set
+			wide_bitset b{w};
+			CHECK(b.any_set());
+			CHECK_FALSE(b.none_set());
+		}
+	}
 }
-

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -184,7 +184,59 @@ TEST_SUITE("bitset") {
 			bounded64 b{};
 			REQUIRE_THROWS_AS(b.set(bounded64::storage_size_in_bits), std::out_of_range);
 			REQUIRE_THROWS_AS(b.test(bounded64::storage_size_in_bits), std::out_of_range);
+			CHECK_EQ(b.size(), 0); // rejected out-of-range set() must not have grown anything
 			CHECK_NOTHROW(b.set(bounded64::storage_size_in_bits - 1));
+		}
+
+		SUBCASE("a large global index computes the exact number of segments needed and zero-fills the rest") {
+			// regression: growth must be driven off the actual bit index (which can require far
+			// more than one extra segment), not just the "next segment" case exercised above.
+			dyn64 b{};
+			b.set(1000); // segment 15 (1000 / 64), so 16 segments are required in total
+			REQUIRE_EQ(b.size(), 16);
+			CHECK(b.test(1000));
+
+			for (size_t i = 0; i < b.size_in_bits(); ++i) {
+				if (i == 1000) continue;
+				CAPTURE(i);
+				CHECK_FALSE(b.test(i));
+			}
+		}
+
+		SUBCASE("setting a lower index after a large-index growth does not grow further") {
+			dyn64 b{};
+			b.set(1000);
+			REQUIRE_EQ(b.size(), 16);
+
+			b.set(0);
+			CHECK_EQ(b.size(), 16); // already had enough room, must not have resized again
+			CHECK(b.test(0));
+			CHECK(b.test(1000));
+		}
+
+		SUBCASE("bounded capacity auto-grows its logical size, staying consistent with count/iteration") {
+			// regression: set() on a bounded bitset used to write the bit directly without ever
+			// growing size(), so test() would report the bit as set while count()/iteration/
+			// all_set()/etc (which all iterate up to size()) stayed blind to it entirely.
+			bounded64 b{};
+			REQUIRE_EQ(b.size(), 0);
+
+			b.set(5);
+			CHECK_EQ(b.size(), 1);
+			CHECK(b.test(5));
+			CHECK_EQ(b.count(), 1);
+
+			size_t visited = 0;
+			for (auto it = b.begin(); it != b.end(); ++it) ++visited;
+			CHECK_EQ(visited, b.size_in_bits());
+		}
+
+		SUBCASE("bounded capacity growth stops exactly at its static maximum and stays zero-filled") {
+			bounded64 b{};
+			b.set(bounded64::storage_size_in_bits - 1); // last valid bit, far beyond current size()
+			REQUIRE_EQ(b.size(), 4);
+			CHECK(b.test(bounded64::storage_size_in_bits - 1));
+			CHECK_EQ(b.count(), 1); // every other (newly exposed) bit must be zero, not garbage
 		}
 	}
 

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -70,7 +70,7 @@ TEST_SUITE("bitset") {
 			}
 		}
 
-		SUBCASE("copy/move construction and assignment are independent of the source") {
+		SUBCASE("copy/move construction and assignment are indepositions_endent of the source") {
 			dyn8 a{0x00, 0x00};
 
 			dyn8 b{a};
@@ -179,7 +179,7 @@ TEST_SUITE("bitset") {
 			bounded64 b{};
 			b.set(bounded64_capacity_bits - 1); // last valid bit, far beyond current size()
 			REQUIRE_EQ(b.capacity_in_bits(), 4 * 64);
-			// size_in_bits() is now the static, growth-independent logical bound (max_bits) -
+			// size_in_bits() is now the static, growth-indepositions_endent logical bound (max_bits) -
 			// it must equal capacity_in_bits() here since growth reached the maximum.
 			CHECK_EQ(bounded64::size_in_bits(), bounded64_capacity_bits);
 			CHECK(b.test(bounded64_capacity_bits - 1));
@@ -336,7 +336,7 @@ TEST_SUITE("bitset") {
 		SUBCASE("grows storage when all existing segments are full") {
 			dyn8 b{0xFF};
 			auto const ix = b.set_first_free();
-			CHECK_EQ(ix, 8); // new segment appended, first bit of it
+			CHECK_EQ(ix, 8); // new segment appositions_ended, first bit of it
 			REQUIRE_EQ(b.capacity_in_bits(), 2 * 8);
 			CHECK(b.test(8));
 		}
@@ -575,7 +575,7 @@ TEST_SUITE("bitset") {
 	TEST_CASE("segment-mode dereferencing: T& reference vs plain T value semantics") {
 		// segment_iterator's reference has operator std::conditional_t<is_const, T const&, T&>()
 		// (SegmentMode-only) - this exercises both sides: binding the dereference to a T&
-		// (an actual alias into storage) vs binding it to a plain T (an independent copy).
+		// (an actual alias into storage) vs binding it to a plain T (an indepositions_endent copy).
 		// bitset itself keeps its segment/storage type private - these tests spell it out as
 		// plain uint8_t (the T dyn8 was defined with below), never referring to any bitset-side
 		// alias for it.
@@ -602,7 +602,7 @@ TEST_SUITE("bitset") {
 			CHECK_EQ(b.count(), 8);        // and is visible through completely separate accessors
 		}
 
-		SUBCASE("dereferencing as a plain T yields an independent copy - mutating it leaves storage untouched") {
+		SUBCASE("dereferencing as a plain T yields an indepositions_endent copy - mutating it leaves storage untouched") {
 			dyn8 b{0xAA, 0xBB};
 			auto it = b.begin<dyn8::bitset_mode::SegmentMode>();
 
@@ -611,12 +611,12 @@ TEST_SUITE("bitset") {
 
 			seg_val = 0xFF; // only the local copy changes
 			CHECK_EQ(it.get(), 0xAA);      // storage is untouched
-			CHECK_EQ(seg_val, 0xFF);       // the copy did change, proving it's genuinely independent
+			CHECK_EQ(seg_val, 0xFF);       // the copy did change, proving it's genuinely indepositions_endent
 		}
 
 		SUBCASE("two iterators over the same segment alias each other through T&, proving real reference semantics") {
 			// the clearest way to tell a reference from a value: write through one iterator's
-			// T& and read it back through a second, independently-obtained iterator/reference.
+			// T& and read it back through a second, indepositions_endently-obtained iterator/reference.
 			dyn8 b{0x00, 0x00};
 			auto writer = b.begin<dyn8::bitset_mode::SegmentMode>();
 			auto reader = b.begin<dyn8::bitset_mode::SegmentMode>();
@@ -702,7 +702,7 @@ TEST_SUITE("bitset") {
 		// as a cryptic constraint-not-satisfied error deep inside <ranges>/<algorithm>. Traversal
 		// policy is now a template parameter baked into the iterator's type (bit_iterator /
 		// segment_iterator, plus their const_ counterparts) rather than a per-call argument, so
-		// both instantiations need to be checked independently.
+		// both instantiations need to be checked indepositions_endently.
 		static_assert(std::default_initializable<dyn64::bit_iterator>);
 		static_assert(std::default_initializable<dyn64::const_bit_iterator>);
 		static_assert(std::totally_ordered<dyn64::bit_iterator>);
@@ -780,7 +780,7 @@ TEST_SUITE("bitset") {
 			CHECK((3 - it) == (it - 3));
 		}
 
-		SUBCASE("default-constructed iterators are equality-comparable and independent of any bitset") {
+		SUBCASE("default-constructed iterators are equality-comparable and indepositions_endent of any bitset") {
 			dyn8::bit_iterator a{};
 			dyn8::bit_iterator b{};
 			CHECK(a == b);
@@ -1069,7 +1069,7 @@ TEST_SUITE("bitset") {
 			CHECK_EQ(std::format("{:b}", b), "[\n[10110011]\n]\n");
 		}
 
-		SUBCASE("binary mode reverses within each segment independently, segments stay in storage order") {
+		SUBCASE("binary mode reverses within each segment indepositions_endently, segments stay in storage order") {
 			dyn8 b{0x00, 0xFF};
 			CHECK_EQ(std::format("{:b}", b), "[\n[00000000]\n[11111111]\n]\n");
 		}
@@ -1318,7 +1318,7 @@ TEST_SUITE("bitset") {
 			static_assert(std::is_same_v<decltype(++std::declval<pos_it&>()), pos_it&>);
 
 			dyn64 b{0b10101, 0b1}; // segment 0: bits 0,2,4 set; segment 1: bit 0 set -> 4 set bits total
-			auto it = b.pbegin(); // already positioned at the first set bit (ix 0)
+			auto it = b.positions_begin(); // already positioned at the first set bit (ix 0)
 
 			size_t steps = 0;
 			for (; it != std::default_sentinel; ++it) {
@@ -1328,18 +1328,18 @@ TEST_SUITE("bitset") {
 			CHECK_EQ(steps, 4);
 		}
 
-		SUBCASE("empty bitset: pbegin() equals pend() immediately") {
+		SUBCASE("empty bitset: positions_begin() equals positions_end() immediately") {
 			dyn64 b{};
-			CHECK(b.pbegin() == b.pend());
-			CHECK(b.pend() == b.pbegin());
+			CHECK(b.positions_begin() == b.positions_end());
+			CHECK(b.positions_end() == b.positions_begin());
 		}
 
-		SUBCASE("pbegin()/pend() walked directly (without positions()) on a non-const bitset") {
+		SUBCASE("positions_begin()/positions_end() walked directly (without positions()) on a non-const bitset") {
 			dyn64 b{0b10101, 0b1}; // segment 0: bits 0,2,4 set; segment 1: bit 0 set
 			std::array<size_t, 4> const expected{0, 2, 4, 64};
 
 			size_t i = 0;
-			for (auto it = b.pbegin(); it != b.pend(); ++it) {
+			for (auto it = b.positions_begin(); it != b.positions_end(); ++it) {
 				REQUIRE_LT(i, expected.size());
 				// *it is a plain value_type (size_t) now - it IS the position directly, not a
 				// proxy with .ix()/operator bool().
@@ -1356,7 +1356,7 @@ TEST_SUITE("bitset") {
 			std::array<size_t, 4> const expected{0, 2, 4, 64};
 
 			size_t i = 0;
-			for (auto it = b.pbegin(); it != b.pend(); ++it) {
+			for (auto it = b.positions_begin(); it != b.positions_end(); ++it) {
 				REQUIRE_LT(i, expected.size());
 				size_t const pos = *it; // direct conversion, not (*it).ix()
 				CHECK_EQ(pos, expected[i]);
@@ -1379,13 +1379,13 @@ TEST_SUITE("bitset") {
 			CHECK_EQ(i, expected.size());
 		}
 
-		SUBCASE("pbegin()/pend() on a const bitset yield a const_positional_iterator") {
+		SUBCASE("positions_begin()/positions_end() on a const bitset yield a const_positional_iterator") {
 			dyn64 const b{0b10101, 0b1};
-			static_assert(std::is_same_v<decltype(b.pbegin()), const_pos_it>);
+			static_assert(std::is_same_v<decltype(b.positions_begin()), const_pos_it>);
 
 			std::array<size_t, 4> const expected{0, 2, 4, 64};
 			size_t i = 0;
-			for (auto it = b.pbegin(); it != b.pend(); ++it) {
+			for (auto it = b.positions_begin(); it != b.positions_end(); ++it) {
 				REQUIRE_LT(i, expected.size());
 				CHECK_EQ(*it, expected[i]);
 				++i;
@@ -1395,7 +1395,7 @@ TEST_SUITE("bitset") {
 
 		SUBCASE("postfix increment returns the pre-increment position; prefix returns *this by reference") {
 			dyn64 b{0b101}; // bits 0 and 2 set
-			auto it = b.pbegin();
+			auto it = b.positions_begin();
 
 			auto const before = it++;
 			CHECK_EQ(*before, 0);
@@ -1403,12 +1403,12 @@ TEST_SUITE("bitset") {
 
 			auto &ref = ++it;
 			CHECK_EQ(&ref, &it); // weakly_incrementable requires "{ ++i } -> same_as<I&>"
-			CHECK(it == b.pend());
+			CHECK(it == b.positions_end());
 		}
 
-		SUBCASE("copies are independent") {
+		SUBCASE("copies are indepositions_endent") {
 			dyn64 b{0b101}; // bits 0 and 2 set
-			auto it1 = b.pbegin();
+			auto it1 = b.positions_begin();
 			auto it2 = it1;
 			++it1;
 
@@ -1427,13 +1427,13 @@ TEST_SUITE("bitset") {
 			static_assert(!dereference_is_assignable<const_pos_it>);
 
 			dyn64 b{0b1};
-			auto it = b.pbegin();
+			auto it = b.positions_begin();
 			CHECK_EQ(*it, 0);
 		}
 
-		SUBCASE("pbegin() skips forward when bit 0 of segment 0 is not actually set") {
+		SUBCASE("positions_begin() skips forward when bit 0 of segment 0 is not actually set") {
 			dyn64 b{0b100}; // bit 2 set, bit 0 NOT set
-			auto it = b.pbegin();
+			auto it = b.positions_begin();
 			CHECK_EQ(*it, 2);
 		}
 

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -17,12 +17,6 @@
 template<typename I>
 concept has_subscript_operator = requires(I i, std::iter_difference_t<I> n) { i[n]; };
 
-// size_in_bits() is now a static, has_max_extent-only member (the "separation between logical
-// size and capacity" change) - a genuine template parameter is needed here too so a fully dynamic
-// bitset fails via substitution rather than a hard compile error.
-template<typename B>
-concept has_static_size_in_bits = requires { B::size_in_bits(); };
-
 // position_iterator's dereference is a plain value_type (size_t) now, not a writable proxy -
 // verifies there is nothing to assign through it.
 template<typename I>
@@ -70,7 +64,7 @@ TEST_SUITE("bitset") {
 			}
 		}
 
-		SUBCASE("copy/move construction and assignment are indepositions_endent of the source") {
+		SUBCASE("copy/move construction and assignment are independent of the source") {
 			dyn8 a{0x00, 0x00};
 
 			dyn8 b{a};
@@ -166,22 +160,29 @@ TEST_SUITE("bitset") {
 			REQUIRE_EQ(b.capacity_in_bits(), 0);
 
 			b.set(5);
+			// logical size (size_in_bits()) tracks the exact bit index reached, NOT rounded up to
+			// a whole segment - capacity_in_bits() is the (larger) physically-allocated amount.
+			CHECK_EQ(b.size_in_bits(), 6);
 			CHECK_EQ(b.capacity_in_bits(), 64);
 			CHECK(b.test(5));
 			CHECK_EQ(b.count(), 1);
 
+			// bit-mode iteration (begin()/end()) is bounded by the exact logical size, not the
+			// rounded-up physical capacity - only the 6 logically-used bits are visited.
 			size_t visited = 0;
 			for (auto it = b.begin(); it != b.end(); ++it) ++visited;
-			CHECK_EQ(visited, b.capacity_in_bits());
+			CHECK_EQ(visited, b.size_in_bits());
 		}
 
 		SUBCASE("bounded capacity growth stops exactly at its static maximum and stays zero-filled") {
 			bounded64 b{};
-			b.set(bounded64_capacity_bits - 1); // last valid bit, far beyond current size()
-			REQUIRE_EQ(b.capacity_in_bits(), 4 * 64);
-			// size_in_bits() is now the static, growth-indepositions_endent logical bound (max_bits) -
-			// it must equal capacity_in_bits() here since growth reached the maximum.
-			CHECK_EQ(bounded64::size_in_bits(), bounded64_capacity_bits);
+			b.set(bounded64_capacity_bits - 1); // last valid bit, right at the maximum
+			// setting the very last valid index grows logical size to exactly its maximum, so
+			// size_in_bits() and capacity_in_bits() coincide here - not because size_in_bits() is
+			// static (it isn't - it's the same dynamic logical size as above), but because this
+			// particular index happens to be capacity_in_bits() - 1.
+			CHECK_EQ(b.size_in_bits(), bounded64_capacity_bits);
+			CHECK_EQ(b.capacity_in_bits(), 4 * 64);
 			CHECK(b.test(bounded64_capacity_bits - 1));
 			CHECK_EQ(b.count(), 1); // every other (newly exposed) bit must be zero, not garbage
 		}
@@ -575,7 +576,7 @@ TEST_SUITE("bitset") {
 	TEST_CASE("segment-mode dereferencing: T& reference vs plain T value semantics") {
 		// segment_iterator's reference has operator std::conditional_t<is_const, T const&, T&>()
 		// (SegmentMode-only) - this exercises both sides: binding the dereference to a T&
-		// (an actual alias into storage) vs binding it to a plain T (an indepositions_endent copy).
+		// (an actual alias into storage) vs binding it to a plain T (an independent copy).
 		// bitset itself keeps its segment/storage type private - these tests spell it out as
 		// plain uint8_t (the T dyn8 was defined with below), never referring to any bitset-side
 		// alias for it.
@@ -602,7 +603,7 @@ TEST_SUITE("bitset") {
 			CHECK_EQ(b.count(), 8);        // and is visible through completely separate accessors
 		}
 
-		SUBCASE("dereferencing as a plain T yields an indepositions_endent copy - mutating it leaves storage untouched") {
+		SUBCASE("dereferencing as a plain T yields an independent copy - mutating it leaves storage untouched") {
 			dyn8 b{0xAA, 0xBB};
 			auto it = b.begin<dyn8::bitset_mode::SegmentMode>();
 
@@ -611,12 +612,12 @@ TEST_SUITE("bitset") {
 
 			seg_val = 0xFF; // only the local copy changes
 			CHECK_EQ(it.get(), 0xAA);      // storage is untouched
-			CHECK_EQ(seg_val, 0xFF);       // the copy did change, proving it's genuinely indepositions_endent
+			CHECK_EQ(seg_val, 0xFF);       // the copy did change, proving it's genuinely independent
 		}
 
 		SUBCASE("two iterators over the same segment alias each other through T&, proving real reference semantics") {
 			// the clearest way to tell a reference from a value: write through one iterator's
-			// T& and read it back through a second, indepositions_endently-obtained iterator/reference.
+			// T& and read it back through a second, independently-obtained iterator/reference.
 			dyn8 b{0x00, 0x00};
 			auto writer = b.begin<dyn8::bitset_mode::SegmentMode>();
 			auto reader = b.begin<dyn8::bitset_mode::SegmentMode>();
@@ -702,7 +703,7 @@ TEST_SUITE("bitset") {
 		// as a cryptic constraint-not-satisfied error deep inside <ranges>/<algorithm>. Traversal
 		// policy is now a template parameter baked into the iterator's type (bit_iterator /
 		// segment_iterator, plus their const_ counterparts) rather than a per-call argument, so
-		// both instantiations need to be checked indepositions_endently.
+		// both instantiations need to be checked independently.
 		static_assert(std::default_initializable<dyn64::bit_iterator>);
 		static_assert(std::default_initializable<dyn64::const_bit_iterator>);
 		static_assert(std::totally_ordered<dyn64::bit_iterator>);
@@ -780,7 +781,7 @@ TEST_SUITE("bitset") {
 			CHECK((3 - it) == (it - 3));
 		}
 
-		SUBCASE("default-constructed iterators are equality-comparable and indepositions_endent of any bitset") {
+		SUBCASE("default-constructed iterators are equality-comparable and independent of any bitset") {
 			dyn8::bit_iterator a{};
 			dyn8::bit_iterator b{};
 			CHECK(a == b);
@@ -1069,7 +1070,7 @@ TEST_SUITE("bitset") {
 			CHECK_EQ(std::format("{:b}", b), "[\n[10110011]\n]\n");
 		}
 
-		SUBCASE("binary mode reverses within each segment indepositions_endently, segments stay in storage order") {
+		SUBCASE("binary mode reverses within each segment independently, segments stay in storage order") {
 			dyn8 b{0x00, 0xFF};
 			CHECK_EQ(std::format("{:b}", b), "[\n[00000000]\n[11111111]\n]\n");
 		}
@@ -1406,7 +1407,7 @@ TEST_SUITE("bitset") {
 			CHECK(it == b.positions_end());
 		}
 
-		SUBCASE("copies are indepositions_endent") {
+		SUBCASE("copies are independent") {
 			dyn64 b{0b101}; // bits 0 and 2 set
 			auto it1 = b.positions_begin();
 			auto it2 = it1;
@@ -1488,63 +1489,335 @@ TEST_SUITE("bitset") {
 		}
 	}
 
-	TEST_CASE("bit count that isn't a multiple of the segment width rounds up to a whole segment") {
-		// the 2nd template parameter is a bit count; internally it's converted to a segment count via
-		// ceil(bits / segment_size_in_bits). These use bit counts that deliberately don't divide evenly
-		// by the segment width, to verify the *actual* capacity is rounded up to cover them, not
-		// truncated down to fewer segments and not left as some other unrelated fixed value.
+	TEST_CASE("bit count that isn't a multiple of the segment width is honored exactly - no rounding") {
+		// the 2nd template parameter (max_bits) is now an exact logical bit-count bound - it is
+		// NOT rounded up to a whole segment for the purposes of what indices are legal. Physical
+		// storage (capacity_in_bits()) still grows in whole-segment increments under the hood, but
+		// size_in_bits()/fits_in_storage() only ever honor the exact max_bits value: index max_bits-1
+		// is the last legal one, and index max_bits itself is always out of range, even though the
+		// physically-allocated segment has room for it.
 
 		SUBCASE("bounded (dynamic size, capped) capacity: uint64_t segments") {
-			// 200 bits doesn't divide evenly by 64 -> needs ceil(200/64) = 4 segments = 256 bits capacity
+			// 200 bits doesn't divide evenly by 64 -> physically needs ceil(200/64) = 4 segments =
+			// 256 bits of capacity, but the logical bound stays exactly 200.
 			using bounded_odd = bitset<dynamic_extent, 200>;
 			constexpr size_t expected_capacity_bits = 4 * 64;
 
 			bounded_odd b{};
-			CHECK_NOTHROW(b.set(expected_capacity_bits - 1)); // last bit of the 4th (rounded-up) segment
-			REQUIRE_EQ(b.capacity_in_bits(), expected_capacity_bits); // grew to a whole segment, not just to 200 bits
-			CHECK_THROWS_AS(b.set(expected_capacity_bits), std::out_of_range); // truly out of capacity
-
-			// size_in_bits() is the static, un-rounded logical bound (max_bits itself, 200) - it
-			// stays fixed regardless of growth, unlike capacity_in_bits() which just grew to 256.
-			CHECK_EQ(bounded_odd::size_in_bits(), 200);
+			REQUIRE_EQ(b.size_in_bits(), 0); // nothing used yet - dynamic size starts at 0, not max_bits
+			CHECK_NOTHROW(b.set(199)); // last legal index (max_bits - 1)
+			CHECK_EQ(b.size_in_bits(), 200); // logical size grew to exactly ix + 1, not rounded
+			CHECK_EQ(b.capacity_in_bits(), expected_capacity_bits); // physical storage did round up to whole segments
+			CHECK(b.test(199));
+			CHECK_THROWS_AS(b.set(200), std::out_of_range); // exactly max_bits is out of range, despite spare room in the 4th segment
 		}
 
 		SUBCASE("fully static capacity: uint64_t segments") {
 			// extent must equal the segment count derived from bits (4) for the fully-static flex_array
-			// specialization to apply; using 200 (not 256) here is what actually exercises the rounding
+			// specialization to apply; using 200 (not 256) here is what actually exercises the bound.
 			using fixed_odd = bitset<4, 200>;
 			constexpr size_t expected_capacity_bits = 4 * 64;
 
 			fixed_odd b{0, 0, 0, 0};
-			CHECK_NOTHROW(b.set(expected_capacity_bits - 1));
-			CHECK_THROWS_AS(b.set(expected_capacity_bits), std::out_of_range);
-
-			// even fully static, size_in_bits() is still the raw max_bits (200), not the
-			// segment-rounded capacity_in_bits() (256) - the two are deliberately distinct concepts.
-			CHECK_EQ(fixed_odd::size_in_bits(), 200);
+			// fully static bitsets have no separate "used so far" tracking - size_in_bits() is
+			// simply max_bits itself from construction, unconditionally.
+			REQUIRE_EQ(b.size_in_bits(), 200);
 			CHECK_EQ(b.capacity_in_bits(), expected_capacity_bits);
+
+			CHECK_NOTHROW(b.set(199));
+			CHECK(b.test(199));
+			CHECK_THROWS_AS(b.set(200), std::out_of_range); // still out of range despite the 4th segment physically existing
 		}
 
 		SUBCASE("bounded capacity: narrow (uint8_t) segments") {
-			// 20 bits doesn't divide evenly by 8 -> needs ceil(20/8) = 3 segments = 24 bits capacity
+			// 20 bits doesn't divide evenly by 8 -> physically needs ceil(20/8) = 3 segments = 24
+			// bits of capacity, but the logical bound stays exactly 20.
 			using bounded_odd8 = bitset<dynamic_extent, 20, uint8_t>;
 			constexpr size_t expected_capacity_bits = 3 * 8;
 
 			bounded_odd8 b{};
-			CHECK_NOTHROW(b.set(expected_capacity_bits - 1));
-			REQUIRE_EQ(b.capacity_in_bits(), expected_capacity_bits);
-			CHECK_THROWS_AS(b.set(expected_capacity_bits), std::out_of_range);
-			CHECK_EQ(bounded_odd8::size_in_bits(), 20);
+			REQUIRE_EQ(b.size_in_bits(), 0);
+			CHECK_NOTHROW(b.set(19));
+			CHECK_EQ(b.size_in_bits(), 20);
+			CHECK_EQ(b.capacity_in_bits(), expected_capacity_bits);
+			CHECK(b.test(19));
+			CHECK_THROWS_AS(b.set(20), std::out_of_range);
+		}
+	}
+
+	TEST_CASE("logical size (size_in_bits()) tracks exact usage, distinct from rounded-up capacity") {
+		SUBCASE("a fresh dynamic bitset starts at logical size 0, not at any rounded segment width") {
+			dyn8 b{};
+			CHECK_EQ(b.size_in_bits(), 0);
+			CHECK_EQ(b.capacity_in_bits(), 0);
 		}
 
-		SUBCASE("fully dynamic capacity has no static size_in_bits() at all") {
-			// size_in_bits() requires has_max_extent - a fully dynamic bitset (both template
-			// parameters left as dynamic_extent) has no compile-time logical bound to report.
-			static_assert(!has_static_size_in_bits<dyn64>);
-			static_assert(!has_static_size_in_bits<dyn8>);
-			static_assert(has_static_size_in_bits<bounded64>);
-			static_assert(has_static_size_in_bits<bitset<4, 4 * 64>>);
-			CHECK(true);
+		SUBCASE("set(ix) grows logical size to exactly ix + 1, never rounded to a segment boundary") {
+			dyn8 b{};
+			b.set(3);
+			CHECK_EQ(b.size_in_bits(), 4); // exactly ix+1, not rounded up to 8
+			CHECK_EQ(b.capacity_in_bits(), 8); // capacity still rounds up to a whole segment
 		}
+
+		SUBCASE("capacity_in_bits() stays a whole-segment multiple while size_in_bits() does not") {
+			dyn8 b{};
+			b.set(9); // segment 1, offset 1 -> needs 2 segments physically
+			CHECK_EQ(b.size_in_bits(), 10);
+			CHECK_EQ(b.capacity_in_bits(), 16);
+		}
+
+		SUBCASE("setting an already-covered lower index does not change logical size") {
+			dyn8 b{};
+			b.set(20);
+			auto const size_after_growth = b.size_in_bits();
+			b.set(3); // well within [0, 21) already
+			CHECK_EQ(b.size_in_bits(), size_after_growth);
+			CHECK_EQ(b.size_in_bits(), 21);
+		}
+
+		SUBCASE("setting the same highest index again does not change logical size") {
+			dyn8 b{};
+			b.set(10);
+			auto const size_after_first = b.size_in_bits();
+			b.set(10);
+			CHECK_EQ(b.size_in_bits(), size_after_first);
+			CHECK_EQ(b.size_in_bits(), 11);
+		}
+
+		SUBCASE("sequential grows each update logical size to the new maximum index reached") {
+			dyn64 b{};
+			b.set(5);
+			CHECK_EQ(b.size_in_bits(), 6);
+			b.set(130);
+			CHECK_EQ(b.size_in_bits(), 131);
+			b.set(20); // lower than current max - no change
+			CHECK_EQ(b.size_in_bits(), 131);
+			b.set(1000);
+			CHECK_EQ(b.size_in_bits(), 1001);
+		}
+	}
+
+	TEST_CASE("every mutating operation updates logical size correctly") {
+		SUBCASE("set(ix) beyond current logical size grows it and sets the bit") {
+			dyn8 b{};
+			b.set(10);
+			CHECK_EQ(b.size_in_bits(), 11);
+			CHECK(b.test(10));
+		}
+
+		SUBCASE("set(ix, false) beyond current logical size grows logical size even though the bit stays low") {
+			// set(ix, false) delegates to reset(ix), which - like set()/flip() - goes through the
+			// same growth path; the bit added by growth is already zero-filled, so this just makes
+			// the (already-implicitly-0) bit explicitly part of the logical range.
+			dyn8 b{};
+			b.set(10, false);
+			CHECK_EQ(b.size_in_bits(), 11);
+			CHECK_FALSE(b.test(10));
+		}
+
+		SUBCASE("reset(ix) beyond current logical size grows logical size, bit stays low") {
+			dyn8 b{};
+			b.reset(10);
+			CHECK_EQ(b.size_in_bits(), 11);
+			CHECK_FALSE(b.test(10));
+		}
+
+		SUBCASE("flip(ix) beyond current logical size grows logical size and flips the implicit 0 to 1") {
+			dyn8 b{};
+			b.flip(10);
+			CHECK_EQ(b.size_in_bits(), 11);
+			CHECK(b.test(10));
+		}
+
+		SUBCASE("set_first_free() grows logical size by exactly 1 when every existing bit is full") {
+			dyn8 b(1); // 1 segment pre-allocated, all zero, logical size 8
+			for (size_t i = 0; i < 8; ++i) b.set(i);
+			REQUIRE_EQ(b.size_in_bits(), 8);
+
+			auto const ix = b.set_first_free();
+			CHECK_EQ(ix, 8);
+			CHECK_EQ(b.size_in_bits(), 9); // grew by exactly the one new bit, not a whole segment
+			CHECK(b.test(8));
+		}
+
+		SUBCASE("set_first_free() returns a free bit within the current logical range without growing it") {
+			dyn8 b{0b11111101}; // bit 1 is the only free bit, logical size already 8
+			auto const ix = b.set_first_free();
+			CHECK_EQ(ix, 1);
+			CHECK_EQ(b.size_in_bits(), 8); // unchanged - the free bit was already within range
+		}
+
+		SUBCASE("set_positions() grows logical size to cover the maximum position given, regardless of order") {
+			dyn64 b(1); // 1 segment, logical size 64
+			b.set_positions(std::array{5uz, 70uz, 3uz}); // 70 is neither first nor last in the list
+			CHECK_EQ(b.size_in_bits(), 71);
+			CHECK(b.test(5));
+			CHECK(b.test(70));
+			CHECK(b.test(3));
+		}
+
+		SUBCASE("reset_positions() also grows logical size for out-of-range positions") {
+			dyn64 b(1);
+			b.reset_positions(std::array{5uz, 70uz});
+			CHECK_EQ(b.size_in_bits(), 71);
+			CHECK_FALSE(b.test(70));
+		}
+	}
+
+	TEST_CASE("a fully static bitset's logical size never changes") {
+		using fixed64 = bitset<4, 4 * 64>;
+
+		fixed64 b{0, 0, 0, 0};
+		REQUIRE_EQ(b.size_in_bits(), 4 * 64); // fixed from construction - has no dynamic tracking at all
+
+		b.set(5);
+		CHECK_EQ(b.size_in_bits(), 4 * 64);
+		b.reset(100);
+		CHECK_EQ(b.size_in_bits(), 4 * 64);
+		b.flip(250);
+		CHECK_EQ(b.size_in_bits(), 4 * 64);
+
+		CHECK_EQ(b.size_in_bits(), b.capacity_in_bits()); // static: logical size and capacity always coincide
+	}
+
+	TEST_CASE("shrink_to_fit keeps logical size and capacity in lockstep") {
+		SUBCASE("dropping a trailing not-fully-set segment shrinks logical size to the new exact capacity") {
+			dyn8 b{0xFF, 0x0F}; // segment 1 (0x0F) is not fully set
+			b.shrink_to_fit();
+			CHECK_EQ(b.size_in_bits(), 8);
+			CHECK_EQ(b.capacity_in_bits(), 8);
+		}
+
+		SUBCASE("no shrink happens when every segment is fully set - logical size is unchanged") {
+			dyn8 b{0xFF, 0xFF};
+			auto const size_before = b.size_in_bits();
+			b.shrink_to_fit();
+			CHECK_EQ(b.size_in_bits(), size_before);
+			CHECK_EQ(b.size_in_bits(), 16);
+			CHECK_EQ(b.capacity_in_bits(), 16);
+		}
+
+		SUBCASE("shrink_to_fit on an empty bitset is a safe no-op") {
+			dyn8 b{};
+			CHECK_NOTHROW(b.shrink_to_fit());
+			CHECK_EQ(b.size_in_bits(), 0);
+			CHECK_EQ(b.capacity_in_bits(), 0);
+		}
+	}
+
+	TEST_CASE("logical size is preserved correctly across copy/move") {
+		SUBCASE("copy construction preserves logical size, and the copy is independent going forward") {
+			dyn8 a{};
+			a.set(20);
+			REQUIRE_EQ(a.size_in_bits(), 21);
+
+			dyn8 b{a};
+			CHECK_EQ(b.size_in_bits(), 21);
+			CHECK(b.test(20));
+
+			b.set(50); // grow only the copy
+			CHECK_EQ(b.size_in_bits(), 51);
+			CHECK_EQ(a.size_in_bits(), 21); // original untouched
+		}
+
+		SUBCASE("copy assignment overwrites logical size with the source's") {
+			dyn8 a{};
+			a.set(20);
+			dyn8 b{};
+			b.set(3);
+			b = a;
+			CHECK_EQ(b.size_in_bits(), 21);
+			CHECK(b.test(20));
+		}
+
+		SUBCASE("move construction preserves logical size") {
+			dyn8 a{};
+			a.set(20);
+			dyn8 b{std::move(a)};
+			CHECK_EQ(b.size_in_bits(), 21);
+			CHECK(b.test(20));
+		}
+
+		SUBCASE("move assignment preserves logical size") {
+			dyn8 a{};
+			a.set(20);
+			dyn8 b{};
+			b = std::move(a);
+			CHECK_EQ(b.size_in_bits(), 21);
+			CHECK(b.test(20));
+		}
+	}
+
+	TEST_CASE("logical size participates in equality, not just physical segment content") {
+		// two bitsets can share the same physical capacity (same number of allocated segments,
+		// all-zero content) while having different logical sizes - equality must still tell them
+		// apart, rather than only comparing raw segment words.
+		dyn8 a{};
+		a.set(5);
+		a.reset(5); // segment content back to all-zero, but logical size stayed at 6
+		REQUIRE_EQ(a.size_in_bits(), 6);
+		REQUIRE_EQ(a.capacity_in_bits(), 8);
+		REQUIRE_EQ(a.count(), 0);
+
+		dyn8 b{};
+		b.set(2);
+		b.reset(2); // all-zero content, logical size 3, same 8-bit physical capacity as a
+		REQUIRE_EQ(b.size_in_bits(), 3);
+		REQUIRE_EQ(b.capacity_in_bits(), 8);
+		REQUIRE_EQ(b.count(), 0);
+
+		CHECK_FALSE(a == b); // same capacity and all-zero content, but different logical size
+	}
+
+	TEST_CASE("logical size bounds iteration and aggregate queries, not physical capacity") {
+		SUBCASE("bit-mode iteration visits exactly size_in_bits() elements") {
+			dyn8 b{};
+			b.set(9); // logical size 10, capacity 16 (2 segments)
+			size_t visited = 0;
+			for (auto it = b.begin(); it != b.end(); ++it) ++visited;
+			CHECK_EQ(visited, b.size_in_bits());
+			CHECK_EQ(visited, 10);
+		}
+
+		SUBCASE("segment-mode iteration still visits every physically-allocated segment") {
+			dyn8 b{};
+			b.set(9); // 2 physical segments, but logical size only reaches partway into the 2nd
+			size_t visited = 0;
+			for (auto it = b.begin<dyn8::bitset_mode::SegmentMode>(); it != b.end(); ++it) ++visited;
+			CHECK_EQ(visited, b.capacity_in_bits() / 8); // capacity_in_bits() / segment width == physical segment count
+			CHECK_EQ(visited, 2);
+		}
+
+		SUBCASE("count()/all_set()/any_set()/none_set() only consider bits within logical size") {
+			dyn8 b(1); // 1 full segment, 8 logical bits
+			for (size_t i = 0; i < 8; ++i) b.set(i);
+			b.set(10); // grows into segment 1; bits 8,9 stay 0, bit 10 is set - segment 1 isn't fully set
+
+			CHECK_EQ(b.count(), 9); // 8 (segment 0) + 1 (bit 10) - not segment 1's unused zero bits
+			CHECK_FALSE(b.all_set()); // segment 1 isn't fully set, so overall not all-set
+			CHECK(b.any_set());
+			CHECK_FALSE(b.none_set());
+		}
+	}
+
+	TEST_CASE("bitwise operators combine bitsets with equal logical size regardless of construction path") {
+		// a grown via set(), b via the size constructor - different histories, same logical size.
+		dyn8 a{};
+		a.set(15);
+		REQUIRE_EQ(a.size_in_bits(), 16);
+
+		dyn8 b(2);
+		b.set(0);
+		REQUIRE_EQ(b.size_in_bits(), 16);
+
+		auto const conjunction = a & b;
+		CHECK_EQ(conjunction.count(), 0); // a has only bit 15 set, b has only bit 0 set - no overlap
+		CHECK_EQ(conjunction.size_in_bits(), 16);
+
+		auto const disjunction = a | b;
+		CHECK_EQ(disjunction.count(), 2);
+		CHECK_EQ(disjunction.size_in_bits(), 16);
+		CHECK(disjunction.test(0));
+		CHECK(disjunction.test(15));
 	}
 }

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -11,16 +11,6 @@
 #include <type_traits>
 #include <utility>
 
-namespace {
-	// non-integral, multi-word segment type (two 64-bit words per segment) used to exercise the
-	// code paths that only trigger for T where alignof(T) < sizeof(T), e.g. segment_slots /
-	// slot_handler / get_chunk_raw, alongside the plain-integral segment tests below.
-	struct wide_word {
-		std::uint64_t lo{};
-		std::uint64_t hi{};
-	};
-} // namespace
-
 TEST_SUITE("bitset") {
 	using namespace dice::template_library;
 
@@ -755,105 +745,6 @@ TEST_SUITE("bitset") {
 		}
 	}
 
-	TEST_CASE("multi-word (non-integral) segment type") {
-		using wide_bitset = bitset<dynamic_extent, dynamic_extent, wide_word>;
-
-		SUBCASE("single-bit addressing within a multi-word segment") {
-			// bit 10 belongs to the low 64-bit word of the segment and must read back as set.
-			// (chosen small enough that a wrong chunk computation still lands in-bounds instead
-			// of reading/writing past the segment.)
-			wide_word w{};
-			w.lo = 1ull << 10;
-
-			wide_bitset b{w};
-			CHECK(b.test(10));
-		}
-
-		SUBCASE("count / countr_zero span both 64-bit words") {
-			wide_word w{};
-			w.lo = 0b1011;                // 3 bits set in the low word
-			w.hi = 0x8000000000000000ull; // top bit of the high word set
-
-			wide_bitset b{w};
-			CHECK_EQ(b.count(), 4);
-			CHECK_EQ(b.countr_zero(), 0); // bit 0 of the low word is already set
-		}
-
-		SUBCASE("segment_free based queries (any_set / none_set)") {
-			wide_bitset empty_b{wide_word{}};
-			CHECK(empty_b.none_set());
-			CHECK_FALSE(empty_b.any_set());
-
-			wide_word w{};
-			w.hi = 1; // only bit 64 set
-			wide_bitset b{w};
-			CHECK(b.any_set());
-			CHECK_FALSE(b.none_set());
-		}
-
-		SUBCASE("bit counting spans multiple multi-word segments") {
-			// segment 0 (lowest) is fully set, segment 1 (highest) is fully zero - mirrors the
-			// "bit counting across multiple segments" integral tests, but for a segment type
-			// wide enough to need segment_slots/slot_handler internally.
-			wide_word full{};
-			full.lo = ~0ull;
-			full.hi = ~0ull;
-			wide_word zero{};
-
-			wide_bitset b{full, zero};
-			CHECK_FALSE(b.all_set());
-			CHECK_EQ(b.countr_one(), 128);
-			CHECK_EQ(b.countl_zero(), 128);
-			CHECK_EQ(b.countl_one(), 0);
-
-			wide_bitset all_full{full, full};
-			CHECK(all_full.all_set());
-		}
-
-		SUBCASE("operator&= / operator|= / operator== on multi-word segments") {
-			wide_word a_word{};
-			a_word.lo = 0b1100;
-			wide_word b_word{};
-			b_word.lo = 0b1010;
-
-			wide_bitset a{a_word};
-			wide_bitset b{b_word};
-
-			auto const conjunction = a & b;
-			CHECK_EQ(conjunction.count(), 1);
-			auto const disjunction = a | b;
-			CHECK_EQ(disjunction.count(), 3);
-
-			CHECK(a == a);
-			CHECK_FALSE(a == b);
-
-			a &= b;
-			CHECK(a == conjunction);
-		}
-
-		SUBCASE("segment_slots exposes every word making up one segment") {
-			wide_word w{};
-			w.lo = 5;
-			w.hi = 9;
-
-			wide_bitset b{w};
-			auto it = b.begin();
-			auto [word, end] = b.segment_slots(it.get());
-			CHECK_EQ(std::distance(word, end), 2); // wide_word packs two 64-bit words per segment
-			CHECK_EQ(*word, 5);
-			CHECK_EQ(*(word + 1), 9);
-		}
-
-		SUBCASE("formatting does not throw for a multi-word segment type") {
-			wide_word w{};
-			w.lo = 0x1234;
-			w.hi = 0x5678;
-			wide_bitset b{w};
-			std::string s;
-			CHECK_NOTHROW(s = std::format("{:x}", b));
-			CHECK_NOTHROW(s = std::format("{:?x}", b));
-		}
-	}
 
 	TEST_CASE("integral segment width coverage") {
 		// verifies storage_word selection (and the derived set/test/count/countr_zero paths)
@@ -880,12 +771,6 @@ TEST_SUITE("bitset") {
 		SUBCASE("uint32_t segments") {
 			check_widths.operator()<std::uint32_t>();
 		}
-
-#ifdef __SIZEOF_INT128__
-		SUBCASE("__uint128_t segments") {
-			check_widths.operator()<__uint128_t>();
-		}
-#endif
 	}
 
 	TEST_CASE("set with an explicit high/low state") {
@@ -920,27 +805,6 @@ TEST_SUITE("bitset") {
 			CHECK_EQ(b.count(), 0);
 		}
 
-		SUBCASE("set_all on a multi-word segment type sets every bit in every word") {
-			using fixed_wide = bitset<2, 2 * 128, wide_word>; // extent stays in segments; 2nd param is now a bit count
-			constexpr size_t fixed_wide_capacity_bits = 2 * 128;
-
-			fixed_wide b{wide_word{}, wide_word{}};
-			b.set_all();
-			CHECK(b.all_set());
-			CHECK_EQ(b.count(), fixed_wide_capacity_bits);
-		}
-
-		SUBCASE("reset_all on a multi-word segment type clears every bit in every word") {
-			using fixed_wide = bitset<2, 2 * 128, wide_word>; // extent stays in segments; 2nd param is now a bit count
-			wide_word full{};
-			full.lo = ~0ull;
-			full.hi = ~0ull;
-
-			fixed_wide b{full, full};
-			b.reset_all();
-			CHECK(b.none_set());
-			CHECK_EQ(b.count(), 0);
-		}
 	}
 
 	TEST_CASE("shrink_to_fit") {
@@ -978,23 +842,6 @@ TEST_SUITE("bitset") {
 			REQUIRE_EQ(b.size_in_bits(), bounded64_segment_bits);
 			CHECK_EQ(b.count(), 64);
 		}
-
-		SUBCASE("multi-word (non-integral) segment type") {
-			using wide_bitset = bitset<dynamic_extent, dynamic_extent, wide_word>;
-
-			wide_word full{};
-			full.lo = ~0ull;
-			full.hi = ~0ull;
-
-			wide_word partial{};
-			partial.lo = ~0ull;
-			partial.hi = 0x0Full; // not fully set -> gets dropped by shrink_to_fit
-
-			wide_bitset b{full, partial};
-			b.shrink_to_fit();
-			REQUIRE_EQ(b.size_in_bits(), 128);
-			CHECK(b.all_set());
-		}
 	}
 
 	TEST_CASE("positions / set_positions / reset_positions") {
@@ -1015,26 +862,6 @@ TEST_SUITE("bitset") {
 		SUBCASE("positions() correctly skips across multiple fully-zero segments") {
 			dyn64 b{0b1, 0, 0, 0b1}; // segment 0 and segment 3 each have bit 0 set, 1-2 are empty
 			std::array<size_t, 2> const expected{0, 3 * 64};
-
-			size_t i = 0;
-			for (auto pos : b.positions()) {
-				REQUIRE_LT(i, expected.size());
-				CHECK_EQ(pos.ix(), expected[i]);
-				++i;
-			}
-			CHECK_EQ(i, expected.size());
-		}
-
-		SUBCASE("positions() spans both words of a multi-word segment type") {
-			using wide_bitset = bitset<dynamic_extent, dynamic_extent, wide_word>;
-
-			wide_word w0{};
-			w0.lo = 0b101; // bits 0 and 2 of the low word
-			wide_word w1{};
-			w1.hi = 1; // bit 0 of the high word -> segment-local offset 64
-
-			wide_bitset b{w0, w1};
-			std::array<size_t, 3> const expected{0, 2, 128 + 64}; // 128 bits per wide_word segment
 
 			size_t i = 0;
 			for (auto pos : b.positions()) {
@@ -1145,25 +972,6 @@ TEST_SUITE("bitset") {
 			CHECK_FALSE(b.test(0));
 		}
 
-		SUBCASE("multi-word (non-integral) segment type walked directly") {
-			using wide_bitset = bitset<dynamic_extent, dynamic_extent, wide_word>;
-			wide_word w0{};
-			w0.lo = 0b101; // bits 0 and 2 of the low word
-			wide_word w1{};
-			w1.hi = 1; // bit 0 of the high word -> segment-local offset 64
-
-			wide_bitset b{w0, w1};
-			std::array<size_t, 3> const expected{0, 2, 128 + 64}; // 128 bits per wide_word segment
-
-			size_t i = 0;
-			for (auto it = b.pbegin(); it != b.pend(); ++it) {
-				REQUIRE_LT(i, expected.size());
-				CHECK_EQ((*it).ix(), expected[i]);
-				++i;
-			}
-			CHECK_EQ(i, expected.size());
-		}
-
 		SUBCASE("pbegin() skips forward when bit 0 of segment 0 is not actually set") {
 			dyn64 b{0b100}; // bit 2 set, bit 0 NOT set
 			auto it = b.pbegin();
@@ -1220,35 +1028,6 @@ TEST_SUITE("bitset") {
 			}
 			CHECK_EQ(i, expected.size());
 		}
-
-		SUBCASE("multi-word segment: beginning/middle/end of each word, crossing both a word and a segment boundary") {
-			using wide_bitset = bitset<dynamic_extent, dynamic_extent, wide_word>;
-
-			wide_word w0{};
-			w0.lo = (1ull << 0) | (1ull << 32) | (1ull << 63); // low word: beginning, middle, end
-			w0.hi = (1ull << 0) | (1ull << 32) | (1ull << 63); // high word: beginning, middle, end
-
-			wide_word const empty1{};
-			wide_word const empty2{}; // two consecutive empty segments -> large jump for the multi-word case too
-
-			wide_word w3{};
-			w3.hi = (1ull << 63); // only the very last bit of the segment
-
-			wide_bitset b{w0, empty1, empty2, w3};
-			std::array<size_t, 7> const expected{
-				0, 32, 63,     // segment 0, low word: beginning, middle, end
-				64, 96, 127,   // segment 0, high word: beginning, middle, end (64 crosses the word boundary)
-				3 * 128 + 127, // segment 3, after skipping segments 1 and 2 entirely
-			};
-
-			size_t i = 0;
-			for (auto pos : b.positions()) {
-				REQUIRE_LT(i, expected.size());
-				CHECK_EQ(pos.ix(), expected[i]);
-				++i;
-			}
-			CHECK_EQ(i, expected.size());
-		}
 	}
 
 	TEST_CASE("bit count that isn't a multiple of the segment width rounds up to a whole segment") {
@@ -1285,18 +1064,6 @@ TEST_SUITE("bitset") {
 			constexpr size_t expected_capacity_bits = 3 * 8;
 
 			bounded_odd8 b{};
-			CHECK_NOTHROW(b.set(expected_capacity_bits - 1));
-			REQUIRE_EQ(b.size_in_bits(), expected_capacity_bits);
-			CHECK_THROWS_AS(b.set(expected_capacity_bits), std::out_of_range);
-		}
-
-		SUBCASE("bounded capacity: multi-word (non-integral) segments") {
-			// wide_word segments are 128 bits wide; 130 bits doesn't divide evenly -> ceil(130/128) = 2
-			// segments = 256 bits capacity
-			using bounded_odd_wide = bitset<dynamic_extent, 130, wide_word>;
-			constexpr size_t expected_capacity_bits = 2 * 128;
-
-			bounded_odd_wide b{};
 			CHECK_NOTHROW(b.set(expected_capacity_bits - 1));
 			REQUIRE_EQ(b.size_in_bits(), expected_capacity_bits);
 			CHECK_THROWS_AS(b.set(expected_capacity_bits), std::out_of_range);

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -1022,10 +1022,10 @@ TEST_SUITE("bitset") {
 	}
 
 	TEST_CASE("formatting") {
-		// the formatter's output isn't specified/stable enough to assert on - just make sure the
-		// supported format specs run without throwing, and print the result for a human to eyeball.
-		// debug mode ('?') and an explicit 'x' spec were removed: hex is now the default (no spec
-		// at all), and 'b' is the only settable spec.
+		// exact content is locked down in "formatter output content (hex and binary, big
+		// endian)" below - this is just a smoke test that also prints the result for a human to
+		// eyeball. debug mode ('?') and an explicit 'x' spec were removed: hex is now the
+		// default (no spec at all), and 'b' is the only settable spec.
 		dyn8 b{0b10110011, 0x00};
 		MESSAGE("hex (default): ", std::format("{}", b));
 		MESSAGE("binary: ", std::format("{:b}", b));
@@ -1035,6 +1035,68 @@ TEST_SUITE("bitset") {
 	    dyn64 b_long(32); // parens - see the "size constructor zero-fills every segment" note above
 	    MESSAGE("hex (default): ", std::format("{}", b_long));
 	    MESSAGE("binary: ", std::format("{:b}", b_long));
+	}
+
+	TEST_CASE("formatter output content (hex and binary, big endian)") {
+		// bit_iterator itself walks LEAST-significant bit first: offset 0 is bit 0 of a segment
+		// (segment_set uses "1 << offset", so offset 0 is the LSB), and ++it moves toward higher
+		// offsets, i.e. toward the MSB. Printing must NOT follow that raw traversal order - a
+		// human reads/writes binary and hex MSB-first - so the formatter reverses direction for
+		// display. This is the specific behavior under test here, primarily in binary mode, where
+		// the formatter explicitly does `subrange(it, seg_end) | std::views::reverse` before
+		// emitting characters (bitset.hpp's format()). Segments themselves are still emitted in
+		// storage order (segment 0 first) - only the bit order *within* a segment is reversed.
+
+		SUBCASE("binary mode: bit at offset 0 (first bit the iterator visits) prints LAST") {
+			// the iterator's first bit (lowest offset, LSB) must end up as the rightmost/last
+			// character - the opposite of iteration order.
+			dyn8 b{0b00000001};
+			CHECK_EQ(std::format("{:b}", b), "[\n[00000001]\n]\n");
+		}
+
+		SUBCASE("binary mode: bit at offset 7 (last bit the iterator visits) prints FIRST") {
+			// the iterator's last bit (highest offset, MSB) must end up as the leftmost/first
+			// character.
+			dyn8 b{0b10000000};
+			CHECK_EQ(std::format("{:b}", b), "[\n[10000000]\n]\n");
+		}
+
+		SUBCASE("binary mode reproduces a mixed bit pattern exactly as written (MSB-first)") {
+			// 0b10110011 is itself written MSB-first in the source; if the formatter forgot to
+			// reverse the LSB-first iteration order, this would come out as "11001101" instead
+			// (the bit-reversal of the actual pattern).
+			dyn8 b{0b10110011};
+			CHECK_EQ(std::format("{:b}", b), "[\n[10110011]\n]\n");
+		}
+
+		SUBCASE("binary mode reverses within each segment independently, segments stay in storage order") {
+			dyn8 b{0x00, 0xFF};
+			CHECK_EQ(std::format("{:b}", b), "[\n[00000000]\n[11111111]\n]\n");
+		}
+
+		SUBCASE("hex mode renders one segment per line, in storage order") {
+			// hex mode reads the raw segment value via it.get() and lets std::format's own hex
+			// notation render it - it does not iterate bit-by-bit, so there is no LSB/MSB
+			// traversal to reverse here. The MSB-first digit order (0xa5, not 0x5a) simply comes
+			// from std::format's normal hex formatting of an integer, not from bitset's own logic.
+			dyn8 b{0x12, 0x34};
+			CHECK_EQ(std::format("{}", b), "[\n[0x12]\n[0x34]\n]\n");
+		}
+
+		SUBCASE("hex mode drops a fully-zero segment's leading zero (no fixed-width zero padding)") {
+			// documents the actual current width behavior rather than assuming it: the format
+			// spec's width only reserves 2*sizeof(T) characters, which already covers "0x" plus
+			// every significant digit for a non-zero byte, but is one digit short of the full
+			// 2-digit zero-padded form for a segment that is exactly 0.
+			dyn8 b{0x00, 0xFF};
+			CHECK_EQ(std::format("{}", b), "[\n[0x0]\n[0xff]\n]\n");
+		}
+
+		SUBCASE("empty bitset formats identically regardless of mode - no segment lines") {
+			dyn8 b{};
+			CHECK_EQ(std::format("{}", b), "[\n]\n");
+			CHECK_EQ(std::format("{:b}", b), "[\n]\n");
+		}
 	}
 
 	TEST_CASE("formatting edge cases") {

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -17,6 +17,17 @@
 template<typename I>
 concept has_subscript_operator = requires(I i, std::iter_difference_t<I> n) { i[n]; };
 
+// size_in_bits() is now a static, has_max_extent-only member (the "separation between logical
+// size and capacity" change) - a genuine template parameter is needed here too so a fully dynamic
+// bitset fails via substitution rather than a hard compile error.
+template<typename B>
+concept has_static_size_in_bits = requires { B::size_in_bits(); };
+
+// position_iterator's dereference is a plain value_type (size_t) now, not a writable proxy -
+// verifies there is nothing to assign through it.
+template<typename I>
+concept dereference_is_assignable = requires(I i, bool b) { *i = b; };
+
 TEST_SUITE("bitset") {
 	using namespace dice::template_library;
 
@@ -33,7 +44,7 @@ TEST_SUITE("bitset") {
 	TEST_CASE("construction") {
 		SUBCASE("initializer list") {
 			dyn8 b{0b00000001, 0b10000000};
-			REQUIRE_EQ(b.size_in_bits(), 16);
+			REQUIRE_EQ(b.capacity_in_bits(), 16);
 
 			CHECK(b.test(0));
 			for (size_t i = 1; i < 7; ++i) {
@@ -53,8 +64,8 @@ TEST_SUITE("bitset") {
 			// segment holding the value 3 instead of calling the explicit size_t constructor,
 			// since a viable initializer_list constructor always wins list-initialization.
 			dyn64 b(3);
-			REQUIRE_EQ(b.size_in_bits(), 3 * 64);
-			for (size_t i = 0; i < b.size_in_bits(); ++i) {
+			REQUIRE_EQ(b.capacity_in_bits(), 3 * 64);
+			for (size_t i = 0; i < b.capacity_in_bits(); ++i) {
 				CHECK_FALSE(b.test(i));
 			}
 		}
@@ -73,7 +84,7 @@ TEST_SUITE("bitset") {
 			dyn8 d{0xFF};
 			d = a;
 			CHECK_FALSE(d.test(3));
-			CHECK_EQ(d.size_in_bits(), 2 * 8);
+			CHECK_EQ(d.capacity_in_bits(), 2 * 8);
 		}
 	}
 
@@ -81,13 +92,13 @@ TEST_SUITE("bitset") {
 		SUBCASE("set/reset/flip/test grows storage automatically") {
 			dyn64 b{};
 			b.set(5);
-			REQUIRE_EQ(b.size_in_bits(), 64);
+			REQUIRE_EQ(b.capacity_in_bits(), 64);
 			CHECK(b.test(5));
 			CHECK_FALSE(b.test(0));
 			CHECK_FALSE(b.test(63));
 
 			b.set(130); // segment 2, offset 2 -> needs 3 segments total
-			REQUIRE_EQ(b.size_in_bits(), 3 * 64);
+			REQUIRE_EQ(b.capacity_in_bits(), 3 * 64);
 			CHECK(b.test(130));
 
 			b.flip(130);
@@ -107,7 +118,7 @@ TEST_SUITE("bitset") {
 			// the fact that bit index 64 needs capacity > 64 bits, not merely >= 64 bits.
 			dyn64 b{};
 			b.set(64);
-			REQUIRE_EQ(b.size_in_bits(), 2 * 64);
+			REQUIRE_EQ(b.capacity_in_bits(), 2 * 64);
 			CHECK(b.test(64));
 			CHECK_FALSE(b.test(0));
 			CHECK_FALSE(b.test(63));
@@ -117,7 +128,7 @@ TEST_SUITE("bitset") {
 			bounded64 b{};
 			REQUIRE_THROWS_AS(b.set(bounded64_capacity_bits), std::out_of_range);
 			REQUIRE_THROWS_AS((void)b.test(bounded64_capacity_bits), std::out_of_range);
-			CHECK_EQ(b.size_in_bits(), 0); // rejected out-of-range set() must not have grown anything
+			CHECK_EQ(b.capacity_in_bits(), 0); // rejected out-of-range set() must not have grown anything
 			CHECK_NOTHROW(b.set(bounded64_capacity_bits - 1));
 		}
 
@@ -126,10 +137,10 @@ TEST_SUITE("bitset") {
 			// more than one extra segment), not just the "next segment" case exercised above.
 			dyn64 b{};
 			b.set(1000); // segment 15 (1000 / 64), so 16 segments are required in total
-			REQUIRE_EQ(b.size_in_bits(), 16 * 64);
+			REQUIRE_EQ(b.capacity_in_bits(), 16 * 64);
 			CHECK(b.test(1000));
 
-			for (size_t i = 0; i < b.size_in_bits(); ++i) {
+			for (size_t i = 0; i < b.capacity_in_bits(); ++i) {
 				if (i == 1000) continue;
 				CAPTURE(i);
 				CHECK_FALSE(b.test(i));
@@ -139,10 +150,10 @@ TEST_SUITE("bitset") {
 		SUBCASE("setting a lower index after a large-index growth does not grow further") {
 			dyn64 b{};
 			b.set(1000);
-			REQUIRE_EQ(b.size_in_bits(), 16 * 64);
+			REQUIRE_EQ(b.capacity_in_bits(), 16 * 64);
 
 			b.set(0);
-			CHECK_EQ(b.size_in_bits(), 16 * 64); // already had enough room, must not have resized again
+			CHECK_EQ(b.capacity_in_bits(), 16 * 64); // already had enough room, must not have resized again
 			CHECK(b.test(0));
 			CHECK(b.test(1000));
 		}
@@ -152,22 +163,25 @@ TEST_SUITE("bitset") {
 			// growing size(), so test() would report the bit as set while count()/iteration/
 			// all_set()/etc (which all iterate up to size()) stayed blind to it entirely.
 			bounded64 b{};
-			REQUIRE_EQ(b.size_in_bits(), 0);
+			REQUIRE_EQ(b.capacity_in_bits(), 0);
 
 			b.set(5);
-			CHECK_EQ(b.size_in_bits(), 64);
+			CHECK_EQ(b.capacity_in_bits(), 64);
 			CHECK(b.test(5));
 			CHECK_EQ(b.count(), 1);
 
 			size_t visited = 0;
 			for (auto it = b.begin(); it != b.end(); ++it) ++visited;
-			CHECK_EQ(visited, b.size_in_bits());
+			CHECK_EQ(visited, b.capacity_in_bits());
 		}
 
 		SUBCASE("bounded capacity growth stops exactly at its static maximum and stays zero-filled") {
 			bounded64 b{};
 			b.set(bounded64_capacity_bits - 1); // last valid bit, far beyond current size()
-			REQUIRE_EQ(b.size_in_bits(), 4 * 64);
+			REQUIRE_EQ(b.capacity_in_bits(), 4 * 64);
+			// size_in_bits() is now the static, growth-independent logical bound (max_bits) -
+			// it must equal capacity_in_bits() here since growth reached the maximum.
+			CHECK_EQ(bounded64::size_in_bits(), bounded64_capacity_bits);
 			CHECK(b.test(bounded64_capacity_bits - 1));
 			CHECK_EQ(b.count(), 1); // every other (newly exposed) bit must be zero, not garbage
 		}
@@ -323,7 +337,7 @@ TEST_SUITE("bitset") {
 			dyn8 b{0xFF};
 			auto const ix = b.set_first_free();
 			CHECK_EQ(ix, 8); // new segment appended, first bit of it
-			REQUIRE_EQ(b.size_in_bits(), 2 * 8);
+			REQUIRE_EQ(b.capacity_in_bits(), 2 * 8);
 			CHECK(b.test(8));
 		}
 
@@ -386,7 +400,7 @@ TEST_SUITE("bitset") {
 				++visited;
 				++it;
 			}
-			CHECK_EQ(visited, b.size_in_bits());
+			CHECK_EQ(visited, b.capacity_in_bits());
 		}
 
 		SUBCASE("operator* reads the bit at the iterator's current position") {
@@ -544,7 +558,7 @@ TEST_SUITE("bitset") {
 				CHECK_EQ(static_cast<bool>(*it), expected);
 				++visited;
 			}
-			CHECK_EQ(visited, b.size_in_bits());
+			CHECK_EQ(visited, b.capacity_in_bits());
 			CHECK_EQ(global_ix, -1);
 		}
 
@@ -554,7 +568,7 @@ TEST_SUITE("bitset") {
 			for (auto it = b.rbegin(); it != b.rend(); ++it) {
 				++visited;
 			}
-			CHECK_EQ(visited, b.size_in_bits());
+			CHECK_EQ(visited, b.capacity_in_bits());
 		}
 	}
 
@@ -562,11 +576,16 @@ TEST_SUITE("bitset") {
 		// segment_iterator's reference has operator std::conditional_t<is_const, T const&, T&>()
 		// (SegmentMode-only) - this exercises both sides: binding the dereference to a T&
 		// (an actual alias into storage) vs binding it to a plain T (an independent copy).
+		// bitset itself keeps its segment/storage type private - these tests spell it out as
+		// plain uint8_t (the T dyn8 was defined with below), never referring to any bitset-side
+		// alias for it.
 
-		SUBCASE("value_type for a segment_iterator reports T, not bool") {
-			// bit_iterator's value_type is bool (one bit); segment_iterator's is the segment
-			// type itself - the two modes really do carry different logical types.
-			static_assert(std::is_same_v<dyn8::segment_iterator::value_type, dyn8::value_type>);
+		SUBCASE("value_type for a segment_iterator reports the underlying storage type, not bool") {
+			// bit_iterator's value_type is bool (one bit), matching bitset::value_type itself;
+			// segment_iterator's value_type is the underlying storage word type (uint8_t for
+			// dyn8) - the two modes really do carry different logical types.
+			static_assert(std::is_same_v<dyn8::segment_iterator::value_type, uint8_t>);
+			static_assert(std::is_same_v<dyn8::bit_iterator::value_type, dyn8::value_type>);
 			static_assert(std::is_same_v<dyn8::bit_iterator::value_type, bool>);
 			CHECK(true);
 		}
@@ -575,7 +594,7 @@ TEST_SUITE("bitset") {
 			dyn8 b{0xAA, 0x00}; // 2nd segment left at 0 so b.count() cleanly reflects only segment 0
 			auto it = b.begin<dyn8::bitset_mode::SegmentMode>();
 
-			dyn8::value_type &seg_ref = *it; // binds the proxy's conversion to an actual T&
+			uint8_t &seg_ref = *it; // binds the proxy's conversion to an actual T&
 			CHECK_EQ(seg_ref, 0xAA);
 
 			seg_ref = 0xFF; // mutate through the reference, not through the iterator/bitset API
@@ -587,7 +606,7 @@ TEST_SUITE("bitset") {
 			dyn8 b{0xAA, 0xBB};
 			auto it = b.begin<dyn8::bitset_mode::SegmentMode>();
 
-			dyn8::value_type seg_val = *it; // binds to a plain T, not a reference: a copy
+			uint8_t seg_val = *it; // binds to a plain T, not a reference: a copy
 			CHECK_EQ(seg_val, 0xAA);
 
 			seg_val = 0xFF; // only the local copy changes
@@ -602,8 +621,8 @@ TEST_SUITE("bitset") {
 			auto writer = b.begin<dyn8::bitset_mode::SegmentMode>();
 			auto reader = b.begin<dyn8::bitset_mode::SegmentMode>();
 
-			dyn8::value_type &write_ref = *writer;
-			dyn8::value_type &read_ref = *reader;
+			uint8_t &write_ref = *writer;
+			uint8_t &read_ref = *reader;
 
 			CHECK_EQ(read_ref, 0x00);
 			write_ref = 0x42;
@@ -617,28 +636,28 @@ TEST_SUITE("bitset") {
 			auto non_const_it = b.begin<dyn8::bitset_mode::SegmentMode>();
 			auto const_it = cb.begin<dyn8::bitset_mode::SegmentMode>();
 
-			dyn8::value_type const &const_ref = *const_it;
+			uint8_t const &const_ref = *const_it;
 			CHECK_EQ(const_ref, 0xAA);
 
 			// mutate through the *non-const* iterator over the same underlying bitset...
-			dyn8::value_type &mutable_ref = *non_const_it;
+			uint8_t &mutable_ref = *non_const_it;
 			mutable_ref = 0x77;
 
 			// ...and the const reference, still bound to the same storage, observes it.
 			CHECK_EQ(const_ref, 0x77);
 
-			static_assert(std::is_same_v<decltype(const_ref), dyn8::value_type const&>);
+			static_assert(std::is_same_v<decltype(const_ref), uint8_t const&>);
 		}
 
 		SUBCASE("advancing a segment_iterator and rebinding to T& tracks the new segment, not the old one") {
 			dyn8 b{0xAA, 0xBB, 0xCC};
 			auto it = b.begin<dyn8::bitset_mode::SegmentMode>();
 
-			dyn8::value_type &first = *it;
+			uint8_t &first = *it;
 			CHECK_EQ(first, 0xAA);
 
 			++it;
-			dyn8::value_type &second = *it; // a fresh reference for the new position
+			uint8_t &second = *it; // a fresh reference for the new position
 			CHECK_EQ(second, 0xBB);
 			CHECK_EQ(first, 0xAA); // the earlier reference is untouched - it aliases segment 0, not segment 1
 
@@ -650,10 +669,10 @@ TEST_SUITE("bitset") {
 		SUBCASE("rbegin/rend segment-mode traversal dereferences to T& and supports write-through") {
 			dyn8 b{0x11, 0x22, 0x33};
 
-			std::array<dyn8::value_type, 3> visited{};
+			std::array<uint8_t, 3> visited{};
 			size_t i = 0;
 			for (auto it = b.rbegin<dyn8::bitset_mode::SegmentMode>(); it != b.rend<dyn8::bitset_mode::SegmentMode>(); ++it) {
-				dyn8::value_type &seg_ref = *it;
+				uint8_t &seg_ref = *it;
 				REQUIRE_LT(i, visited.size());
 				visited[i++] = seg_ref;
 			}
@@ -664,7 +683,7 @@ TEST_SUITE("bitset") {
 
 			// write through the reverse-order reference and confirm it lands on the right segment
 			for (auto it = b.rbegin<dyn8::bitset_mode::SegmentMode>(); it != b.rend<dyn8::bitset_mode::SegmentMode>(); ++it) {
-				dyn8::value_type &seg_ref = *it;
+				uint8_t &seg_ref = *it;
 				if (seg_ref == 0x22) {
 					seg_ref = 0x99;
 				}
@@ -718,7 +737,7 @@ TEST_SUITE("bitset") {
 		SUBCASE("operator[] matches *(it + n) for every position") {
 			dyn8 b{0b10110010, 0b01001101};
 			auto const it = b.begin();
-			for (size_t n = 0; n < b.size_in_bits(); ++n) {
+			for (size_t n = 0; n < b.capacity_in_bits(); ++n) {
 				CAPTURE(n);
 				CHECK_EQ(static_cast<bool>(it[n]), static_cast<bool>(*(it + n)));
 			}
@@ -875,31 +894,31 @@ TEST_SUITE("bitset") {
 			CHECK_EQ(b.count(), 5);
 		}
 
-		SUBCASE("shift by exactly size_in_bits() clears everything") {
+		SUBCASE("shift by exactly capacity_in_bits() clears everything") {
 			dyn8 b{0xFF, 0xFF};
-			b <<= b.size_in_bits();
+			b <<= b.capacity_in_bits();
 			CHECK_EQ(b.count(), 0);
 
 			dyn8 b2{0xFF, 0xFF};
-			b2 >>= b2.size_in_bits();
+			b2 >>= b2.capacity_in_bits();
 			CHECK_EQ(b2.count(), 0);
 		}
 
-		SUBCASE("shift by more than size_in_bits() clears everything (regression: used to hang)") {
+		SUBCASE("shift by more than capacity_in_bits() clears everything (regression: used to hang)") {
 			// previously, shifting by more bits than the bitset holds caused the internal
 			// iterator arithmetic to compare against the static storage capacity instead of
 			// the bitset's actual size, so the move/fill loop in operator<<=/>>= never
 			// terminated for bitsets whose size() can be less than their max capacity.
 			dyn8 b{0xFF, 0xFF};
-			b <<= b.size_in_bits() + 5;
+			b <<= b.capacity_in_bits() + 5;
 			CHECK_EQ(b.count(), 0);
 
 			dyn8 b2{0xFF, 0xFF};
-			b2 >>= b2.size_in_bits() + 5;
+			b2 >>= b2.capacity_in_bits() + 5;
 			CHECK_EQ(b2.count(), 0);
 
 			bounded64 b3{~0ull, ~0ull}; // size() == 2 segments, capacity 4 segments
-			b3 <<= b3.size_in_bits() + 30; // within capacity, beyond current size
+			b3 <<= b3.capacity_in_bits() + 30; // within capacity, beyond current size
 			CHECK_EQ(b3.count(), 0);
 
 			bounded64 b4{~0ull, ~0ull};
@@ -926,27 +945,27 @@ TEST_SUITE("bitset") {
 
 	TEST_CASE("all_set / any_set / none_set on an empty bitset") {
 		dyn8 b{};
-		REQUIRE_EQ(b.size_in_bits(), 0);
+		REQUIRE_EQ(b.capacity_in_bits(), 0);
 		CHECK(b.all_set());   // vacuously true: no bit fails to be set
 		CHECK_FALSE(b.any_set());
 		CHECK(b.none_set());  // vacuously true: no bit is set
 	}
 
-	TEST_CASE("bitwise combination with mismatched sizes leaves the receiver untouched") {
-		// segment_handler(bitset const&) bails out (returns false) as soon as it sees a size
-		// mismatch, before touching any segment - documenting that &=/|= are silent no-ops here
-		// rather than throwing, unlike e.g. set()/test() which throw on out-of-range access.
+	TEST_CASE("bitwise combination with mismatched sizes throws, leaving the receiver untouched") {
+		// operator&=/|=/^= check size_match() first and throw std::logic_error immediately on
+		// any mismatch, before touching any segment - unlike e.g. set()/test() which throw
+		// std::out_of_range instead, and unlike operator== which just reports false.
 		SUBCASE("operator&= with a differently-sized operand") {
 			dyn8 a{0xFF, 0xFF};
 			dyn8 b{0xFF};
-			a &= b;
-			CHECK_EQ(a.count(), 16);
+			CHECK_THROWS_AS(a &= b, std::logic_error);
+			CHECK_EQ(a.count(), 16); // untouched: the throw happens before any segment is combined
 		}
 
 		SUBCASE("operator|= with a differently-sized operand") {
 			dyn8 a{0x00, 0x00};
 			dyn8 b{0xFF};
-			a |= b;
+			CHECK_THROWS_AS(a |= b, std::logic_error);
 			CHECK_EQ(a.count(), 0);
 		}
 	}
@@ -997,40 +1016,32 @@ TEST_SUITE("bitset") {
 			bounded64 b{~0ull, ~0ull}; // 2 of 4 segments used, both full
 			auto const ix = b.set_first_free();
 			CHECK_EQ(ix, bounded64_segment_bits * 2); // first bit of the freshly grown 3rd segment
-			REQUIRE_EQ(b.size_in_bits(), 3 * bounded64_segment_bits);
+			REQUIRE_EQ(b.capacity_in_bits(), 3 * bounded64_segment_bits);
 			CHECK(b.test(ix));
 		}
 	}
 
 	TEST_CASE("formatting") {
 		// the formatter's output isn't specified/stable enough to assert on - just make sure the
-		// various format specs run without throwing, and print the result for a human to eyeball.
+		// supported format specs run without throwing, and print the result for a human to eyeball.
+		// debug mode ('?') and an explicit 'x' spec were removed: hex is now the default (no spec
+		// at all), and 'b' is the only settable spec.
 		dyn8 b{0b10110011, 0x00};
-		MESSAGE("hex: ", std::format("{:x}", b));
+		MESSAGE("hex (default): ", std::format("{}", b));
 		MESSAGE("binary: ", std::format("{:b}", b));
-		MESSAGE("debug+hex: ", std::format("{:?x}", b));
-		MESSAGE("debug+binary: ", std::format("{:?b}", b));
 	}
 
     TEST_CASE("formatting long") {
 	    dyn64 b_long(32); // parens - see the "size constructor zero-fills every segment" note above
-	    MESSAGE("hex: ", std::format("{:x}", b_long));
+	    MESSAGE("hex (default): ", std::format("{}", b_long));
 	    MESSAGE("binary: ", std::format("{:b}", b_long));
-	    MESSAGE("debug+hex: ", std::format("{:?x}", b_long));
-	    MESSAGE("debug+binary: ", std::format("{:?b}", b_long));
 	}
 
 	TEST_CASE("formatting edge cases") {
-		SUBCASE("no format spec just steps through without hex/binary rendering") {
+		SUBCASE("no format spec defaults to hex rendering") {
 			dyn8 b{0b10110011};
 			std::string s;
 			CHECK_NOTHROW(s = std::format("{}", b));
-		}
-
-		SUBCASE("debug spec alone (no hex/binary) is accepted") {
-			dyn8 b{0b10110011};
-			std::string s;
-			CHECK_NOTHROW(s = std::format("{:?}", b));
 		}
 
 		SUBCASE("an unrecognized format spec character throws format_error") {
@@ -1039,6 +1050,15 @@ TEST_SUITE("bitset") {
 			dyn8 b{0x00};
 			std::string s;
 			CHECK_THROWS_AS(s = std::vformat("{:z}", std::make_format_args(b)), std::format_error);
+		}
+
+		SUBCASE("debug spec ('?') was removed and is now just as invalid as any other character") {
+			// same reasoning as above: a compile-time literal "{:?}" would fail to compile
+			// (consteval parse() validation), so a runtime format string is used to exercise
+			// the throwing path instead.
+			dyn8 b{0x00};
+			std::string s;
+			CHECK_THROWS_AS(s = std::vformat("{:?}", std::make_format_args(b)), std::format_error);
 		}
 	}
 
@@ -1054,7 +1074,7 @@ TEST_SUITE("bitset") {
 			b.set(3);
 			b.set(segment_bits + 1); // force growth into a 2nd segment
 
-			CHECK_EQ(b.size_in_bits(), 2 * segment_bits);
+			CHECK_EQ(b.capacity_in_bits(), 2 * segment_bits);
 			CHECK_EQ(b.count(), 2);
 			CHECK(b.test(3));
 			CHECK(b.test(segment_bits + 1));
@@ -1108,8 +1128,8 @@ TEST_SUITE("bitset") {
 		SUBCASE("drops a trailing not-fully-set segment") {
 			dyn8 b{0xFF, 0xFF, 0x0F};
 			b.shrink_to_fit();
-			REQUIRE_EQ(b.size_in_bits(), 2 * 8);
-			for (size_t i = 0; i < b.size_in_bits(); ++i) {
+			REQUIRE_EQ(b.capacity_in_bits(), 2 * 8);
+			for (size_t i = 0; i < b.capacity_in_bits(); ++i) {
 				CHECK(b.test(i));
 			}
 		}
@@ -1120,8 +1140,8 @@ TEST_SUITE("bitset") {
 			// to exclude it and everything after it, keeping only segment 0.
 			dyn8 b{0xFF, 0x0F, 0xFF, 0xFF};
 			b.shrink_to_fit();
-			REQUIRE_EQ(b.size_in_bits(), 1 * 8);
-			for (size_t i = 0; i < b.size_in_bits(); ++i) {
+			REQUIRE_EQ(b.capacity_in_bits(), 1 * 8);
+			for (size_t i = 0; i < b.capacity_in_bits(); ++i) {
 				CHECK(b.test(i));
 			}
 		}
@@ -1129,14 +1149,14 @@ TEST_SUITE("bitset") {
 		SUBCASE("no shrink happens when every segment is fully set") {
 			dyn8 b{0xFF, 0xFF, 0xFF};
 			b.shrink_to_fit();
-			CHECK_EQ(b.size_in_bits(), 3 * 8);
+			CHECK_EQ(b.capacity_in_bits(), 3 * 8);
 			CHECK_EQ(b.count(), 24);
 		}
 
 		SUBCASE("bounded (max-extent) capacity uses resize instead of storage reconstruction") {
 			bounded64 b{~0ull, 0x0Full};
 			b.shrink_to_fit();
-			REQUIRE_EQ(b.size_in_bits(), bounded64_segment_bits);
+			REQUIRE_EQ(b.capacity_in_bits(), bounded64_segment_bits);
 			CHECK_EQ(b.count(), 64);
 		}
 	}
@@ -1149,8 +1169,10 @@ TEST_SUITE("bitset") {
 			size_t i = 0;
 			for (auto pos : b.positions()) {
 				REQUIRE_LT(i, expected.size());
-				CHECK_EQ(pos.ix(), expected[i]);
-				CHECK(static_cast<bool>(pos));
+				// pos is a plain value_type (size_t) now - it IS the position, not a proxy with
+				// .ix()/operator bool() (position_iterator only ever yields set-bit positions,
+				// so there's no separate "is it set" state left to query here).
+				CHECK_EQ(pos, expected[i]);
 				++i;
 			}
 			CHECK_EQ(i, expected.size());
@@ -1163,7 +1185,7 @@ TEST_SUITE("bitset") {
 			size_t i = 0;
 			for (auto pos : b.positions()) {
 				REQUIRE_LT(i, expected.size());
-				CHECK_EQ(pos.ix(), expected[i]);
+				CHECK_EQ(pos, expected[i]);
 				++i;
 			}
 			CHECK_EQ(i, expected.size());
@@ -1257,17 +1279,17 @@ TEST_SUITE("bitset") {
 			size_t i = 0;
 			for (auto it = b.pbegin(); it != b.pend(); ++it) {
 				REQUIRE_LT(i, expected.size());
-				CHECK_EQ((*it).ix(), expected[i]);
-				CHECK(static_cast<bool>(*it));
+				// *it is a plain value_type (size_t) now - it IS the position directly, not a
+				// proxy with .ix()/operator bool().
+				CHECK_EQ(*it, expected[i]);
 				++i;
 			}
 			CHECK_EQ(i, expected.size());
 		}
 
 		SUBCASE("dereferencing converts directly to size_t - no .ix() call needed") {
-			// the same reference proxy bitset_iterator dereferences to also has an implicit
-			// operator size_t() (returning ix()), so a plain assignment - not a call to .ix() -
-			// is enough to pull the logical position back out.
+			// position_iterator::operator*() returns value_type (size_t) by value directly -
+			// a plain assignment, not a call to .ix(), is enough to pull the position back out.
 			dyn64 b{0b10101, 0b1}; // segment 0: bits 0,2,4 set; segment 1: bit 0 set
 			std::array<size_t, 4> const expected{0, 2, 4, 64};
 
@@ -1303,7 +1325,7 @@ TEST_SUITE("bitset") {
 			size_t i = 0;
 			for (auto it = b.pbegin(); it != b.pend(); ++it) {
 				REQUIRE_LT(i, expected.size());
-				CHECK_EQ((*it).ix(), expected[i]);
+				CHECK_EQ(*it, expected[i]);
 				++i;
 			}
 			CHECK_EQ(i, expected.size());
@@ -1314,8 +1336,8 @@ TEST_SUITE("bitset") {
 			auto it = b.pbegin();
 
 			auto const before = it++;
-			CHECK_EQ((*before).ix(), 0);
-			CHECK_EQ((*it).ix(), 2);
+			CHECK_EQ(*before, 0);
+			CHECK_EQ(*it, 2);
 
 			auto &ref = ++it;
 			CHECK_EQ(&ref, &it); // weakly_incrementable requires "{ ++i } -> same_as<I&>"
@@ -1329,26 +1351,28 @@ TEST_SUITE("bitset") {
 			++it1;
 
 			CHECK(it1 != it2);
-			CHECK_EQ((*it2).ix(), 0);
-			CHECK_EQ((*it1).ix(), 2);
+			CHECK_EQ(*it2, 0);
+			CHECK_EQ(*it1, 2);
 
 			it2 = it1;
 			CHECK(it1 == it2);
 		}
 
-		SUBCASE("dereferencing yields the same writable proxy as the bit-mode iterator") {
+		SUBCASE("dereferencing yields a read-only size_t, not a writable proxy") {
+			// unlike bit_iterator's reference proxy, position_iterator::operator*() returns
+			// value_type (size_t) by value - there is nothing left to assign through.
+			static_assert(!dereference_is_assignable<pos_it>);
+			static_assert(!dereference_is_assignable<const_pos_it>);
+
 			dyn64 b{0b1};
 			auto it = b.pbegin();
-			CHECK(static_cast<bool>(*it));
-			*it = false;
-			CHECK_FALSE(b.test(0));
+			CHECK_EQ(*it, 0);
 		}
 
 		SUBCASE("pbegin() skips forward when bit 0 of segment 0 is not actually set") {
 			dyn64 b{0b100}; // bit 2 set, bit 0 NOT set
 			auto it = b.pbegin();
-			CHECK(static_cast<bool>(*it));
-			CHECK_EQ((*it).ix(), 2);
+			CHECK_EQ(*it, 2);
 		}
 
 		SUBCASE("multiple jumps within one segment: bits at its beginning, middle and end") {
@@ -1358,7 +1382,7 @@ TEST_SUITE("bitset") {
 			size_t i = 0;
 			for (auto pos : b.positions()) {
 				REQUIRE_LT(i, expected.size());
-				CHECK_EQ(pos.ix(), expected[i]);
+				CHECK_EQ(pos, expected[i]);
 				++i;
 			}
 			CHECK_EQ(i, expected.size());
@@ -1382,7 +1406,7 @@ TEST_SUITE("bitset") {
 			size_t i = 0;
 			for (auto pos : b.positions()) {
 				REQUIRE_LT(i, expected.size());
-				CHECK_EQ(pos.ix(), expected[i]);
+				CHECK_EQ(pos, expected[i]);
 				++i;
 			}
 			CHECK_EQ(i, expected.size());
@@ -1395,7 +1419,7 @@ TEST_SUITE("bitset") {
 			size_t i = 0;
 			for (auto pos : b.positions()) {
 				REQUIRE_LT(i, expected.size());
-				CHECK_EQ(pos.ix(), expected[i]);
+				CHECK_EQ(pos, expected[i]);
 				++i;
 			}
 			CHECK_EQ(i, expected.size());
@@ -1415,8 +1439,12 @@ TEST_SUITE("bitset") {
 
 			bounded_odd b{};
 			CHECK_NOTHROW(b.set(expected_capacity_bits - 1)); // last bit of the 4th (rounded-up) segment
-			REQUIRE_EQ(b.size_in_bits(), expected_capacity_bits); // grew to a whole segment, not just to 200 bits
+			REQUIRE_EQ(b.capacity_in_bits(), expected_capacity_bits); // grew to a whole segment, not just to 200 bits
 			CHECK_THROWS_AS(b.set(expected_capacity_bits), std::out_of_range); // truly out of capacity
+
+			// size_in_bits() is the static, un-rounded logical bound (max_bits itself, 200) - it
+			// stays fixed regardless of growth, unlike capacity_in_bits() which just grew to 256.
+			CHECK_EQ(bounded_odd::size_in_bits(), 200);
 		}
 
 		SUBCASE("fully static capacity: uint64_t segments") {
@@ -1428,6 +1456,11 @@ TEST_SUITE("bitset") {
 			fixed_odd b{0, 0, 0, 0};
 			CHECK_NOTHROW(b.set(expected_capacity_bits - 1));
 			CHECK_THROWS_AS(b.set(expected_capacity_bits), std::out_of_range);
+
+			// even fully static, size_in_bits() is still the raw max_bits (200), not the
+			// segment-rounded capacity_in_bits() (256) - the two are deliberately distinct concepts.
+			CHECK_EQ(fixed_odd::size_in_bits(), 200);
+			CHECK_EQ(b.capacity_in_bits(), expected_capacity_bits);
 		}
 
 		SUBCASE("bounded capacity: narrow (uint8_t) segments") {
@@ -1437,8 +1470,19 @@ TEST_SUITE("bitset") {
 
 			bounded_odd8 b{};
 			CHECK_NOTHROW(b.set(expected_capacity_bits - 1));
-			REQUIRE_EQ(b.size_in_bits(), expected_capacity_bits);
+			REQUIRE_EQ(b.capacity_in_bits(), expected_capacity_bits);
 			CHECK_THROWS_AS(b.set(expected_capacity_bits), std::out_of_range);
+			CHECK_EQ(bounded_odd8::size_in_bits(), 20);
+		}
+
+		SUBCASE("fully dynamic capacity has no static size_in_bits() at all") {
+			// size_in_bits() requires has_max_extent - a fully dynamic bitset (both template
+			// parameters left as dynamic_extent) has no compile-time logical bound to report.
+			static_assert(!has_static_size_in_bits<dyn64>);
+			static_assert(!has_static_size_in_bits<dyn8>);
+			static_assert(has_static_size_in_bits<bounded64>);
+			static_assert(has_static_size_in_bits<bitset<4, 4 * 64>>);
+			CHECK(true);
 		}
 	}
 }

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -558,6 +558,126 @@ TEST_SUITE("bitset") {
 		}
 	}
 
+	TEST_CASE("segment-mode dereferencing: T& reference vs plain T value semantics") {
+		// segment_iterator's reference has operator std::conditional_t<is_const, T const&, T&>()
+		// (SegmentMode-only) - this exercises both sides: binding the dereference to a T&
+		// (an actual alias into storage) vs binding it to a plain T (an independent copy).
+
+		SUBCASE("value_type for a segment_iterator reports T, not bool") {
+			// bit_iterator's value_type is bool (one bit); segment_iterator's is the segment
+			// type itself - the two modes really do carry different logical types.
+			static_assert(std::is_same_v<dyn8::segment_iterator::value_type, dyn8::value_type>);
+			static_assert(std::is_same_v<dyn8::bit_iterator::value_type, bool>);
+			CHECK(true);
+		}
+
+		SUBCASE("dereferencing as T& yields a real reference - mutating it writes through to storage") {
+			dyn8 b{0xAA, 0x00}; // 2nd segment left at 0 so b.count() cleanly reflects only segment 0
+			auto it = b.begin<dyn8::bitset_mode::SegmentMode>();
+
+			dyn8::value_type &seg_ref = *it; // binds the proxy's conversion to an actual T&
+			CHECK_EQ(seg_ref, 0xAA);
+
+			seg_ref = 0xFF; // mutate through the reference, not through the iterator/bitset API
+			CHECK_EQ(it.get(), 0xFF);      // storage itself changed
+			CHECK_EQ(b.count(), 8);        // and is visible through completely separate accessors
+		}
+
+		SUBCASE("dereferencing as a plain T yields an independent copy - mutating it leaves storage untouched") {
+			dyn8 b{0xAA, 0xBB};
+			auto it = b.begin<dyn8::bitset_mode::SegmentMode>();
+
+			dyn8::value_type seg_val = *it; // binds to a plain T, not a reference: a copy
+			CHECK_EQ(seg_val, 0xAA);
+
+			seg_val = 0xFF; // only the local copy changes
+			CHECK_EQ(it.get(), 0xAA);      // storage is untouched
+			CHECK_EQ(seg_val, 0xFF);       // the copy did change, proving it's genuinely independent
+		}
+
+		SUBCASE("two iterators over the same segment alias each other through T&, proving real reference semantics") {
+			// the clearest way to tell a reference from a value: write through one iterator's
+			// T& and read it back through a second, independently-obtained iterator/reference.
+			dyn8 b{0x00, 0x00};
+			auto writer = b.begin<dyn8::bitset_mode::SegmentMode>();
+			auto reader = b.begin<dyn8::bitset_mode::SegmentMode>();
+
+			dyn8::value_type &write_ref = *writer;
+			dyn8::value_type &read_ref = *reader;
+
+			CHECK_EQ(read_ref, 0x00);
+			write_ref = 0x42;
+			CHECK_EQ(read_ref, 0x42); // read_ref observes the mutation - genuinely the same storage
+		}
+
+		SUBCASE("const_segment_iterator dereferences to T const& - reads live storage, cannot write") {
+			dyn8 b{0xAA, 0xBB};
+			dyn8 const &cb = b;
+
+			auto non_const_it = b.begin<dyn8::bitset_mode::SegmentMode>();
+			auto const_it = cb.begin<dyn8::bitset_mode::SegmentMode>();
+
+			dyn8::value_type const &const_ref = *const_it;
+			CHECK_EQ(const_ref, 0xAA);
+
+			// mutate through the *non-const* iterator over the same underlying bitset...
+			dyn8::value_type &mutable_ref = *non_const_it;
+			mutable_ref = 0x77;
+
+			// ...and the const reference, still bound to the same storage, observes it.
+			CHECK_EQ(const_ref, 0x77);
+
+			static_assert(std::is_same_v<decltype(const_ref), dyn8::value_type const&>);
+		}
+
+		SUBCASE("advancing a segment_iterator and rebinding to T& tracks the new segment, not the old one") {
+			dyn8 b{0xAA, 0xBB, 0xCC};
+			auto it = b.begin<dyn8::bitset_mode::SegmentMode>();
+
+			dyn8::value_type &first = *it;
+			CHECK_EQ(first, 0xAA);
+
+			++it;
+			dyn8::value_type &second = *it; // a fresh reference for the new position
+			CHECK_EQ(second, 0xBB);
+			CHECK_EQ(first, 0xAA); // the earlier reference is untouched - it aliases segment 0, not segment 1
+
+			second = 0x11;
+			CHECK_EQ(it.get(), 0x11);
+			CHECK_EQ(first, 0xAA); // still segment 0 - confirms `first` and `second` alias different segments
+		}
+
+		SUBCASE("rbegin/rend segment-mode traversal dereferences to T& and supports write-through") {
+			dyn8 b{0x11, 0x22, 0x33};
+
+			std::array<dyn8::value_type, 3> visited{};
+			size_t i = 0;
+			for (auto it = b.rbegin<dyn8::bitset_mode::SegmentMode>(); it != b.rend<dyn8::bitset_mode::SegmentMode>(); ++it) {
+				dyn8::value_type &seg_ref = *it;
+				REQUIRE_LT(i, visited.size());
+				visited[i++] = seg_ref;
+			}
+			CHECK_EQ(i, 3);
+			CHECK_EQ(visited[0], 0x33); // last segment first
+			CHECK_EQ(visited[1], 0x22);
+			CHECK_EQ(visited[2], 0x11); // first segment last
+
+			// write through the reverse-order reference and confirm it lands on the right segment
+			for (auto it = b.rbegin<dyn8::bitset_mode::SegmentMode>(); it != b.rend<dyn8::bitset_mode::SegmentMode>(); ++it) {
+				dyn8::value_type &seg_ref = *it;
+				if (seg_ref == 0x22) {
+					seg_ref = 0x99;
+				}
+			}
+			auto check_it = b.begin<dyn8::bitset_mode::SegmentMode>();
+			CHECK_EQ(check_it.get(), 0x11);
+			++check_it;
+			CHECK_EQ(check_it.get(), 0x99); // middle segment was the one mutated
+			++check_it;
+			CHECK_EQ(check_it.get(), 0x33);
+		}
+	}
+
 	TEST_CASE("bitset_iterator satisfies std::random_access_iterator") {
 		// compile-time only: if these ever regress, this is where it should surface, rather than
 		// as a cryptic constraint-not-satisfied error deep inside <ranges>/<algorithm>. Traversal
@@ -1069,12 +1189,12 @@ TEST_SUITE("bitset") {
 	}
 
 	TEST_CASE("position_iterator behavior") {
-		// positional_iterator/const_positional_iterator are template aliases parameterized by
-		// bitset_mode with no default (unlike bitset_iterator's bit_iterator/segment_iterator,
-		// there's no public non-template convenience alias for these) - name the BitMode
-		// instantiation once here for readability, since positional iteration is always bit-mode.
-		using pos_it = dyn64::positional_iterator<dyn64::bitset_mode::BitMode>;
-		using const_pos_it = dyn64::const_positional_iterator<dyn64::bitset_mode::BitMode>;
+		// positional_iterator/const_positional_iterator are now plain (non-template) aliases -
+		// position_iterator itself dropped its bitset_mode parameter and always uses BitMode
+		// internally, since positional iteration is only ever meaningful bit-by-bit. Local
+		// aliases kept here purely for the shorter names used throughout this TEST_CASE.
+		using pos_it = dyn64::positional_iterator;
+		using const_pos_it = dyn64::const_positional_iterator;
 
 		SUBCASE("satisfies std::input_iterator and positions() satisfies std::ranges::input_range") {
 			// compile-time only: if these ever regress, this is where it should surface, rather

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -1165,9 +1165,7 @@ TEST_SUITE("bitset") {
 		CHECK(b.test(3));
 	}
 
-	TEST_CASE("set_all / reset_all (fully static capacity only)") {
-		// set_all()/reset_all() require !has_dynamic_extent, i.e. extent == segments - neither
-		// dyn8/dyn64 (fully dynamic) nor bounded64 (dynamic size, bounded capacity) qualify.
+	TEST_CASE("set_all / reset_all on a fully static, segment-aligned capacity") {
 		using fixed64 = bitset<4, 4 * 64>; // extent stays in segments; 2nd param is now a bit count
 		constexpr size_t fixed64_capacity_bits = 4 * 64;
 
@@ -1184,7 +1182,84 @@ TEST_SUITE("bitset") {
 			CHECK(b.none_set());
 			CHECK_EQ(b.count(), 0);
 		}
+	}
 
+	TEST_CASE("set_all / reset_all now work in every capacity mode, including a non-aligned logical size") {
+		// set_all()/reset_all() used to require !has_dynamic_extent; that restriction is gone, so
+		// this exercises the previously-disallowed dynamic/bounded modes, plus the case that
+		// actually stresses the last-segment logic: a logical size that isn't a whole number of
+		// segments, where only the low leftover_bits() bits of the last segment may end up set.
+
+		SUBCASE("dynamic, narrow (uint8_t) segments, non-aligned logical size") {
+			dyn8 b{};
+			b.set(11); // logical size 12: 1 full 8-bit segment + 4 leftover bits
+			REQUIRE_EQ(b.size_in_bits(), 12);
+
+			b.set_all();
+			CHECK(b.all_set());
+			CHECK_EQ(b.count(), 12); // exactly the logical size - no leaked padding bits
+			for (size_t i = 0; i < 12; ++i) {
+				CHECK(b.test(i));
+			}
+
+			b.reset_all();
+			CHECK(b.none_set());
+			CHECK_EQ(b.count(), 0);
+		}
+
+		SUBCASE("dynamic, default (uint64_t) segments, non-aligned logical size spanning multiple segments") {
+			dyn64 b{};
+			b.set(69);
+			b.reset(69); // logical size 70: 1 full 64-bit segment + 6 leftover bits, content all 0
+
+			b.set_all();
+			CHECK(b.all_set());
+			CHECK_EQ(b.count(), 70);
+			CHECK(b.test(69)); // last legal (leftover) bit
+			// dyn64 has no max_bits cap, so going past logical size is just "not set", not an
+			// error - unlike the capped/fixed modes below, where fits_in_storage() rejects it.
+			CHECK_FALSE(b.test(70));
+
+			b.reset_all();
+			CHECK(b.none_set());
+			CHECK_EQ(b.count(), 0);
+		}
+
+		SUBCASE("bounded (dynamic size, capped capacity), non-aligned logical size") {
+			using bounded_odd = bitset<dynamic_extent, 100>;
+
+			bounded_odd b{};
+			b.set(69);
+			b.reset(69); // logical size 70, capacity rounds up to 128
+			REQUIRE_EQ(b.size_in_bits(), 70);
+
+			b.set_all();
+			CHECK(b.all_set());
+			CHECK_EQ(b.count(), 70);
+
+			b.reset_all();
+			CHECK(b.none_set());
+			CHECK_EQ(b.count(), 0);
+		}
+
+		SUBCASE("fully static capacity, permanently non-aligned logical size") {
+			// extent (2 segments = 128 bits of storage) is fixed regardless of max_bits (100) -
+			// logical size is always exactly 100 for this type, never a whole number of segments.
+			using fixed_odd = bitset<2, 100>;
+
+			fixed_odd b{0, 0};
+			REQUIRE_EQ(b.size_in_bits(), 100);
+
+			b.set_all();
+			CHECK(b.all_set());
+			CHECK_EQ(b.count(), 100);
+			CHECK(b.test(99));
+			CHECK_THROWS_AS((void)b.test(100), std::out_of_range);
+
+			b.reset_all();
+			CHECK(b.none_set());
+			CHECK_EQ(b.count(), 0);
+		}
 	}
 
 	TEST_CASE("shrink_to_fit") {
@@ -1819,5 +1894,309 @@ TEST_SUITE("bitset") {
 		CHECK_EQ(disjunction.size_in_bits(), 16);
 		CHECK(disjunction.test(0));
 		CHECK(disjunction.test(15));
+	}
+
+	TEST_CASE("countr_zero honors an exact (non-segment-aligned) logical size") {
+		// segment width for the default (uint64_t) instantiations used below; bitset<> keeps this
+		// private, so - like bounded64_segment_bits above - it is hardcoded here from the known
+		// template argument.
+		constexpr size_t seg64 = 64;
+
+		SUBCASE("aligned: the set bit sits in an early segment (non-edge - the leftover segment does not exist)") {
+			dyn64 b{1ull << 5, 0}; // 2 full segments (128 bits, aligned); bit 5 is the first 1
+			CHECK_EQ(b.countr_zero(), 5);
+		}
+
+		SUBCASE("aligned: an entirely-zero bitset returns exactly the (segment-aligned) logical size") {
+			dyn64 b{0, 0};
+			CHECK_EQ(b.countr_zero(), 2 * seg64);
+		}
+
+		SUBCASE("misaligned: the set bit sits in a full segment before the leftover one (non-edge)") {
+			dyn64 b{};
+			b.set(69);
+			b.reset(69); // logical size 70 (1 full segment + 6 leftover bits), content back to 0
+			b.set(3);    // the only 1 bit is in segment 0, well before the leftover segment
+			REQUIRE_EQ(b.size_in_bits(), 70);
+			CHECK_EQ(b.countr_zero(), 3);
+		}
+
+		SUBCASE("misaligned: the set bit sits inside the leftover region itself (edge)") {
+			dyn64 b{};
+			b.set(69);
+			b.reset(69); // logical size 70, leftover = 6 valid bits (global 64..69)
+			b.set(67);   // offset 3 within the leftover segment
+			REQUIRE_EQ(b.size_in_bits(), 70);
+			CHECK_EQ(b.countr_zero(), seg64 + 3);
+		}
+
+		SUBCASE("misaligned: everything is zero, including the leftover - capped at the logical size, not the segment width (edge)") {
+			// distinguishes a correct implementation from one that treats the padding bits above
+			// logical size as real zeros (over-counts up to a full extra segment width) or one
+			// that mishandles the leftover scan and stops too early.
+			dyn64 b{};
+			b.set(69);
+			b.reset(69);
+			REQUIRE_EQ(b.size_in_bits(), 70);
+			CHECK_EQ(b.countr_zero(), 70); // not 128 (2 * seg64)
+		}
+
+		SUBCASE("misaligned, narrow (uint8_t) segments") {
+			dyn8 b{};
+			b.set(11);
+			b.reset(11); // logical size 12 (1 full 8-bit segment + 4 leftover bits), all zero
+			REQUIRE_EQ(b.size_in_bits(), 12);
+			CHECK_EQ(b.countr_zero(), 12);
+		}
+
+		SUBCASE("misaligned, bounded (capped-dynamic) capacity") {
+			using bounded_odd = bitset<dynamic_extent, 100>;
+			bounded_odd b{};
+			b.set(69);
+			b.reset(69);
+			REQUIRE_EQ(b.size_in_bits(), 70);
+			CHECK_EQ(b.countr_zero(), 70);
+		}
+
+		SUBCASE("misaligned, fully-static (fixed) capacity") {
+			// extent (2 segments = 128 bits of storage) is fixed regardless of max_bits (100) -
+			// logical size is always exactly 100, permanently non-segment-aligned.
+			using fixed_odd = bitset<2, 100>;
+			fixed_odd b{0, 1ull << 26}; // offset 26 within the 36-bit leftover (global bit 90)
+			REQUIRE_EQ(b.size_in_bits(), 100);
+			CHECK_EQ(b.countr_zero(), seg64 + 26);
+		}
+	}
+
+	TEST_CASE("countl_zero honors an exact (non-segment-aligned) logical size") {
+		constexpr size_t seg64 = 64;
+
+		SUBCASE("aligned: the set bit sits in the last segment (non-edge - resolved without any fallback)") {
+			dyn64 b{0, 1ull << 58}; // 2 full segments (128 bits, aligned)
+			CHECK_EQ(b.countl_zero(), 5); // 63 - 58
+		}
+
+		SUBCASE("aligned: an entirely-zero bitset returns exactly the (segment-aligned) logical size") {
+			dyn64 b{0, 0};
+			CHECK_EQ(b.countl_zero(), 2 * seg64);
+		}
+
+		SUBCASE("misaligned: resolved within the leftover region, not at its very top (edge, no fallback)") {
+			dyn64 b{};
+			b.set(69);
+			b.reset(69); // logical size 70, leftover = 6 valid bits (global 64..69)
+			b.set(67);   // offset 3 of 0..5 - two leading zero bits (offsets 5, 4) above it
+			REQUIRE_EQ(b.size_in_bits(), 70);
+			CHECK_EQ(b.countl_zero(), 2);
+		}
+
+		SUBCASE("misaligned: the leftover is entirely zero, so it falls back to an earlier full segment (edge)") {
+			dyn64 b{};
+			b.set(69);
+			b.reset(69); // logical size 70, leftover all zero
+			b.set(5);    // segment 0 (a full, non-last segment) decides the answer
+			REQUIRE_EQ(b.size_in_bits(), 70);
+			CHECK_EQ(b.countl_zero(), 6 + (seg64 - 1 - 5)); // 6 leftover zeros + segment 0's own leading zeros
+		}
+
+		SUBCASE("misaligned: everything is zero - capped at the logical size, not the segment width (edge)") {
+			dyn64 b{};
+			b.set(69);
+			b.reset(69);
+			REQUIRE_EQ(b.size_in_bits(), 70);
+			CHECK_EQ(b.countl_zero(), 70); // not 128
+		}
+
+		SUBCASE("misaligned, narrow (uint8_t) segments") {
+			// this is the exact shape that used to fail to compile: countl_zero() on a non-aligned
+			// bitset with a segment type narrower than int (integer promotion made the masked
+			// operand's type disagree with what std::countl_zero requires).
+			dyn8 b{};
+			b.set(11);
+			b.reset(11); // logical size 12, leftover = 4 valid bits (global 8..11)
+			b.set(9);    // offset 1 of 0..3 - two leading zero bits (offsets 3, 2) above it
+			REQUIRE_EQ(b.size_in_bits(), 12);
+			CHECK_EQ(b.countl_zero(), 2);
+		}
+
+		SUBCASE("misaligned, bounded (capped-dynamic) capacity") {
+			using bounded_odd = bitset<dynamic_extent, 100>;
+			bounded_odd b{};
+			b.set(69);
+			b.reset(69);
+			REQUIRE_EQ(b.size_in_bits(), 70);
+			CHECK_EQ(b.countl_zero(), 70);
+		}
+
+		SUBCASE("misaligned, fully-static (fixed) capacity, falls back into an earlier full segment") {
+			using fixed_odd = bitset<2, 100>;
+			fixed_odd b{1ull << 10, 0}; // leftover (segment 1) all zero; segment 0 decides the answer
+			REQUIRE_EQ(b.size_in_bits(), 100);
+			CHECK_EQ(b.countl_zero(), 36 + (seg64 - 1 - 10)); // 36 leftover zeros + segment 0's leading zeros
+		}
+	}
+
+	TEST_CASE("all_set with a non-segment-aligned logical size") {
+		SUBCASE("misaligned: an earlier full segment isn't fully set - false without the leftover ever mattering (non-edge)") {
+			dyn64 b{};
+			b.set(69);
+			b.reset(69); // logical size 70, segment 0 not fully set (all zero), leftover also all zero
+			REQUIRE_EQ(b.size_in_bits(), 70);
+			CHECK_FALSE(b.all_set());
+		}
+
+		SUBCASE("misaligned: every full segment is set, but the leftover is only partially set (edge)") {
+			dyn64 b{};
+			b.set(69);
+			b.reset(69); // logical size 70, leftover = 6 valid bits (global 64..69)
+			for (size_t i = 0; i < 64; ++i) b.set(i); // segment 0 fully set
+			b.set(64);
+			b.set(65); // only 2 of the 6 leftover bits set
+			REQUIRE_EQ(b.size_in_bits(), 70);
+			CHECK_FALSE(b.all_set());
+		}
+
+		SUBCASE("misaligned: every full segment is set and the leftover is set exactly up to its width, no more (edge)") {
+			dyn64 b{};
+			b.set(69);
+			b.reset(69);
+			b.set_all();
+			REQUIRE_EQ(b.size_in_bits(), 70);
+			CHECK(b.all_set());
+			CHECK_EQ(b.count(), 70); // not 128 - confirms the leftover comparison isn't just "segment is non-zero"
+		}
+
+		SUBCASE("misaligned, narrow (uint8_t) segments") {
+			dyn8 full{};
+			full.set(11);
+			full.reset(11);
+			full.set_all();
+			CHECK(full.all_set());
+
+			dyn8 partial{};
+			partial.set(11);
+			partial.reset(11);
+			for (size_t i = 0; i < 8; ++i) partial.set(i); // segment 0 full, leftover untouched
+			CHECK_FALSE(partial.all_set());
+		}
+
+		SUBCASE("misaligned, bounded (capped-dynamic) capacity") {
+			using bounded_odd = bitset<dynamic_extent, 100>;
+			bounded_odd b{};
+			b.set(69);
+			b.reset(69);
+			b.set_all();
+			CHECK(b.all_set());
+
+			b.reset(64); // clear a single leftover bit
+			CHECK_FALSE(b.all_set());
+		}
+
+		SUBCASE("misaligned, fully-static (fixed) capacity") {
+			using fixed_odd = bitset<2, 100>;
+			// leftover is 36 valid bits (global 64..99); mask sets exactly those, nothing above.
+			constexpr uint64_t leftover_mask = (uint64_t{1} << 36) - 1;
+
+			fixed_odd full{~0ull, leftover_mask};
+			CHECK(full.all_set());
+
+			fixed_odd partial{~0ull, leftover_mask >> 1}; // one leftover bit short
+			CHECK_FALSE(partial.all_set());
+		}
+	}
+
+	TEST_CASE("operator~ preserves the zero-padding invariant across a non-aligned boundary") {
+		SUBCASE("aligned: NOT of all-zero is all-one and vice versa, double negation is the identity") {
+			dyn64 b{0, 0};
+			auto const notb = ~b;
+			CHECK(notb.all_set());
+			CHECK_EQ(notb.count(), 2 * 64);
+
+			auto const notnotb = ~notb;
+			CHECK(notnotb.none_set());
+			CHECK(notnotb == b);
+		}
+
+		SUBCASE("misaligned: exactly the logical bits flip - no padding bits leak into count()/all_set()") {
+			dyn64 b{};
+			b.set(69); // logical size 70, only bit 69 set
+			REQUIRE_EQ(b.size_in_bits(), 70);
+
+			auto const notb = ~b;
+			CHECK_EQ(notb.count(), 69); // 70 logical bits, 1 was set -> 69 should now be set
+			CHECK_FALSE(notb.test(69));
+			for (size_t i = 0; i < 69; ++i) {
+				CHECK(notb.test(i));
+			}
+			CHECK_FALSE(notb.all_set()); // bit 69 is 0, so not every logical bit is set
+
+			CHECK((~notb) == b); // double negation round-trips exactly
+		}
+
+		SUBCASE("misaligned, narrow (uint8_t) segments") {
+			dyn8 b{};
+			b.set(11); // logical size 12, only bit 11 set
+			auto const notb = ~b;
+			CHECK_EQ(notb.count(), 11);
+			CHECK_FALSE(notb.test(11));
+			CHECK((~notb) == b);
+		}
+
+		SUBCASE("misaligned, bounded (capped-dynamic) capacity") {
+			using bounded_odd = bitset<dynamic_extent, 100>;
+			bounded_odd b{};
+			b.set(69);
+			auto const notb = ~b;
+			CHECK_EQ(notb.count(), 69);
+			CHECK_EQ(notb.size_in_bits(), 70);
+		}
+
+		SUBCASE("misaligned, fully-static (fixed) capacity") {
+			using fixed_odd = bitset<2, 100>;
+			fixed_odd b{0, 1ull << 10}; // one bit set, deep inside the 36-bit leftover
+			auto const notb = ~b;
+			CHECK_EQ(notb.count(), 99); // 100 logical bits, 1 was set
+			CHECK_FALSE(notb.all_set());
+			CHECK((~notb) == b);
+		}
+	}
+
+	TEST_CASE("bitwise and/or/xor preserve the zero-padding invariant across a non-aligned boundary") {
+		// and/or/xor never touch a bit that both operands agree is 0 - so as long as both operands
+		// already keep their padding at 0 (which set()/set_all()/the fixed operator~ above all
+		// guarantee), these can't introduce a leak on their own. These identities exercise exactly
+		// that: mixing in an operator~ result (the operation that used to leak) and checking the
+		// combination still respects the exact logical size.
+		SUBCASE("misaligned, narrow (uint8_t) segments") {
+			dyn8 a{0b01011010};
+			a.set(11); // logical size 12, a mixed (non-trivial) pattern in segment 0 plus a leftover bit
+
+			CHECK((a ^ a).none_set());
+			CHECK_EQ((a ^ a).count(), 0);
+
+			auto const xor_not = a ^ ~a;
+			CHECK(xor_not.all_set());
+			CHECK_EQ(xor_not.count(), 12);
+
+			CHECK((a & ~a).none_set());
+			CHECK((a | ~a).all_set());
+		}
+
+		SUBCASE("misaligned, default (uint64_t) segments spanning multiple segments") {
+			dyn64 a{};
+			a.set(69);
+			a.reset(69);
+			a.set(40);
+			a.set(3); // mixed pattern: segment 0 has 2 bits set, leftover has none
+
+			CHECK((a ^ a).none_set());
+
+			auto const xor_not = a ^ ~a;
+			CHECK(xor_not.all_set());
+			CHECK_EQ(xor_not.count(), 70);
+
+			CHECK((a & ~a).none_set());
+			CHECK((a | ~a).all_set());
+		}
 	}
 }

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -11,6 +11,12 @@
 #include <type_traits>
 #include <utility>
 
+// helper for the position_iterator concept checks below: requires-expressions need a genuine
+// template parameter to fail via substitution rather than a hard compile error, so this can't be
+// inlined as `requires(dyn64::positional_iterator it, ...) { it[n]; }` inside the static_assert.
+template<typename I>
+concept has_subscript_operator = requires(I i, std::iter_difference_t<I> n) { i[n]; };
+
 TEST_SUITE("bitset") {
 	using namespace dice::template_library;
 
@@ -530,6 +536,144 @@ TEST_SUITE("bitset") {
 		}
 	}
 
+	TEST_CASE("bitset_iterator satisfies std::random_access_iterator") {
+		// compile-time only: if these ever regress, this is where it should surface, rather than
+		// as a cryptic constraint-not-satisfied error deep inside <ranges>/<algorithm>.
+		static_assert(std::default_initializable<dyn64::iterator>);
+		static_assert(std::default_initializable<dyn64::const_iterator>);
+		static_assert(std::totally_ordered<dyn64::iterator>);
+		static_assert(std::totally_ordered<dyn64::const_iterator>);
+		static_assert(std::sized_sentinel_for<dyn64::iterator, dyn64::iterator>);
+		static_assert(std::random_access_iterator<dyn64::iterator>);
+		static_assert(std::random_access_iterator<dyn64::const_iterator>);
+		CHECK(true);
+	}
+
+	TEST_CASE("bitset_iterator new random-access operations") {
+		SUBCASE("operator[] reads the bit at begin() + n without moving the iterator") {
+			dyn8 b{0b00000000, 0b00000010};
+			auto const it = b.begin();
+
+			CHECK_FALSE(static_cast<bool>(it[0]));
+			CHECK(static_cast<bool>(it[9])); // segment 1, offset 1
+			CHECK_EQ(it[9].ix(), 9);
+
+			// must not have moved
+			CHECK_EQ(it, b.begin());
+		}
+
+		SUBCASE("operator[] matches *(it + n) for every position") {
+			dyn8 b{0b10110010, 0b01001101};
+			auto const it = b.begin();
+			for (size_t n = 0; n < b.size_in_bits(); ++n) {
+				CAPTURE(n);
+				CHECK_EQ(static_cast<bool>(it[n]), static_cast<bool>(*(it + n)));
+			}
+		}
+
+		SUBCASE("relational operators order iterators by their global bit position") {
+			dyn8 b{0x00, 0x00, 0x00};
+			auto const low = b.begin() + 3;
+			auto const mid = b.begin() + 9;   // different segment
+			auto const high = b.begin() + 20;
+
+			CHECK(low < mid);
+			CHECK(mid < high);
+			CHECK(low < high);
+			CHECK(mid > low);
+			CHECK(low <= low);
+			CHECK(low <= mid);
+			CHECK(mid >= low);
+			CHECK(low >= low);
+			CHECK_FALSE(mid < low);
+			CHECK_FALSE(high <= mid);
+
+			CHECK_EQ(low <=> low, std::strong_ordering::equal);
+			CHECK_EQ(low <=> mid, std::strong_ordering::less);
+			CHECK_EQ(high <=> mid, std::strong_ordering::greater);
+		}
+
+		SUBCASE("commutative operator+ : n + it == it + n") {
+			dyn8 b{0x00, 0x00};
+			auto const it = b.begin() + 2;
+
+			CHECK((5 + it) == (it + 5));
+			CHECK_EQ((5 + it).get(), (it + 5).get());
+		}
+
+		SUBCASE("free operator- : n - it == it - n (library-defined symmetric semantics)") {
+			dyn8 b{0x00, 0x00};
+			auto const it = b.begin() + 10;
+
+			CHECK((3 - it) == (it - 3));
+		}
+
+		SUBCASE("default-constructed iterators are equality-comparable and independent of any bitset") {
+			dyn8::iterator a{};
+			dyn8::iterator b{};
+			CHECK(a == b);
+
+			dyn8 bs{0x00};
+			auto valid = bs.begin();
+			a = valid;
+			CHECK(a == valid);
+			CHECK(a != b);
+		}
+
+		SUBCASE("negative offsets: it += (-n) matches it -= n, it -= (-n) matches it += n") {
+			dyn8 b{0x00, 0x00};
+			auto const base = b.begin() + 9;
+
+			dyn8::iterator::difference_type const n = 3;
+
+			auto plus_neg = base;
+			plus_neg += -n;
+			CHECK_EQ(plus_neg, base - n);
+
+			auto minus_neg = base;
+			minus_neg -= -n;
+			CHECK_EQ(minus_neg, base + n);
+
+			CHECK_EQ(base + (-n), base - n);
+			CHECK_EQ(base - (-n), base + n);
+		}
+
+		SUBCASE("negative offsets round-trip back to the exact starting position") {
+			dyn8 b{0x00, 0x00, 0x00};
+			auto const base = b.begin() + 15;
+			dyn8::iterator::difference_type const n = 7;
+
+			auto it = base + n;
+			it += -n;
+			CHECK_EQ(it, base);
+
+			auto it2 = base - n;
+			it2 -= -n;
+			CHECK_EQ(it2, base);
+		}
+
+		SUBCASE("std::next/std::prev/std::distance work via the random-access fast path") {
+			dyn8 b{0x00, 0x00, 0x00};
+			auto const it = b.begin() + 5;
+
+			auto const next5 = std::next(it, 5);
+			CHECK_EQ(next5, b.begin() + 10);
+
+			auto const prev3 = std::prev(it, 3);
+			CHECK_EQ(prev3, b.begin() + 2);
+
+			CHECK_EQ(std::distance(prev3, next5), 8);
+			CHECK_EQ(std::distance(next5, prev3), -8);
+		}
+
+		SUBCASE("std::advance with a negative distance moves backwards correctly") {
+			dyn8 b{0x00, 0x00, 0x00};
+			auto it = b.begin() + 12;
+			std::advance(it, -5);
+			CHECK_EQ(it, b.begin() + 7);
+		}
+	}
+
 	TEST_CASE("shifts") {
 		SUBCASE("operator<<= moves bits toward lower indices and clears vacated bits") {
 			dyn8 b{0b10110011}; // bit(i): 1,1,0,0,1,1,0,1 for i = 0..7
@@ -901,6 +1045,43 @@ TEST_SUITE("bitset") {
 			static_assert(std::sentinel_for<std::default_sentinel_t, dyn64::const_positional_iterator>);
 			static_assert(std::ranges::input_range<decltype(std::declval<dyn64 const&>().positions())>);
 			CHECK(true);
+		}
+
+		SUBCASE("is exactly an input_iterator - it does not (over-)satisfy any stronger category") {
+			// position_iterator only ever moves forward one step at a time via seek(), has no
+			// default constructor (ctor requires a bitset&), and has no operator+=/-=/[] at all -
+			// so unlike bitset_iterator, it must fail default_initializable and every iterator
+			// category above input_iterator, and must not expose a subscript operator either
+			// (operator[] is a random_access_iterator-only requirement, not an input_iterator one).
+			static_assert(!std::default_initializable<dyn64::positional_iterator>);
+			static_assert(!std::default_initializable<dyn64::const_positional_iterator>);
+
+			static_assert(!std::forward_iterator<dyn64::positional_iterator>);
+			static_assert(!std::forward_iterator<dyn64::const_positional_iterator>);
+
+			static_assert(!std::bidirectional_iterator<dyn64::positional_iterator>);
+			static_assert(!std::random_access_iterator<dyn64::positional_iterator>);
+
+			static_assert(!has_subscript_operator<dyn64::positional_iterator>);
+			static_assert(!has_subscript_operator<dyn64::const_positional_iterator>);
+			CHECK(true);
+		}
+
+		SUBCASE("input_iterator semantics: single-pass forward traversal reaches the sentinel") {
+			// exercises the actual runtime behavior behind the concept check above: only
+			// operator++ (no --, no +=), operator*, and comparison against std::default_sentinel_t.
+			static_assert(std::is_same_v<decltype(std::declval<dyn64::positional_iterator&>()++), dyn64::positional_iterator>);
+			static_assert(std::is_same_v<decltype(++std::declval<dyn64::positional_iterator&>()), dyn64::positional_iterator&>);
+
+			dyn64 b{0b10101, 0b1}; // segment 0: bits 0,2,4 set; segment 1: bit 0 set -> 4 set bits total
+			auto it = b.pbegin(); // already positioned at the first set bit (ix 0)
+
+			size_t steps = 0;
+			for (; it != std::default_sentinel; ++it) {
+				++steps;
+				REQUIRE_LE(steps, 4); // guard against an infinite loop if seek() ever regresses
+			}
+			CHECK_EQ(steps, 4);
 		}
 
 		SUBCASE("empty bitset: pbegin() equals pend() immediately") {

--- a/tests/tests_bitset.cpp
+++ b/tests/tests_bitset.cpp
@@ -13,7 +13,7 @@
 
 // helper for the position_iterator concept checks below: requires-expressions need a genuine
 // template parameter to fail via substitution rather than a hard compile error, so this can't be
-// inlined as `requires(dyn64::positional_iterator it, ...) { it[n]; }` inside the static_assert.
+// inlined as `requires(dyn64::positional_iterator<...> it, ...) { it[n]; }` inside the static_assert.
 template<typename I>
 concept has_subscript_operator = requires(I i, std::iter_difference_t<I> n) { i[n]; };
 
@@ -399,6 +399,24 @@ TEST_SUITE("bitset") {
 			CHECK(*it); // bit 2
 		}
 
+		SUBCASE("operator* converts directly to bool - no static_cast needed") {
+			// bitset_iterator::reference has an implicit operator bool(), so the logical type
+			// behind the proxy (a single bit) comes out with a plain assignment, not a cast.
+			dyn8 b{0b00000101};
+			auto it = b.begin();
+
+			bool const bit0 = *it; // direct conversion, not static_cast<bool>(*it)
+			CHECK(bit0);
+
+			++it;
+			bool const bit1 = *it;
+			CHECK_FALSE(bit1);
+
+			++it;
+			bool const bit2 = *it;
+			CHECK(bit2);
+		}
+
 		SUBCASE("writing through the iterator itself (not *it) sets the underlying bit") {
 			dyn8 b{0x00};
 			auto it = b.begin();
@@ -414,10 +432,12 @@ TEST_SUITE("bitset") {
 		}
 
 		SUBCASE("segment-mode increment advances by a whole segment") {
+			// the traversal policy is now baked into the iterator's own type - request a
+			// segment_iterator up front instead of calling a separate advance_segment() helper.
 			dyn8 b{0xAA, 0xBB};
-			auto it = b.begin();
+			auto it = b.begin<dyn8::bitset_mode::SegmentMode>();
 			CHECK_EQ(it.get(), 0xAA);
-			it = b.advance_segment(it); // advance_segment takes/returns by value - capture the result
+			++it;
 			CHECK_EQ(it.get(), 0xBB);
 		}
 
@@ -431,8 +451,8 @@ TEST_SUITE("bitset") {
 			auto const it2 = b.begin() + 9;
 			CHECK(*it2);
 
-			auto it3 = b.begin();
-			it3 = b.advance_segment(it3, 1);
+			auto it3 = b.begin<dyn8::bitset_mode::SegmentMode>();
+			it3 += 1;
 			CHECK_EQ(it3.get(), 0b00000010);
 		}
 
@@ -465,10 +485,10 @@ TEST_SUITE("bitset") {
 			CHECK(it2 == b.begin());
 
 			dyn8 b2{0xAA, 0xBB};
-			auto it3 = b2.begin();
-			it3 = b2.advance_segment(it3);
+			auto it3 = b2.begin<dyn8::bitset_mode::SegmentMode>();
+			++it3;
 			CHECK_EQ(it3.get(), 0xBB);
-			it3 = b2.advance_segment_backwards(it3);
+			--it3;
 			CHECK_EQ(it3.get(), 0xAA);
 		}
 
@@ -494,21 +514,23 @@ TEST_SUITE("bitset") {
 		}
 
 		SUBCASE("explicit iterator construction with an offset validates the offset") {
+			// dyn8::iterator is now a template alias (parameterized by bitset_mode) - bit_iterator
+			// is the public non-template convenience alias for the BitMode instantiation.
 			dyn8 b{0x00};
-			CHECK_NOTHROW((dyn8::iterator{b, 7}));
-			CHECK_THROWS_AS((dyn8::iterator{b, 8}), std::out_of_range); // dyn8's segment width is 8 bits
+			CHECK_NOTHROW((dyn8::bit_iterator{b, 7}));
+			CHECK_THROWS_AS((dyn8::bit_iterator{b, 8}), std::out_of_range); // dyn8's segment width is 8 bits
 
-			dyn8::iterator it{b, 3};
+			dyn8::bit_iterator it{b, 3};
 			CHECK(it == b.begin() + 3);
 		}
 
 		SUBCASE("explicit iterator construction with an offset and segment validates both") {
 			dyn8 b{0x00, 0x00};
-			CHECK_NOTHROW((dyn8::iterator{b, 0, 1}));
-			CHECK_THROWS_AS((dyn8::iterator{b, 8, 0}), std::out_of_range); // bad offset
-			CHECK_THROWS_AS((dyn8::iterator{b, 0, 2}), std::out_of_range); // segment out of bounds (only 2 segments exist)
+			CHECK_NOTHROW((dyn8::bit_iterator{b, 0, 1}));
+			CHECK_THROWS_AS((dyn8::bit_iterator{b, 8, 0}), std::out_of_range); // bad offset
+			CHECK_THROWS_AS((dyn8::bit_iterator{b, 0, 2}), std::out_of_range); // segment out of bounds (only 2 segments exist)
 
-			dyn8::iterator it{b, 2, 1};
+			dyn8::bit_iterator it{b, 2, 1};
 			CHECK(it == b.begin() + 10);
 		}
 
@@ -538,14 +560,25 @@ TEST_SUITE("bitset") {
 
 	TEST_CASE("bitset_iterator satisfies std::random_access_iterator") {
 		// compile-time only: if these ever regress, this is where it should surface, rather than
-		// as a cryptic constraint-not-satisfied error deep inside <ranges>/<algorithm>.
-		static_assert(std::default_initializable<dyn64::iterator>);
-		static_assert(std::default_initializable<dyn64::const_iterator>);
-		static_assert(std::totally_ordered<dyn64::iterator>);
-		static_assert(std::totally_ordered<dyn64::const_iterator>);
-		static_assert(std::sized_sentinel_for<dyn64::iterator, dyn64::iterator>);
-		static_assert(std::random_access_iterator<dyn64::iterator>);
-		static_assert(std::random_access_iterator<dyn64::const_iterator>);
+		// as a cryptic constraint-not-satisfied error deep inside <ranges>/<algorithm>. Traversal
+		// policy is now a template parameter baked into the iterator's type (bit_iterator /
+		// segment_iterator, plus their const_ counterparts) rather than a per-call argument, so
+		// both instantiations need to be checked independently.
+		static_assert(std::default_initializable<dyn64::bit_iterator>);
+		static_assert(std::default_initializable<dyn64::const_bit_iterator>);
+		static_assert(std::totally_ordered<dyn64::bit_iterator>);
+		static_assert(std::totally_ordered<dyn64::const_bit_iterator>);
+		static_assert(std::sized_sentinel_for<dyn64::bit_iterator, dyn64::bit_iterator>);
+		static_assert(std::random_access_iterator<dyn64::bit_iterator>);
+		static_assert(std::random_access_iterator<dyn64::const_bit_iterator>);
+
+		static_assert(std::default_initializable<dyn64::segment_iterator>);
+		static_assert(std::default_initializable<dyn64::const_segment_iterator>);
+		static_assert(std::totally_ordered<dyn64::segment_iterator>);
+		static_assert(std::totally_ordered<dyn64::const_segment_iterator>);
+		static_assert(std::sized_sentinel_for<dyn64::segment_iterator, dyn64::segment_iterator>);
+		static_assert(std::random_access_iterator<dyn64::segment_iterator>);
+		static_assert(std::random_access_iterator<dyn64::const_segment_iterator>);
 		CHECK(true);
 	}
 
@@ -609,8 +642,8 @@ TEST_SUITE("bitset") {
 		}
 
 		SUBCASE("default-constructed iterators are equality-comparable and independent of any bitset") {
-			dyn8::iterator a{};
-			dyn8::iterator b{};
+			dyn8::bit_iterator a{};
+			dyn8::bit_iterator b{};
 			CHECK(a == b);
 
 			dyn8 bs{0x00};
@@ -624,7 +657,7 @@ TEST_SUITE("bitset") {
 			dyn8 b{0x00, 0x00};
 			auto const base = b.begin() + 9;
 
-			dyn8::iterator::difference_type const n = 3;
+			dyn8::bit_iterator::difference_type const n = 3;
 
 			auto plus_neg = base;
 			plus_neg += -n;
@@ -641,7 +674,7 @@ TEST_SUITE("bitset") {
 		SUBCASE("negative offsets round-trip back to the exact starting position") {
 			dyn8 b{0x00, 0x00, 0x00};
 			auto const base = b.begin() + 15;
-			dyn8::iterator::difference_type const n = 7;
+			dyn8::bit_iterator::difference_type const n = 7;
 
 			auto it = base + n;
 			it += -n;
@@ -1036,13 +1069,20 @@ TEST_SUITE("bitset") {
 	}
 
 	TEST_CASE("position_iterator behavior") {
+		// positional_iterator/const_positional_iterator are template aliases parameterized by
+		// bitset_mode with no default (unlike bitset_iterator's bit_iterator/segment_iterator,
+		// there's no public non-template convenience alias for these) - name the BitMode
+		// instantiation once here for readability, since positional iteration is always bit-mode.
+		using pos_it = dyn64::positional_iterator<dyn64::bitset_mode::BitMode>;
+		using const_pos_it = dyn64::const_positional_iterator<dyn64::bitset_mode::BitMode>;
+
 		SUBCASE("satisfies std::input_iterator and positions() satisfies std::ranges::input_range") {
 			// compile-time only: if these ever regress, this is where it should surface, rather
 			// than as a cryptic "no viable constructor/deduction guide" deep inside <ranges>.
-			static_assert(std::input_iterator<dyn64::positional_iterator>);
-			static_assert(std::input_iterator<dyn64::const_positional_iterator>);
-			static_assert(std::sentinel_for<std::default_sentinel_t, dyn64::positional_iterator>);
-			static_assert(std::sentinel_for<std::default_sentinel_t, dyn64::const_positional_iterator>);
+			static_assert(std::input_iterator<pos_it>);
+			static_assert(std::input_iterator<const_pos_it>);
+			static_assert(std::sentinel_for<std::default_sentinel_t, pos_it>);
+			static_assert(std::sentinel_for<std::default_sentinel_t, const_pos_it>);
 			static_assert(std::ranges::input_range<decltype(std::declval<dyn64 const&>().positions())>);
 			CHECK(true);
 		}
@@ -1053,25 +1093,25 @@ TEST_SUITE("bitset") {
 			// so unlike bitset_iterator, it must fail default_initializable and every iterator
 			// category above input_iterator, and must not expose a subscript operator either
 			// (operator[] is a random_access_iterator-only requirement, not an input_iterator one).
-			static_assert(!std::default_initializable<dyn64::positional_iterator>);
-			static_assert(!std::default_initializable<dyn64::const_positional_iterator>);
+			static_assert(!std::default_initializable<pos_it>);
+			static_assert(!std::default_initializable<const_pos_it>);
 
-			static_assert(!std::forward_iterator<dyn64::positional_iterator>);
-			static_assert(!std::forward_iterator<dyn64::const_positional_iterator>);
+			static_assert(!std::forward_iterator<pos_it>);
+			static_assert(!std::forward_iterator<const_pos_it>);
 
-			static_assert(!std::bidirectional_iterator<dyn64::positional_iterator>);
-			static_assert(!std::random_access_iterator<dyn64::positional_iterator>);
+			static_assert(!std::bidirectional_iterator<pos_it>);
+			static_assert(!std::random_access_iterator<pos_it>);
 
-			static_assert(!has_subscript_operator<dyn64::positional_iterator>);
-			static_assert(!has_subscript_operator<dyn64::const_positional_iterator>);
+			static_assert(!has_subscript_operator<pos_it>);
+			static_assert(!has_subscript_operator<const_pos_it>);
 			CHECK(true);
 		}
 
 		SUBCASE("input_iterator semantics: single-pass forward traversal reaches the sentinel") {
 			// exercises the actual runtime behavior behind the concept check above: only
 			// operator++ (no --, no +=), operator*, and comparison against std::default_sentinel_t.
-			static_assert(std::is_same_v<decltype(std::declval<dyn64::positional_iterator&>()++), dyn64::positional_iterator>);
-			static_assert(std::is_same_v<decltype(++std::declval<dyn64::positional_iterator&>()), dyn64::positional_iterator&>);
+			static_assert(std::is_same_v<decltype(std::declval<pos_it&>()++), pos_it>);
+			static_assert(std::is_same_v<decltype(++std::declval<pos_it&>()), pos_it&>);
 
 			dyn64 b{0b10101, 0b1}; // segment 0: bits 0,2,4 set; segment 1: bit 0 set -> 4 set bits total
 			auto it = b.pbegin(); // already positioned at the first set bit (ix 0)
@@ -1104,9 +1144,40 @@ TEST_SUITE("bitset") {
 			CHECK_EQ(i, expected.size());
 		}
 
+		SUBCASE("dereferencing converts directly to size_t - no .ix() call needed") {
+			// the same reference proxy bitset_iterator dereferences to also has an implicit
+			// operator size_t() (returning ix()), so a plain assignment - not a call to .ix() -
+			// is enough to pull the logical position back out.
+			dyn64 b{0b10101, 0b1}; // segment 0: bits 0,2,4 set; segment 1: bit 0 set
+			std::array<size_t, 4> const expected{0, 2, 4, 64};
+
+			size_t i = 0;
+			for (auto it = b.pbegin(); it != b.pend(); ++it) {
+				REQUIRE_LT(i, expected.size());
+				size_t const pos = *it; // direct conversion, not (*it).ix()
+				CHECK_EQ(pos, expected[i]);
+				++i;
+			}
+			CHECK_EQ(i, expected.size());
+		}
+
+		SUBCASE("positions() elements convert directly to size_t as well") {
+			dyn64 b{0b10101, 0b1};
+			std::array<size_t, 4> const expected{0, 2, 4, 64};
+
+			size_t i = 0;
+			for (auto pos_ref : b.positions()) {
+				REQUIRE_LT(i, expected.size());
+				size_t const pos = pos_ref; // direct conversion, not pos_ref.ix()
+				CHECK_EQ(pos, expected[i]);
+				++i;
+			}
+			CHECK_EQ(i, expected.size());
+		}
+
 		SUBCASE("pbegin()/pend() on a const bitset yield a const_positional_iterator") {
 			dyn64 const b{0b10101, 0b1};
-			static_assert(std::is_same_v<decltype(b.pbegin()), dyn64::const_positional_iterator>);
+			static_assert(std::is_same_v<decltype(b.pbegin()), const_pos_it>);
 
 			std::array<size_t, 4> const expected{0, 2, 4, 64};
 			size_t i = 0;


### PR DESCRIPTION
Support for a multi-type bitset supporting both dynamic and static growth.

Supported features:
- [x] set(ix)
- [x] flip(ix)
- [x] unset(ix)
- [x] test(ix) -> bool
- [x] count() -> size_t
- [x] set_first_free() -> ix
- [x] \<bit> equivalents e.g. countr_zero()
- [x] all_set() -> bool
- [x] any_set() -> bool
- [x] none_set() -> bool
- [x] std::formatter ; two modes - hex, bin
- [x] bit operators
- [x] bit iterator
- [x] positional iterator
- [x] positions query, positions core functions