### PR TITLE
Feature: generic `try_*` range algorithms and `DICE_TRY`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ It contains:
 - `pointer_tag_pair`: A pointer and value pair that stores a small integer tag in the pointer alignment bits based on the API
   from [P3125 (constexpr pointer tagging)](https://wg21.link/P3125).
 - `ipow`: Integer exponentiation (power by squaring) with over-/underflow detection.
+- `control_flow`: Rust inspired `ControlFlow`, holding either a `cfbreak` or a `cfcontinue`.
+- `try_traits`/`DICE_TRY`: A common interface for fallible types (`std::optional`, `std::expected`, `control_flow`)
+  and a macro that propagates their errors like rust's `?` operator.
 
 ## Usage
 
@@ -181,6 +184,11 @@ It also supports allocators with "fancy" pointers.
 Additional range algorithms (e.g. `unique_view`) and adaptors (e.g., a pipeable `all_of`)
 that are missing from the standard library.
 
+It also contains fallible counterparts of some standard algorithms: `try_fold_left`, `try_fold_left_first` and
+`try_for_each` apply a function that returns a [try_result](#try_traitsdice_try) to each element and stop at the
+first residual (i.e. a `std::nullopt`, a `std::unexpected` or a `cfbreak`), propagating it to the caller
+together with the iterator they stopped at.
+
 ### `next_to_range`/`next_to_view`/`next_to_iter`
 Eliminate the boilerplate required to write C++ iterators and ranges.
 To get a fully functional range, the only thing that is required is
@@ -271,6 +279,52 @@ ipow(2, 100);   // throws std::overflow_error
 ```
 
 Note: not supported by MSVC because it relies on `__builtin_mul_overflow`.
+
+### `control_flow`
+A rust like `ControlFlow`: it holds either a `cfbreak<B>`, telling the caller to stop and propagate the break value,
+or a `cfcontinue<C>`, telling it to carry on with the continue value.
+
+```cpp
+control_flow<std::string, int> checked_double(int x) {
+    if (x > 100) {
+        return cfbreak{std::string{"too large"}};
+    }
+
+    return cfcontinue{x * 2};
+}
+```
+
+Either arm may be `void` to express that it cannot occur, e.g. a `control_flow<E, void>` can only ever break.
+The value is retrieved with `get_break()`/`get_continue()` (both propagate the value category of the
+`control_flow` they are called on) or by visiting it with `visit`/[`match`](#overloaded-and-match).
+
+### `try_traits`/`DICE_TRY`
+`try_traits` is the common interface of all fallible ("try") types. It is implemented for `std::optional`,
+`std::expected` and `control_flow`, and can be specialized for your own types.
+A type that implements it satisfies the `try_result` concept and can be used with `DICE_TRY` and the
+fallible range algorithms (see [`ranges`](#ranges)).
+
+`DICE_TRY` behaves like rust's `?` operator: it unwraps the output value of a `try_result`, or returns its residual
+(the `std::nullopt`, `std::unexpected` or `cfbreak`) from the enclosing function.
+
+```cpp
+std::expected<int, std::string> parse_int(std::string const &s);
+
+std::expected<double, std::string> parse_and_halve(std::string const &s) {
+    int const value = DICE_TRY(parse_int(s)); // returns the error from parse_and_halve if there is one
+    return static_cast<double>(value) / 2.0;
+}
+```
+
+As shown above, the residual is propagated even if the enclosing function has a different output type,
+because rebinding the output of a `try_result` keeps its residual channel intact.
+
+Notes:
+- `DICE_TRY` moves its argument if it is an rvalue and copies it otherwise, so passing a named variable leaves
+  it intact. Consequently, a move only `try_result` has to be passed as an rvalue.
+- `DICE_TRY` relies on statement expressions and is therefore only available on GCC and clang.
+
+Examples can be found [here](examples/example_try.cpp).
 
 ### Further Examples
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -218,3 +218,10 @@ target_link_libraries(example_ipow
         dice-template-library::dice-template-library
 )
 
+add_executable(example_try
+        example_try.cpp)
+target_link_libraries(example_try
+        PRIVATE
+        dice-template-library::dice-template-library
+)
+

--- a/examples/example_try.cpp
+++ b/examples/example_try.cpp
@@ -1,0 +1,73 @@
+#include <dice/template-library/ranges.hpp>
+#include <dice/template-library/try_traits.hpp>
+
+#include <array>
+#include <expected>
+#include <iostream>
+#include <optional>
+#include <string>
+
+namespace dtl = dice::template_library;
+
+std::expected<int, std::string> parse_int(std::string const &s) {
+    try {
+        return std::stoi(s);
+    } catch (std::exception const &) {
+        return std::unexpected{"not a number: " + s};
+    }
+}
+
+// DICE_TRY unwraps the value or returns the error from the enclosing function.
+// Note that the error is propagated even though the output type changes from int to double.
+std::expected<double, std::string> parse_and_halve(std::string const &s) {
+    int const value = DICE_TRY(parse_int(s));
+    return static_cast<double>(value) / 2.0;
+}
+
+// It works for every try_result, e.g. for std::optional ...
+std::optional<char> first_char_of(std::string const &s) {
+    return s.empty() ? std::nullopt : std::optional{s.front()};
+}
+
+std::optional<std::string> describe_first_char(std::string const &s) {
+    return std::string{"first char is '"} + DICE_TRY(first_char_of(s)) + "'";
+}
+
+// ... and for control_flow, where you pick what the break arm carries
+dtl::control_flow<std::string, int> checked_double(int x) {
+    if (x > 100) {
+        return dtl::cfbreak{std::string{"too large"}};
+    }
+
+    return dtl::cfcontinue{x * 2};
+}
+
+dtl::control_flow<std::string, std::string> doubled_as_string(int x) {
+    return dtl::cfcontinue{std::to_string(DICE_TRY(checked_double(x)))};
+}
+
+int main() {
+    std::cout << "parse_and_halve(\"42\")     = " << parse_and_halve("42").value_or(-1) << "\n";
+    std::cout << "parse_and_halve(\"abc\")    = " << parse_and_halve("abc").error() << "\n";
+
+    std::cout << "describe_first_char(\"hi\") = " << describe_first_char("hi").value_or("<nothing>") << "\n";
+    std::cout << "describe_first_char(\"\")   = " << describe_first_char("").value_or("<nothing>") << "\n";
+
+    std::cout << "doubled_as_string(21)     = " << doubled_as_string(21).get_continue() << "\n";
+    std::cout << "doubled_as_string(1000)   = " << doubled_as_string(1000).get_break() << "\n";
+
+    // The same try_results drive the fallible range algorithms.
+    // try_fold_left stops at the first residual and propagates it.
+    std::array<std::string, 3> const numbers{"1", "2", "3"};
+    auto const sum = dtl::try_fold_left(numbers, 0, [](int acc, std::string const &s) -> std::expected<int, std::string> {
+        return acc + DICE_TRY(parse_int(s));
+    });
+    std::cout << "try_fold_left(sum)        = " << sum.value.value_or(-1) << "\n";
+
+    std::array<std::string, 3> const broken{"1", "nope", "3"};
+    auto const failed = dtl::try_fold_left(broken, 0, [](int acc, std::string const &s) -> std::expected<int, std::string> {
+        return acc + DICE_TRY(parse_int(s));
+    });
+    std::cout << "try_fold_left(broken)     = " << failed.value.error() << "\n";
+    std::cout << "  stopped at              = " << *failed.in << "\n";
+}

--- a/examples/example_try.cpp
+++ b/examples/example_try.cpp
@@ -2,24 +2,24 @@
 #include <dice/template-library/try_traits.hpp>
 
 #include <array>
-#include <expected>
 #include <iostream>
 #include <optional>
 #include <string>
 
 namespace dtl = dice::template_library;
 
-std::expected<int, std::string> parse_int(std::string const &s) {
+// Should be using std::expected but that does not work on clang-18 yet
+std::optional<int> parse_int(std::string const &s) {
     try {
         return std::stoi(s);
     } catch (std::exception const &) {
-        return std::unexpected{"not a number: " + s};
+        return std::nullopt;
     }
 }
 
 // DICE_TRY unwraps the value or returns the error from the enclosing function.
 // Note that the error is propagated even though the output type changes from int to double.
-std::expected<double, std::string> parse_and_halve(std::string const &s) {
+std::optional<double> parse_and_halve(std::string const &s) {
     int const value = DICE_TRY(parse_int(s));
     return static_cast<double>(value) / 2.0;
 }
@@ -48,7 +48,7 @@ dtl::control_flow<std::string, std::string> doubled_as_string(int x) {
 
 int main() {
     std::cout << "parse_and_halve(\"42\")     = " << parse_and_halve("42").value_or(-1) << "\n";
-    std::cout << "parse_and_halve(\"abc\")    = " << parse_and_halve("abc").error() << "\n";
+    std::cout << "parse_and_halve(\"abc\")    = " << !parse_and_halve("abc").has_value() << "\n";
 
     std::cout << "describe_first_char(\"hi\") = " << describe_first_char("hi").value_or("<nothing>") << "\n";
     std::cout << "describe_first_char(\"\")   = " << describe_first_char("").value_or("<nothing>") << "\n";
@@ -59,15 +59,15 @@ int main() {
     // The same try_results drive the fallible range algorithms.
     // try_fold_left stops at the first residual and propagates it.
     std::array<std::string, 3> const numbers{"1", "2", "3"};
-    auto const sum = dtl::try_fold_left(numbers, 0, [](int acc, std::string const &s) -> std::expected<int, std::string> {
+    auto const sum = dtl::try_fold_left(numbers, 0, [](int acc, std::string const &s) -> std::optional<int> {
         return acc + DICE_TRY(parse_int(s));
     });
     std::cout << "try_fold_left(sum)        = " << sum.value.value_or(-1) << "\n";
 
     std::array<std::string, 3> const broken{"1", "nope", "3"};
-    auto const failed = dtl::try_fold_left(broken, 0, [](int acc, std::string const &s) -> std::expected<int, std::string> {
+    auto const failed = dtl::try_fold_left(broken, 0, [](int acc, std::string const &s) -> std::optional<int> {
         return acc + DICE_TRY(parse_int(s));
     });
-    std::cout << "try_fold_left(broken)     = " << failed.value.error() << "\n";
+    std::cout << "try_fold_left(broken)     = " << !failed.value.has_value() << "\n";
     std::cout << "  stopped at              = " << *failed.in << "\n";
 }

--- a/include/dice/template-library/control_flow.hpp
+++ b/include/dice/template-library/control_flow.hpp
@@ -1,12 +1,8 @@
 #ifndef DICE_TEMPLATELIBRARY_CONTROLFLOW_HPP
 #define DICE_TEMPLATELIBRARY_CONTROLFLOW_HPP
 
-#include "type_traits.hpp"
-
-
-#include <dice/template-library/overloaded.hpp>
 #include <dice/template-library/variant2.hpp>
-#include <expected>
+#include <dice/template-library/type_traits.hpp>
 
 namespace dice::template_library {
     template<typename T>

--- a/include/dice/template-library/control_flow.hpp
+++ b/include/dice/template-library/control_flow.hpp
@@ -5,23 +5,30 @@
 #include <dice/template-library/type_traits.hpp>
 
 namespace dice::template_library {
+    /**
+     * The break arm of a control_flow: stop the computation and propagate value to the caller.
+     */
     template<typename T>
     struct cfbreak {
         T value;
 
-        bool operator==(cfbreak const &other) const noexcept = default;
-        auto operator<=>(cfbreak const &other) const noexcept = default;
+        bool operator==(cfbreak const &other) const = default;
+        auto operator<=>(cfbreak const &other) const = default;
     };
 
     template<>
     struct cfbreak<void>;
 
+    /**
+     * The continue arm of a control_flow: carry on with value.
+     * Defaults to std::monostate for computations that have nothing to carry (see try_for_each).
+     */
     template<typename T = std::monostate>
     struct cfcontinue {
         T value;
 
-        bool operator==(cfcontinue const &other) const noexcept = default;
-        auto operator<=>(cfcontinue const &other) const noexcept = default;
+        bool operator==(cfcontinue const &other) const = default;
+        auto operator<=>(cfcontinue const &other) const = default;
     };
 
     template<>
@@ -56,6 +63,16 @@ namespace dice::template_library {
         };
     } // namespace detail_control_flow
 
+    /**
+     * Rust like ControlFlow: holds either a cfbreak<B>, telling the caller to stop and propagate the break value,
+     * or a cfcontinue<C>, telling it to carry on with the continue value. Used by the try_* range algorithms to
+     * decide whether to keep iterating (see try_traits::branch).
+     *
+     * Either arm may be void to express that it cannot occur, e.g. control_flow<E, void> can only ever break.
+     *
+     * @tparam B break type, void if the computation cannot break
+     * @tparam C continue type, void if the computation cannot continue
+     */
     template<typename B, typename C = std::monostate>
     struct control_flow {
         static constexpr bool has_break = !std::is_void_v<B>;
@@ -102,8 +119,18 @@ namespace dice::template_library {
         {
         }
 
+        constexpr control_flow(control_flow<B, void> &&other) requires (has_break)
+            : control_flow{in_place_break, std::move(other).get_break()}
+        {
+        }
+
         constexpr control_flow(control_flow<void, C> const &other) requires (has_continue)
             : control_flow{in_place_continue, other.get_continue()}
+        {
+        }
+
+        constexpr control_flow(control_flow<void, C> &&other) requires (has_continue)
+            : control_flow{in_place_continue, std::move(other).get_continue()}
         {
         }
 
@@ -130,8 +157,8 @@ namespace dice::template_library {
             return visit(std::forward<F>(visitor), dice::template_library::forward_like<Self>(self.data_));
         }
 
-        bool operator==(control_flow const &other) const noexcept = default;
-        auto operator<=>(control_flow const &other) const noexcept = default;
+        bool operator==(control_flow const &other) const = default;
+        auto operator<=>(control_flow const &other) const = default;
     };
 
 } // namespace dice::template_library

--- a/include/dice/template-library/control_flow.hpp
+++ b/include/dice/template-library/control_flow.hpp
@@ -1,0 +1,143 @@
+#ifndef DICE_TEMPLATELIBRARY_CONTROLFLOW_HPP
+#define DICE_TEMPLATELIBRARY_CONTROLFLOW_HPP
+
+#include "type_traits.hpp"
+
+
+#include <dice/template-library/overloaded.hpp>
+#include <dice/template-library/variant2.hpp>
+#include <expected>
+
+namespace dice::template_library {
+    template<typename T>
+    struct cfbreak {
+        T value;
+
+        bool operator==(cfbreak const &other) const noexcept = default;
+        auto operator<=>(cfbreak const &other) const noexcept = default;
+    };
+
+    template<>
+    struct cfbreak<void>;
+
+    template<typename T = std::monostate>
+    struct cfcontinue {
+        T value;
+
+        bool operator==(cfcontinue const &other) const noexcept = default;
+        auto operator<=>(cfcontinue const &other) const noexcept = default;
+    };
+
+    template<>
+    struct cfcontinue<void>;
+
+
+    struct in_place_break_t {};
+    inline constexpr in_place_break_t in_place_break{};
+
+    struct in_place_continue_t {};
+    inline constexpr in_place_continue_t in_place_continue{};
+
+
+    namespace detail_control_flow {
+        template<typename B, typename C>
+        struct select_impl {
+            static constexpr size_t continue_index = 0;
+            static constexpr size_t break_index = 1;
+            using type = dice::template_library::variant<cfcontinue<C>, cfbreak<B>>;
+        };
+
+        template<typename B>
+        struct select_impl<B, void> {
+            static constexpr size_t break_index = 0;
+            using type = dice::template_library::variant<cfbreak<B>>;
+        };
+
+        template<typename C>
+        struct select_impl<void, C> {
+            static constexpr size_t continue_index = 0;
+            using type = dice::template_library::variant<cfcontinue<C>>;
+        };
+    } // namespace detail_control_flow
+
+    template<typename B, typename C = std::monostate>
+    struct control_flow {
+        static constexpr bool has_break = !std::is_void_v<B>;
+        static constexpr bool has_continue = !std::is_void_v<C>;
+
+    private:
+        template<typename, typename>
+        friend struct control_flow;
+
+        using select = detail_control_flow::select_impl<B, C>;
+        select::type data_;
+
+    public:
+        control_flow() = delete;
+
+        constexpr control_flow(cfcontinue<C> const &cont) requires (has_continue)
+            : data_{cont} {
+        }
+        constexpr control_flow(cfcontinue<C> &&cont) requires (has_continue)
+            : data_{std::move(cont)} {
+        }
+
+        constexpr control_flow(cfbreak<B> const &brk) requires (has_break)
+            : data_{brk} {
+        }
+        constexpr control_flow(cfbreak<B> &&brk) requires (has_break)
+            : data_{std::move(brk)} {
+        }
+
+        template<typename ...Args> requires (has_continue)
+        explicit constexpr control_flow(in_place_continue_t, Args &&...args)
+            : data_{std::in_place_index<select::continue_index>, std::forward<Args>(args)...}
+        {
+        }
+
+        template<typename ...Args> requires (has_break)
+        explicit constexpr control_flow(in_place_break_t, Args &&...args)
+            : data_{std::in_place_index<select::break_index>, std::forward<Args>(args)...}
+        {
+        }
+
+        constexpr control_flow(control_flow<B, void> const &other) requires (has_break)
+            : control_flow{in_place_break, other.get_break()}
+        {
+        }
+
+        constexpr control_flow(control_flow<void, C> const &other) requires (has_continue)
+            : control_flow{in_place_continue, other.get_continue()}
+        {
+        }
+
+        [[nodiscard]] constexpr bool is_continue() const noexcept requires (has_continue) {
+            return data_.index() == select::continue_index;
+        }
+
+        [[nodiscard]] constexpr bool is_break() const noexcept requires (has_break) {
+            return data_.index() == select::break_index;
+        }
+
+        template<typename Self>
+        [[nodiscard]] constexpr decltype(auto) get_continue(this Self &&self) requires (has_continue) {
+            return dice::template_library::forward_like<Self>(get<cfcontinue<C>>(self.data_).value);
+        }
+
+        template<typename Self>
+        [[nodiscard]] constexpr decltype(auto) get_break(this Self &&self) requires (has_break) {
+            return dice::template_library::forward_like<Self>(get<cfbreak<B>>(self.data_).value);
+        }
+
+        template<typename Self, typename F> requires (std::is_same_v<std::remove_cvref_t<Self>, control_flow>)
+        friend constexpr decltype(auto) visit(F &&visitor, Self &&self) {
+            return visit(std::forward<F>(visitor), dice::template_library::forward_like<Self>(self.data_));
+        }
+
+        bool operator==(control_flow const &other) const noexcept = default;
+        auto operator<=>(control_flow const &other) const noexcept = default;
+    };
+
+} // namespace dice::template_library
+
+#endif // DICE_TEMPLATELIBRARY_CONTROLFLOW_HPP

--- a/include/dice/template-library/ranges.hpp
+++ b/include/dice/template-library/ranges.hpp
@@ -4,6 +4,7 @@
 #include <dice/template-library/next_to_range.hpp>
 #include <dice/template-library/control_flow.hpp>
 #include <dice/template-library/try_traits.hpp>
+#include <dice/template-library/type_traits.hpp>
 
 #include <algorithm>
 #include <functional>
@@ -784,7 +785,7 @@ namespace dice::template_library {
             requires (try_result<try_for_each_pred_result_t<Pred, std::ranges::iterator_t<R>>>
                       && try_for_each_output<typename try_traits<try_for_each_pred_result_t<Pred, std::ranges::iterator_t<R>>>::output_type>)
             [[nodiscard]] constexpr try_for_each_pred_result_t<Pred, std::ranges::iterator_t<R>> operator()(R &&range, Pred pred) const {
-                return try_for_each_fn{}(std::ranges::begin(range), std::ranges::end(range), pred);
+                return try_for_each_fn{}(std::ranges::begin(range), std::ranges::end(range), std::move(pred));
             }
         };
     }  // namespace ranges_algo_detail

--- a/include/dice/template-library/ranges.hpp
+++ b/include/dice/template-library/ranges.hpp
@@ -2,6 +2,8 @@
 #define DICE_TEMPLATELIBRARY_HPP
 
 #include <dice/template-library/next_to_range.hpp>
+#include <dice/template-library/control_flow.hpp>
+#include <dice/template-library/try_traits.hpp>
 
 #include <algorithm>
 #include <functional>
@@ -690,6 +692,212 @@ namespace dice::template_library {
      * @return lexicographical three-way compare result of the two ranges
      */
     inline constexpr ranges_algo_detail::lexicographical_compare_three_way_fn lexicographical_compare_three_way;
+
+
+    namespace ranges_algo_detail {
+        template<typename Pred, typename Acc, typename I>
+        using try_fold_left_pred_result_t = std::invoke_result_t<Pred, Acc, std::iter_reference_t<I>>;
+
+        struct try_fold_left_fn {
+            template<std::input_iterator I, std::sentinel_for<I> S, typename Acc, typename Pred>
+            requires (try_result<try_fold_left_pred_result_t<Pred, Acc, I>>)
+            [[nodiscard]] constexpr try_fold_left_pred_result_t<Pred, Acc, I> operator()(I first, S last, Acc init, Pred pred) const {
+                using ret_type = try_fold_left_pred_result_t<Pred, Acc, I>;
+                using traits = try_traits<ret_type>;
+
+                for (; first != last; ++first) {
+                    auto ret = traits::branch(std::invoke(pred, std::move(init), *first));
+                    if (ret.is_break()) {
+                        return std::move(ret).get_break();
+                    }
+
+                    init = std::move(ret).get_continue();
+                }
+
+                return traits::from_output(std::move(init));
+            }
+
+            template<std::ranges::input_range R, typename Acc, typename Pred>
+            requires (try_result<try_fold_left_pred_result_t<Pred, Acc, std::ranges::iterator_t<R>>>)
+            [[nodiscard]] constexpr try_fold_left_pred_result_t<Pred, Acc, std::ranges::iterator_t<R>> operator()(R &&range, Acc init, Pred pred) const {
+                return try_fold_left_fn{}(std::ranges::begin(range), std::ranges::end(range), std::move(init), std::move(pred));
+            }
+        };
+    }  // namespace ranges_algo_detail
+
+    /**
+     * Folds every element of the given range into an accumulator by applying a fallible function, stopping at the
+     * first break/residual (i.e. a nullopt, an unexpected or a cfbreak) and propagating it.
+     * This can be thought of as the fallible form of std::ranges::fold_left.
+     *
+     * @param range or first+last range to fold
+     * @param init initial value of the accumulator
+     * @param pred fallible binary function applied to the accumulator and each element, its output/continue value
+     *      becomes the accumulator for the next element
+     * @return the residual of the first breaking invocation of pred, otherwise - including for an empty range -
+     *      pred's try-type constructed from the final accumulator
+     *
+     * @par Example:
+     * @code
+     * auto r = dtl::try_fold_left(dtl::range(1, 6), 0, [](int acc, int x) -> std::optional<int> {
+     *     if (acc > 5) {
+     *         return std::nullopt;
+     *     }
+     *
+     *     return acc + x;
+     * });
+     *
+     * assert(r == std::nullopt);
+     * @endcode
+     *
+     * @see try_for_each, try_fold_left_first
+     */
+    inline constexpr ranges_algo_detail::try_fold_left_fn try_fold_left;
+
+
+    namespace ranges_algo_detail {
+        template<typename Pred, typename I>
+        using try_for_each_pred_result_t = std::invoke_result_t<Pred, std::iter_reference_t<I>>;
+
+        template<typename T>
+        concept try_for_each_output = is_zst_v<T> && std::is_default_constructible_v<T>;
+
+        struct try_for_each_fn {
+            template<std::input_iterator I, std::sentinel_for<I> S, typename Pred>
+            requires (try_result<try_for_each_pred_result_t<Pred, I>>
+                      && try_for_each_output<typename try_traits<try_for_each_pred_result_t<Pred, I>>::output_type>)
+            [[nodiscard]] constexpr try_for_each_pred_result_t<Pred, I> operator()(I first, S last, Pred pred) const {
+                using ret_type = try_for_each_pred_result_t<Pred, I>;
+                using traits = try_traits<ret_type>;
+
+                for (; first != last; ++first) {
+                    auto ret = traits::branch(std::invoke(pred, *first));
+                    if (ret.is_break()) {
+                        return std::move(ret).get_break();
+                    }
+                }
+
+                return traits::from_output(typename traits::output_type{});
+            }
+
+            template<std::ranges::input_range R, typename Pred>
+            requires (try_result<try_for_each_pred_result_t<Pred, std::ranges::iterator_t<R>>>
+                      && try_for_each_output<typename try_traits<try_for_each_pred_result_t<Pred, std::ranges::iterator_t<R>>>::output_type>)
+            [[nodiscard]] constexpr try_for_each_pred_result_t<Pred, std::ranges::iterator_t<R>> operator()(R &&range, Pred pred) const {
+                return try_for_each_fn{}(std::ranges::begin(range), std::ranges::end(range), pred);
+            }
+        };
+    }  // namespace ranges_algo_detail
+
+    /**
+     * Applies a fallible function to each element of the given range, stopping at the first break/residual
+     * (i.e. a nullopt, an unexpected or a cfbreak) and propagating it.
+     * This can be thought of as the fallible form of std::ranges::for_each.
+     *
+     * pred's try-type must have a unit-like (ZST) output type, e.g. std::optional<std::monostate> or
+     * control_flow<E>, as there is nothing meaningful to return for a fully iterated range.
+     *
+     * @param range or first+last range to iterate over
+     * @param pred fallible unary function applied to each element
+     * @return the residual of the first breaking invocation of pred, otherwise - including for an empty range -
+     *      pred's try-type constructed from a default constructed output
+     *
+     * @par Example:
+     * @code
+     * auto r = dtl::try_for_each(dtl::range(2, 100), [](auto const &x) -> dtl::control_flow<int> {
+     *     if (323 % x == 0) {
+     *         return dtl::cfbreak{x};
+     *     }
+     *
+     *     return dtl::cfcontinue<>{};
+     * });
+     *
+     * assert(r == dtl::cfbreak{17});
+     * @endcode
+     *
+     * @see try_fold_left, try_fold_left_first
+     */
+    inline constexpr ranges_algo_detail::try_for_each_fn try_for_each;
+
+
+    namespace ranges_algo_detail {
+        template<typename Pred, typename I>
+        using try_fold_left_first_pred_result_t = std::invoke_result_t<Pred, std::iter_value_t<I>, std::iter_reference_t<I>>;
+
+        template<typename Pred, typename I>
+        struct try_fold_left_first_result {
+            using pred_result_traits = try_traits<try_fold_left_first_pred_result_t<Pred, I>>;
+            using type = pred_result_traits::template rebind_output<std::optional<typename pred_result_traits::output_type>>;
+        };
+
+        template<typename Pred, typename T>
+        using try_fold_left_first_result_t = try_fold_left_first_result<Pred, T>::type;
+
+        struct try_fold_left_first_fn {
+            template<std::input_iterator I, std::sentinel_for<I> S, typename Pred>
+            requires (try_result<try_fold_left_first_pred_result_t<Pred, I>>)
+            [[nodiscard]] constexpr try_fold_left_first_result_t<Pred, I> operator()(I first, S last, Pred pred) const {
+                using traits = try_traits<try_fold_left_first_pred_result_t<Pred, I>>;
+                using result_traits = try_traits<try_fold_left_first_result_t<Pred, I>>;
+                using acc_type = traits::output_type;
+
+                if (first == last) {
+                    return result_traits::from_output(std::nullopt);
+                }
+
+                acc_type init = *first;
+                ++first;
+
+                auto ret = traits::branch(try_fold_left_fn{}(std::move(first), std::move(last), std::move(init), std::move(pred)));
+                if (ret.is_break()) {
+                    return std::move(ret).get_break();
+                }
+
+                return result_traits::from_output(std::move(ret).get_continue());
+            }
+
+            template<std::ranges::input_range R, typename Pred>
+            requires (try_result<try_fold_left_first_pred_result_t<Pred, std::ranges::iterator_t<R>>>)
+            [[nodiscard]] constexpr try_fold_left_first_result_t<Pred, std::ranges::iterator_t<R>> operator()(R &&range, Pred pred) const {
+                return try_fold_left_first_fn{}(std::ranges::begin(range), std::ranges::end(range), std::move(pred));
+            }
+        };
+    } // ranges_algo_detail
+
+    /**
+     * Like try_fold_left, but uses the first element of the range as the initial accumulator value instead of an explicit init.
+     * This can be thought of as the fallible form of std::ranges::fold_left_first.
+     *
+     * The output/continue type is wrapped in a std::optional to be able to express the empty range case,
+     * e.g. reducing with a pred returning std::expected<T, E> yields std::expected<std::optional<T>, E>.
+     *
+     * @param range or first+last range to reduce
+     * @param pred fallible binary function applied to the accumulator and each element but the first, its
+     *      output/continue value becomes the accumulator for the next element
+     * @return the residual of the first breaking invocation of pred, otherwise pred's try-type constructed from
+     *      the final accumulator, or from nullopt if the range was empty
+     *
+     * @par Example:
+     * @code
+     * // note the optional output type
+     * using result_type = std::expected<std::optional<int>, std::string>;
+     *
+     * auto sum = dtl::try_fold_left_first(dtl::range(1, 6), [](int acc, int x) -> std::expected<int, std::string> {
+     *     return acc + x;
+     * });
+     *
+     * assert(sum == result_type{15});
+     *
+     * auto empty = dtl::try_fold_left_first(std::views::empty<int>, [](int acc, int x) -> std::expected<int, std::string> {
+     *     return acc + x;
+     * });
+     *
+     * assert(empty == result_type{std::nullopt});
+     * @endcode
+     *
+     * @see try_fold_left, try_for_each
+     */
+    inline constexpr ranges_algo_detail::try_fold_left_first_fn try_fold_left_first;
 
 }// namespace dice::template_library
 

--- a/include/dice/template-library/ranges.hpp
+++ b/include/dice/template-library/ranges.hpp
@@ -695,6 +695,9 @@ namespace dice::template_library {
     inline constexpr ranges_algo_detail::lexicographical_compare_three_way_fn lexicographical_compare_three_way;
 
 
+    template<typename I, typename T>
+    using try_fold_left_result = std::ranges::in_value_result<I, T>;
+
     namespace ranges_algo_detail {
         template<typename Pred, typename Acc, typename I>
         using try_fold_left_pred_result_t = std::invoke_result_t<Pred, Acc, std::iter_reference_t<I>>;
@@ -702,25 +705,25 @@ namespace dice::template_library {
         struct try_fold_left_fn {
             template<std::input_iterator I, std::sentinel_for<I> S, typename Acc, typename Pred>
             requires (try_result<try_fold_left_pred_result_t<Pred, Acc, I>>)
-            [[nodiscard]] constexpr try_fold_left_pred_result_t<Pred, Acc, I> operator()(I first, S last, Acc init, Pred pred) const {
+            [[nodiscard]] constexpr try_fold_left_result<I, try_fold_left_pred_result_t<Pred, Acc, I>> operator()(I first, S last, Acc init, Pred pred) const {
                 using ret_type = try_fold_left_pred_result_t<Pred, Acc, I>;
                 using traits = try_traits<ret_type>;
 
                 for (; first != last; ++first) {
                     auto ret = traits::branch(std::invoke(pred, std::move(init), *first));
                     if (ret.is_break()) {
-                        return std::move(ret).get_break();
+                        return {std::move(first), std::move(ret).get_break()};
                     }
 
                     init = std::move(ret).get_continue();
                 }
 
-                return traits::from_output(std::move(init));
+                return {std::move(first), traits::from_output(std::move(init))};
             }
 
             template<std::ranges::input_range R, typename Acc, typename Pred>
             requires (try_result<try_fold_left_pred_result_t<Pred, Acc, std::ranges::iterator_t<R>>>)
-            [[nodiscard]] constexpr try_fold_left_pred_result_t<Pred, Acc, std::ranges::iterator_t<R>> operator()(R &&range, Acc init, Pred pred) const {
+            [[nodiscard]] constexpr try_fold_left_result<std::ranges::borrowed_iterator_t<R>, try_fold_left_pred_result_t<Pred, Acc, std::ranges::iterator_t<R>>> operator()(R &&range, Acc init, Pred pred) const {
                 return try_fold_left_fn{}(std::ranges::begin(range), std::ranges::end(range), std::move(init), std::move(pred));
             }
         };
@@ -729,14 +732,16 @@ namespace dice::template_library {
     /**
      * Folds every element of the given range into an accumulator by applying a fallible function, stopping at the
      * first break/residual (i.e. a nullopt, an unexpected or a cfbreak) and propagating it.
-     * This can be thought of as the fallible form of std::ranges::fold_left.
+     * This can be thought of as the fallible form of std::ranges::fold_left_with_iter.
      *
      * @param range or first+last range to fold
      * @param init initial value of the accumulator
      * @param pred fallible binary function applied to the accumulator and each element, its output/continue value
      *      becomes the accumulator for the next element
-     * @return the residual of the first breaking invocation of pred, otherwise - including for an empty range -
-     *      pred's try-type constructed from the final accumulator
+     * @return an aggregate of
+     *      - `in`: the iterator to the element that caused the break, or the end iterator if pred never broke
+     *      - `value`: the residual of the first breaking invocation of pred, otherwise - including for an empty
+     *        range - pred's try-type constructed from the final accumulator
      *
      * @par Example:
      * @code
@@ -748,13 +753,31 @@ namespace dice::template_library {
      *     return acc + x;
      * });
      *
-     * assert(r == std::nullopt);
+     * assert(r.value == std::nullopt);
      * @endcode
      *
      * @see try_for_each, try_fold_left_first
      */
     inline constexpr ranges_algo_detail::try_fold_left_fn try_fold_left;
 
+    template<typename I, typename T, typename F>
+    struct try_for_each_result {
+        [[no_unique_address]] I in;
+        T value;
+        [[no_unique_address]] F fun;
+
+        template<typename I2, typename T2, typename F2>
+        requires (std::convertible_to<I const &, I2> && std::convertible_to<T const &, T2> && std::convertible_to<F const &, F2>)
+        constexpr operator try_for_each_result<I2, T2, F2>() const & {
+            return {in, value, fun};
+        }
+
+        template<typename I2, typename T2, typename F2>
+        requires (std::convertible_to<I, I2> && std::convertible_to<T, T2> && std::convertible_to<F, F2>)
+        constexpr operator try_for_each_result<I2, T2, F2>() && {
+            return {std::move(in), std::move(value), std::move(fun)};
+        }
+    };
 
     namespace ranges_algo_detail {
         template<typename Pred, typename I>
@@ -767,24 +790,24 @@ namespace dice::template_library {
             template<std::input_iterator I, std::sentinel_for<I> S, typename Pred>
             requires (try_result<try_for_each_pred_result_t<Pred, I>>
                       && try_for_each_output<typename try_traits<try_for_each_pred_result_t<Pred, I>>::output_type>)
-            [[nodiscard]] constexpr try_for_each_pred_result_t<Pred, I> operator()(I first, S last, Pred pred) const {
+            [[nodiscard]] constexpr try_for_each_result<I, try_for_each_pred_result_t<Pred, I>, Pred> operator()(I first, S last, Pred pred) const {
                 using ret_type = try_for_each_pred_result_t<Pred, I>;
                 using traits = try_traits<ret_type>;
 
                 for (; first != last; ++first) {
                     auto ret = traits::branch(std::invoke(pred, *first));
                     if (ret.is_break()) {
-                        return std::move(ret).get_break();
+                        return {std::move(first), std::move(ret).get_break(), std::move(pred)};
                     }
                 }
 
-                return traits::from_output(typename traits::output_type{});
+                return {std::move(first), traits::from_output(typename traits::output_type{}), std::move(pred)};
             }
 
             template<std::ranges::input_range R, typename Pred>
             requires (try_result<try_for_each_pred_result_t<Pred, std::ranges::iterator_t<R>>>
                       && try_for_each_output<typename try_traits<try_for_each_pred_result_t<Pred, std::ranges::iterator_t<R>>>::output_type>)
-            [[nodiscard]] constexpr try_for_each_pred_result_t<Pred, std::ranges::iterator_t<R>> operator()(R &&range, Pred pred) const {
+            [[nodiscard]] constexpr try_for_each_result<std::ranges::borrowed_iterator_t<R>, try_for_each_pred_result_t<Pred, std::ranges::iterator_t<R>>, Pred> operator()(R &&range, Pred pred) const {
                 return try_for_each_fn{}(std::ranges::begin(range), std::ranges::end(range), std::move(pred));
             }
         };
@@ -800,8 +823,11 @@ namespace dice::template_library {
      *
      * @param range or first+last range to iterate over
      * @param pred fallible unary function applied to each element
-     * @return the residual of the first breaking invocation of pred, otherwise - including for an empty range -
-     *      pred's try-type constructed from a default constructed output
+     * @return an aggregate of
+     *      - `in`: the iterator to the element that caused the break, or the end iterator if pred never broke
+     *      - `value`: the residual of the first breaking invocation of pred, otherwise - including for an empty
+     *        range - pred's try-type constructed from a default constructed output
+     *      - `fun`: pred, moved out of the algorithm
      *
      * @par Example:
      * @code
@@ -813,7 +839,7 @@ namespace dice::template_library {
      *     return dtl::cfcontinue<>{};
      * });
      *
-     * assert(r == dtl::cfbreak{17});
+     * assert(r.value == dtl::cfbreak{17});
      * @endcode
      *
      * @see try_fold_left, try_fold_left_first
@@ -821,45 +847,50 @@ namespace dice::template_library {
     inline constexpr ranges_algo_detail::try_for_each_fn try_for_each;
 
 
+    template<typename I, typename T>
+    using try_fold_left_first_result = std::ranges::in_value_result<I, T>;
+
     namespace ranges_algo_detail {
         template<typename Pred, typename I>
         using try_fold_left_first_pred_result_t = std::invoke_result_t<Pred, std::iter_value_t<I>, std::iter_reference_t<I>>;
 
         template<typename Pred, typename I>
-        struct try_fold_left_first_result {
+        struct try_fold_left_first_mapped_pred_result {
             using pred_result_traits = try_traits<try_fold_left_first_pred_result_t<Pred, I>>;
             using type = pred_result_traits::template rebind_output<std::optional<typename pred_result_traits::output_type>>;
         };
 
         template<typename Pred, typename T>
-        using try_fold_left_first_result_t = try_fold_left_first_result<Pred, T>::type;
+        using try_fold_left_first_mapped_pred_result_t = try_fold_left_first_mapped_pred_result<Pred, T>::type;
 
         struct try_fold_left_first_fn {
             template<std::input_iterator I, std::sentinel_for<I> S, typename Pred>
             requires (try_result<try_fold_left_first_pred_result_t<Pred, I>>)
-            [[nodiscard]] constexpr try_fold_left_first_result_t<Pred, I> operator()(I first, S last, Pred pred) const {
+            [[nodiscard]] constexpr try_fold_left_first_result<I, try_fold_left_first_mapped_pred_result_t<Pred, I>> operator()(I first, S last, Pred pred) const {
                 using traits = try_traits<try_fold_left_first_pred_result_t<Pred, I>>;
-                using result_traits = try_traits<try_fold_left_first_result_t<Pred, I>>;
+                using result_traits = try_traits<try_fold_left_first_mapped_pred_result_t<Pred, I>>;
                 using acc_type = traits::output_type;
 
                 if (first == last) {
-                    return result_traits::from_output(std::nullopt);
+                    return {std::move(first), result_traits::from_output(std::nullopt)};
                 }
 
                 acc_type init = *first;
                 ++first;
 
-                auto ret = traits::branch(try_fold_left_fn{}(std::move(first), std::move(last), std::move(init), std::move(pred)));
+                auto [new_first, result] = try_fold_left_fn{}(std::move(first), std::move(last), std::move(init), std::move(pred));
+
+                auto ret = traits::branch(std::move(result));
                 if (ret.is_break()) {
-                    return std::move(ret).get_break();
+                    return {std::move(new_first), std::move(ret).get_break()};
                 }
 
-                return result_traits::from_output(std::move(ret).get_continue());
+                return {std::move(new_first), result_traits::from_output(std::move(ret).get_continue())};
             }
 
             template<std::ranges::input_range R, typename Pred>
             requires (try_result<try_fold_left_first_pred_result_t<Pred, std::ranges::iterator_t<R>>>)
-            [[nodiscard]] constexpr try_fold_left_first_result_t<Pred, std::ranges::iterator_t<R>> operator()(R &&range, Pred pred) const {
+            [[nodiscard]] constexpr try_fold_left_first_result<std::ranges::borrowed_iterator_t<R>, try_fold_left_first_mapped_pred_result_t<Pred, std::ranges::iterator_t<R>>> operator()(R &&range, Pred pred) const {
                 return try_fold_left_first_fn{}(std::ranges::begin(range), std::ranges::end(range), std::move(pred));
             }
         };
@@ -867,7 +898,7 @@ namespace dice::template_library {
 
     /**
      * Like try_fold_left, but uses the first element of the range as the initial accumulator value instead of an explicit init.
-     * This can be thought of as the fallible form of std::ranges::fold_left_first.
+     * This can be thought of as the fallible form of std::ranges::fold_left_first_with_iter.
      *
      * The output/continue type is wrapped in a std::optional to be able to express the empty range case,
      * e.g. reducing with a pred returning std::expected<T, E> yields std::expected<std::optional<T>, E>.
@@ -875,8 +906,10 @@ namespace dice::template_library {
      * @param range or first+last range to reduce
      * @param pred fallible binary function applied to the accumulator and each element but the first, its
      *      output/continue value becomes the accumulator for the next element
-     * @return the residual of the first breaking invocation of pred, otherwise pred's try-type constructed from
-     *      the final accumulator, or from nullopt if the range was empty
+     * @return an aggregate of
+     *      - `in`: the iterator to the element that caused the break, or the end iterator if pred never broke
+     *      - `value`: the residual of the first breaking invocation of pred, otherwise pred's try-type constructed
+     *        from the final accumulator, or from nullopt if the range was empty
      *
      * @par Example:
      * @code
@@ -887,13 +920,13 @@ namespace dice::template_library {
      *     return acc + x;
      * });
      *
-     * assert(sum == result_type{15});
+     * assert(sum.value == result_type{15});
      *
      * auto empty = dtl::try_fold_left_first(std::views::empty<int>, [](int acc, int x) -> std::expected<int, std::string> {
      *     return acc + x;
      * });
      *
-     * assert(empty == result_type{std::nullopt});
+     * assert(empty.value == result_type{std::nullopt});
      * @endcode
      *
      * @see try_fold_left, try_for_each

--- a/include/dice/template-library/try_traits.hpp
+++ b/include/dice/template-library/try_traits.hpp
@@ -141,4 +141,33 @@ namespace dice::template_library {
 
 } // namespace dice::template_library
 
+/**
+ * Like rust's ? operator.
+ * If the expression is an error/break, returns the error from the current function.
+ * If the expression is not an error/break resolves to the ok/continue value.
+ *
+ * @param expr
+ *
+ * @par Example
+ * @code
+ *
+ * std::expected<int, int> fallible_function()
+ *
+ * auto x = DICE_TRY(
+ *
+ *
+ * @endcode
+ */
+#define DICE_TRY(expr) \
+    ({ \
+        using traits = ::dice::template_library::try_traits<decltype(expr)>; \
+        auto res = traits::branch(std::move(expr)); \
+        if (res.is_break()) {\
+            return std::move(res).get_break(); \
+        } \
+                                       \
+        std::move(res).get_continue(); \
+    })
+
+
 #endif // DICE_TEMPLATELIBRARY_TRYTRAITS_HPP

--- a/include/dice/template-library/try_traits.hpp
+++ b/include/dice/template-library/try_traits.hpp
@@ -3,9 +3,12 @@
 
 #include <dice/template-library/control_flow.hpp>
 #include <dice/template-library/overloaded.hpp>
+#include <dice/template-library/type_traits.hpp>
 
 #include <concepts>
 #include <optional>
+#include <type_traits>
+#include <utility>
 
 #if __has_include(<expected>)
 #include <expected>
@@ -63,7 +66,13 @@ namespace dice::template_library {
     };
 
 
-    template<typename B, typename C>
+    /**
+     * @note constrained to control_flows that have both arms, because a control_flow that cannot continue has
+     *      no output_type and a control_flow that cannot break has no (representable) residual_type.
+     *      Without the constraint, instantiating try_traits for those would be a hard error instead of
+     *      making them simply not satisfy try_result.
+     */
+    template<typename B, typename C> requires (!std::is_void_v<B> && !std::is_void_v<C>)
     struct try_traits<control_flow<B, C>> {
         using self_type = control_flow<B, C>;
         using output_type = C;
@@ -72,11 +81,11 @@ namespace dice::template_library {
         template<typename Out>
         using rebind_output = control_flow<B, Out>;
 
-        static constexpr self_type from_output(output_type &&out) {
+        static constexpr self_type from_output(output_type out) {
             return cfcontinue{std::move(out)};
         }
 
-        static constexpr control_flow<residual_type, output_type> branch(self_type &&self) {
+        static constexpr control_flow<residual_type, output_type> branch(self_type self) {
             return match(std::move(self),
                 [](cfcontinue<C> &&cont) -> control_flow<residual_type, output_type> {
                     return std::move(cont);
@@ -99,11 +108,11 @@ namespace dice::template_library {
         template<typename Out>
         using rebind_output = std::optional<Out>;
 
-        static constexpr self_type from_output(output_type &&out) {
+        static constexpr self_type from_output(output_type out) {
             return self_type{std::move(out)};
         }
 
-        static constexpr control_flow<residual_type, output_type> branch(self_type &&self) {
+        static constexpr control_flow<residual_type, output_type> branch(self_type self) {
             if (self.has_value()) {
                 return control_flow<residual_type, output_type>{in_place_continue, std::move(*self)};
             }
@@ -124,11 +133,11 @@ namespace dice::template_library {
         template<typename Out>
         using rebind_output = std::expected<Out, E>;
 
-        static constexpr self_type from_output(output_type &&out) {
+        static constexpr self_type from_output(output_type out) {
             return self_type{std::in_place, std::move(out)};
         }
 
-        static constexpr control_flow<residual_type, output_type> branch(self_type &&self) {
+        static constexpr control_flow<residual_type, output_type> branch(self_type self) {
             if (self.has_value()) {
                 return control_flow<residual_type, output_type>{in_place_continue, std::move(*self)};
             }
@@ -141,6 +150,8 @@ namespace dice::template_library {
 
 } // namespace dice::template_library
 
+#if defined(__GNUC__) || defined(__clang__)
+
 /**
  * Like rust's ? operator.
  * If the expression is an error/break, returns the error from the current function.
@@ -150,24 +161,33 @@ namespace dice::template_library {
  *
  * @par Example
  * @code
+ * std::expected<int, int> fallible_function();
  *
- * std::expected<int, int> fallible_function()
- *
- * auto x = DICE_TRY(
- *
- *
+ * std::expected<int, int> func() {
+ *     int x = DICE_TRY(fallible_function());
+ *     return x + 1;
+ * }
  * @endcode
+ *
+ * Requires compiler extensions to work. But good news, they have been in the compilers
+ * since basically the beginning.
  */
-#define DICE_TRY(expr) \
-    ({ \
-        using traits = ::dice::template_library::try_traits<decltype(expr)>; \
-        auto res = traits::branch(std::move(expr)); \
-        if (res.is_break()) {\
-            return std::move(res).get_break(); \
-        } \
-                                       \
-        std::move(res).get_continue(); \
+#define DICE_TRY(...)                                                                                 \
+    ({                                                                                                \
+        decltype(auto) _dice_try_expr = (__VA_ARGS__);                                                \
+        using _dice_try_expr_type = std::remove_cvref_t<decltype(_dice_try_expr)>;                    \
+        static_assert(::dice::template_library::try_result<_dice_try_expr_type>,                      \
+                      "The expression passed to DICE_TRY must be a try_result (e.g. std::optional)"); \
+        using _dice_try_traits = ::dice::template_library::try_traits<_dice_try_expr_type>;           \
+                                                                                                      \
+        auto _dice_try_res = _dice_try_traits::branch(DICE_MOVE_IF_VALUE(_dice_try_expr));            \
+        if (_dice_try_res.is_break()) {                                                               \
+            return std::move(_dice_try_res).get_break();                                              \
+        }                                                                                             \
+                                                                                                      \
+        std::move(_dice_try_res).get_continue();                                                      \
     })
 
+#endif // defined(__GNUC__) || defined(__clang__)
 
 #endif // DICE_TEMPLATELIBRARY_TRYTRAITS_HPP

--- a/include/dice/template-library/try_traits.hpp
+++ b/include/dice/template-library/try_traits.hpp
@@ -1,0 +1,136 @@
+#ifndef DICE_TEMPLATELIBRARY_TRYTRAITS_HPP
+#define DICE_TEMPLATELIBRARY_TRYTRAITS_HPP
+
+#include <dice/template-library/control_flow.hpp>
+#include <dice/template-library/overloaded.hpp>
+
+#include <concepts>
+#include <optional>
+
+#if __has_include(<expected>)
+#include <expected>
+#endif // __has_include(<expected>)
+
+namespace dice::template_library {
+
+    template<typename T>
+    struct try_traits;
+
+    /**
+     * A type that can be used in try_* algorithms.
+     */
+    template<typename T>
+    concept try_result = requires (T self, typename try_traits<T>::output_type out) {
+        /**
+         * The non-error value produced by unwrapping an instance of self.
+         * e.g. for optional<T> this is T
+         */
+        typename try_traits<T>::output_type;
+
+        /**
+         * All possible values of self which are **not** represented in output_type.
+         */
+        typename try_traits<T>::residual_type;
+
+        /**
+         * Rebind the output_type of self.
+         */
+        typename try_traits<T>::template rebind_output<int>;
+
+        /**
+         * Construct self from the output_type.
+         */
+        { try_traits<T>::from_output(std::move(out)) } -> std::same_as<T>;
+
+        /**
+         * Used to decide if a value is produced (cfcontinue) or a value should be propagated to the caller (cfbreak).
+         */
+        { try_traits<T>::branch(std::move(self)) } -> std::same_as<control_flow<typename try_traits<T>::residual_type, typename try_traits<T>::output_type>>;
+
+        /**
+         * rebinding the output must keep the residual channel intact, i.e. residuals of T must remain usable as residuals of the rebound type
+         */
+        requires std::same_as<typename try_traits<typename try_traits<T>::template rebind_output<int>>::output_type, int>;
+        requires std::convertible_to<typename try_traits<T>::residual_type, typename try_traits<T>::template rebind_output<int>>;
+    };
+
+
+    template<typename B, typename C>
+    struct try_traits<control_flow<B, C>> {
+        using self_type = control_flow<B, C>;
+        using output_type = C;
+        using residual_type = control_flow<B, void>;
+
+        template<typename Out>
+        using rebind_output = control_flow<B, Out>;
+
+        static self_type from_output(output_type &&out) {
+            return cfcontinue{std::move(out)};
+        }
+
+        static control_flow<residual_type, output_type> branch(self_type &&self) {
+            return match(std::move(self),
+                [](cfcontinue<C> &&cont) -> control_flow<residual_type, output_type> {
+                    return std::move(cont);
+                },
+                [](cfbreak<B> &&brk) -> control_flow<residual_type, output_type> {
+                    return control_flow<residual_type, output_type>{in_place_break, std::move(brk)};
+                }
+            );
+        }
+    };
+    static_assert(try_result<control_flow<int, int>>);
+
+
+    template<typename T>
+    struct try_traits<std::optional<T>> {
+        using self_type = std::optional<T>;
+        using output_type = T;
+        using residual_type = std::nullopt_t;
+
+        template<typename Out>
+        using rebind_output = std::optional<Out>;
+
+        static self_type from_output(output_type &&out) {
+            return self_type{std::move(out)};
+        }
+
+        static control_flow<residual_type, output_type> branch(self_type &&self) {
+            if (self.has_value()) {
+                return control_flow<residual_type, output_type>{in_place_continue, std::move(*self)};
+            }
+
+            return control_flow<residual_type, output_type>{in_place_break, std::nullopt};
+        }
+    };
+    static_assert(try_result<std::optional<int>>);
+
+
+#if __cpp_lib_expected >= 202202L
+    template<typename T, typename E>
+    struct try_traits<std::expected<T, E>> {
+        using self_type = std::expected<T, E>;
+        using output_type = T;
+        using residual_type = std::unexpected<E>;
+
+        template<typename Out>
+        using rebind_output = std::expected<Out, E>;
+
+        static self_type from_output(output_type &&out) {
+            return self_type{std::in_place, std::move(out)};
+        }
+
+        static control_flow<residual_type, output_type> branch(self_type &&self) {
+            if (self.has_value()) {
+                return control_flow<residual_type, output_type>{in_place_continue, std::move(*self)};
+            }
+
+            return control_flow<residual_type, output_type>{in_place_break, std::unexpected{std::move(self.error())}};
+        }
+    };
+    static_assert(try_result<std::expected<int, int>>);
+#endif // __cpp_lib_expected >= 202202L
+
+} // namespace dice::template_library
+
+#endif // DICE_TEMPLATELIBRARY_TRYTRAITS_HPP

--- a/include/dice/template-library/try_traits.hpp
+++ b/include/dice/template-library/try_traits.hpp
@@ -16,6 +16,14 @@ namespace dice::template_library {
     template<typename T>
     struct try_traits;
 
+    namespace detail_try_traits {
+        /**
+         * just a type to check rebind to avoid using
+         * any fixed type that could have been in the try_result before rebind
+         */
+        struct rebind_probe {};
+    } // detail_try_traits
+
     /**
      * A type that can be used in try_* algorithms.
      */
@@ -35,7 +43,7 @@ namespace dice::template_library {
         /**
          * Rebind the output_type of self.
          */
-        typename try_traits<T>::template rebind_output<int>;
+        typename try_traits<T>::template rebind_output<detail_try_traits::rebind_probe>;
 
         /**
          * Construct self from the output_type.
@@ -50,8 +58,8 @@ namespace dice::template_library {
         /**
          * rebinding the output must keep the residual channel intact, i.e. residuals of T must remain usable as residuals of the rebound type
          */
-        requires std::same_as<typename try_traits<typename try_traits<T>::template rebind_output<int>>::output_type, int>;
-        requires std::convertible_to<typename try_traits<T>::residual_type, typename try_traits<T>::template rebind_output<int>>;
+        requires std::same_as<typename try_traits<typename try_traits<T>::template rebind_output<detail_try_traits::rebind_probe>>::output_type, detail_try_traits::rebind_probe>;
+        requires std::convertible_to<typename try_traits<T>::residual_type, typename try_traits<T>::template rebind_output<detail_try_traits::rebind_probe>>;
     };
 
 
@@ -64,11 +72,11 @@ namespace dice::template_library {
         template<typename Out>
         using rebind_output = control_flow<B, Out>;
 
-        static self_type from_output(output_type &&out) {
+        static constexpr self_type from_output(output_type &&out) {
             return cfcontinue{std::move(out)};
         }
 
-        static control_flow<residual_type, output_type> branch(self_type &&self) {
+        static constexpr control_flow<residual_type, output_type> branch(self_type &&self) {
             return match(std::move(self),
                 [](cfcontinue<C> &&cont) -> control_flow<residual_type, output_type> {
                     return std::move(cont);
@@ -91,11 +99,11 @@ namespace dice::template_library {
         template<typename Out>
         using rebind_output = std::optional<Out>;
 
-        static self_type from_output(output_type &&out) {
+        static constexpr self_type from_output(output_type &&out) {
             return self_type{std::move(out)};
         }
 
-        static control_flow<residual_type, output_type> branch(self_type &&self) {
+        static constexpr control_flow<residual_type, output_type> branch(self_type &&self) {
             if (self.has_value()) {
                 return control_flow<residual_type, output_type>{in_place_continue, std::move(*self)};
             }
@@ -116,11 +124,11 @@ namespace dice::template_library {
         template<typename Out>
         using rebind_output = std::expected<Out, E>;
 
-        static self_type from_output(output_type &&out) {
+        static constexpr self_type from_output(output_type &&out) {
             return self_type{std::in_place, std::move(out)};
         }
 
-        static control_flow<residual_type, output_type> branch(self_type &&self) {
+        static constexpr control_flow<residual_type, output_type> branch(self_type &&self) {
             if (self.has_value()) {
                 return control_flow<residual_type, output_type>{in_place_continue, std::move(*self)};
             }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,3 +129,9 @@ custom_add_test(tests_exchange_channel)
 
 add_executable(tests_sandbox tests_sandbox.cpp)
 custom_add_test(tests_sandbox)
+
+add_executable(tests_control_flow tests_control_flow.cpp)
+custom_add_test(tests_control_flow)
+
+add_executable(tests_try tests_try.cpp)
+custom_add_test(tests_try)

--- a/tests/tests_control_flow.cpp
+++ b/tests/tests_control_flow.cpp
@@ -1,0 +1,222 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <dice/template-library/control_flow.hpp>
+#include <dice/template-library/overloaded.hpp>
+
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace dtl = dice::template_library;
+
+namespace {
+    template<typename T>
+    concept has_is_continue = requires(T cf) { cf.is_continue(); };
+
+    template<typename T>
+    concept has_get_continue = requires(T cf) { cf.get_continue(); };
+
+    template<typename T>
+    concept has_is_break = requires(T cf) { cf.is_break(); };
+
+    template<typename T>
+    concept has_get_break = requires(T cf) { cf.get_break(); };
+} // namespace
+
+TEST_SUITE("cfbreak and cfcontinue") {
+    TEST_CASE("construction") {
+        static_assert(std::same_as<decltype(dtl::cfbreak{42}), dtl::cfbreak<int>>);
+        static_assert(std::same_as<decltype(dtl::cfcontinue{42}), dtl::cfcontinue<int>>);
+
+        // cfcontinue defaults to monostate for computations that have nothing to carry
+        static_assert(std::same_as<dtl::cfcontinue<>, dtl::cfcontinue<std::monostate>>);
+
+        CHECK_EQ(dtl::cfbreak{42}.value, 42);
+        CHECK_EQ(dtl::cfcontinue{42}.value, 42);
+    }
+
+    TEST_CASE("comparison") {
+        CHECK_EQ(dtl::cfbreak{42}, dtl::cfbreak{42});
+        CHECK_NE(dtl::cfbreak{42}, dtl::cfbreak{43});
+        CHECK_LT(dtl::cfbreak{42}, dtl::cfbreak{43});
+
+        CHECK_EQ(dtl::cfcontinue{42}, dtl::cfcontinue{42});
+        CHECK_NE(dtl::cfcontinue{42}, dtl::cfcontinue{43});
+        CHECK_LT(dtl::cfcontinue{42}, dtl::cfcontinue{43});
+
+        CHECK_EQ(dtl::cfcontinue<>{}, dtl::cfcontinue<>{});
+    }
+}
+
+TEST_SUITE("control_flow") {
+    using cf_int = dtl::control_flow<std::string, int>;
+
+    static_assert(cf_int::has_break);
+    static_assert(cf_int::has_continue);
+    static_assert(!std::is_default_constructible_v<cf_int>);
+
+    // control_flow defaults its continue type to monostate
+    static_assert(std::same_as<dtl::control_flow<int>, dtl::control_flow<int, std::monostate>>);
+
+    TEST_CASE("construction from an arm") {
+        SUBCASE("continue") {
+            cf_int const cf{dtl::cfcontinue{42}};
+            REQUIRE(cf.is_continue());
+            REQUIRE_FALSE(cf.is_break());
+            CHECK_EQ(cf.get_continue(), 42);
+        }
+
+        SUBCASE("break") {
+            cf_int const cf{dtl::cfbreak{std::string{"stop"}}};
+            REQUIRE(cf.is_break());
+            REQUIRE_FALSE(cf.is_continue());
+            CHECK_EQ(cf.get_break(), "stop");
+        }
+
+        SUBCASE("copy of an arm") {
+            dtl::cfcontinue<int> const cont{42};
+            cf_int const cf{cont};
+            REQUIRE(cf.is_continue());
+            CHECK_EQ(cf.get_continue(), 42);
+            CHECK_EQ(cont.value, 42); // untouched
+        }
+    }
+
+    TEST_CASE("in place construction") {
+        SUBCASE("continue") {
+            cf_int const cf{dtl::in_place_continue, 42};
+            REQUIRE(cf.is_continue());
+            CHECK_EQ(cf.get_continue(), 42);
+        }
+
+        SUBCASE("break") {
+            cf_int const cf{dtl::in_place_break, "stop"};
+            REQUIRE(cf.is_break());
+            CHECK_EQ(cf.get_break(), "stop");
+        }
+    }
+
+    TEST_CASE("get_* propagates the value category of the control_flow") {
+        static_assert(std::same_as<decltype(std::declval<cf_int &>().get_continue()), int &>);
+        static_assert(std::same_as<decltype(std::declval<cf_int const &>().get_continue()), int const &>);
+        static_assert(std::same_as<decltype(std::declval<cf_int &&>().get_continue()), int &&>);
+
+        static_assert(std::same_as<decltype(std::declval<cf_int &>().get_break()), std::string &>);
+        static_assert(std::same_as<decltype(std::declval<cf_int const &>().get_break()), std::string const &>);
+        static_assert(std::same_as<decltype(std::declval<cf_int &&>().get_break()), std::string &&>);
+
+        SUBCASE("mutation through the reference") {
+            cf_int cf{dtl::cfcontinue{42}};
+            cf.get_continue() = 43;
+            CHECK_EQ(cf.get_continue(), 43);
+        }
+
+        SUBCASE("moving the value out") {
+            dtl::control_flow<int, std::unique_ptr<int>> cf{dtl::cfcontinue{std::make_unique<int>(42)}};
+
+            auto const ptr = std::move(cf).get_continue();
+            REQUIRE_NE(ptr, nullptr);
+            CHECK_EQ(*ptr, 42);
+            CHECK_EQ(cf.get_continue(), nullptr); // moved from
+        }
+    }
+
+    TEST_CASE("visit and match") {
+        SUBCASE("visit") {
+            cf_int const cf{dtl::cfcontinue{42}};
+
+            auto const res = visit(dtl::overloaded{
+                                       [](dtl::cfcontinue<int> const &cont) { return cont.value; },
+                                       [](dtl::cfbreak<std::string> const &) { return -1; }},
+                                   cf);
+
+            CHECK_EQ(res, 42);
+        }
+
+        SUBCASE("match") {
+            cf_int const cf{dtl::cfbreak{std::string{"stop"}}};
+
+            auto const res = match(
+                    cf,
+                    [](dtl::cfcontinue<int> const &cont) { return std::to_string(cont.value); },
+                    [](dtl::cfbreak<std::string> const &brk) { return brk.value; });
+
+            CHECK_EQ(res, "stop");
+        }
+    }
+
+    TEST_CASE("comparison") {
+        CHECK_EQ(cf_int{dtl::cfcontinue{42}}, cf_int{dtl::cfcontinue{42}});
+        CHECK_NE(cf_int{dtl::cfcontinue{42}}, cf_int{dtl::cfcontinue{43}});
+        CHECK_NE(cf_int{dtl::cfcontinue{42}}, cf_int{dtl::cfbreak{std::string{"stop"}}});
+        CHECK_EQ(cf_int{dtl::cfbreak{std::string{"stop"}}}, cf_int{dtl::cfbreak{std::string{"stop"}}});
+    }
+
+    TEST_CASE("void arms") {
+        using break_only = dtl::control_flow<std::string, void>;
+        using continue_only = dtl::control_flow<void, int>;
+
+        static_assert(break_only::has_break);
+        static_assert(!break_only::has_continue);
+        static_assert(!continue_only::has_break);
+        static_assert(continue_only::has_continue);
+
+        static_assert(!has_is_continue<break_only>);
+        static_assert(!has_get_continue<break_only>);
+        static_assert(has_is_break<break_only>);
+        static_assert(has_get_break<break_only>);
+
+        static_assert(!has_is_break<continue_only>);
+        static_assert(!has_get_break<continue_only>);
+        static_assert(has_is_continue<continue_only>);
+        static_assert(has_get_continue<continue_only>);
+
+        SUBCASE("break only") {
+            break_only const cf{dtl::cfbreak{std::string{"stop"}}};
+            REQUIRE(cf.is_break());
+            CHECK_EQ(cf.get_break(), "stop");
+        }
+
+        SUBCASE("continue only") {
+            continue_only const cf{dtl::cfcontinue{42}};
+            REQUIRE(cf.is_continue());
+            CHECK_EQ(cf.get_continue(), 42);
+        }
+    }
+
+    TEST_CASE("conversion from a single armed control_flow") {
+        SUBCASE("break only") {
+            dtl::control_flow<std::string, void> const residual{dtl::cfbreak{std::string{"stop"}}};
+
+            cf_int const cf = residual;
+            REQUIRE(cf.is_break());
+            CHECK_EQ(cf.get_break(), "stop");
+            CHECK_EQ(residual.get_break(), "stop"); // copied, not moved
+
+            // the whole point of the conversion: a residual works for any continue type
+            dtl::control_flow<std::string, double> const other = residual;
+            REQUIRE(other.is_break());
+            CHECK_EQ(other.get_break(), "stop");
+        }
+
+        SUBCASE("break only, moved") {
+            dtl::control_flow<std::unique_ptr<int>, void> residual{dtl::cfbreak{std::make_unique<int>(42)}};
+
+            dtl::control_flow<std::unique_ptr<int>, std::string> const cf = std::move(residual);
+            REQUIRE(cf.is_break());
+            REQUIRE_NE(cf.get_break(), nullptr);
+            CHECK_EQ(*cf.get_break(), 42);
+            CHECK_EQ(residual.get_break(), nullptr); // moved from
+        }
+
+        SUBCASE("continue only") {
+            dtl::control_flow<void, int> const cont{dtl::cfcontinue{42}};
+
+            cf_int const cf = cont;
+            REQUIRE(cf.is_continue());
+            CHECK_EQ(cf.get_continue(), 42);
+        }
+    }
+}

--- a/tests/tests_ranges.cpp
+++ b/tests/tests_ranges.cpp
@@ -8,9 +8,12 @@
 #include <cmath>
 #include <iterator>
 #include <list>
+#include <memory>
+#include <optional>
 #include <ranges>
 #include <sstream>
 #include <string>
+#include <variant>
 #include <vector>
 
 namespace dtl = dice::template_library;
@@ -583,5 +586,510 @@ TEST_SUITE("lexicographical_compare_three_way") {
         CHECK_EQ(dtl::lexicographical_compare_three_way(s1.begin(), s1.end(), s2.begin(), s2.end(), cmp), std::strong_ordering::greater);
         CHECK_EQ(dtl::lexicographical_compare_three_way(s1.begin(), s1.end(), s2.begin(), s2.end(), cmp, proj1), std::strong_ordering::equal);
         CHECK_EQ(dtl::lexicographical_compare_three_way(s1.begin(), s1.end(), s2.begin(), s2.end(), cmp, proj1, proj2), std::strong_ordering::less);
+    }
+}
+
+TEST_SUITE("try_fold_left") {
+    TEST_CASE("sanity check") {
+        std::array ints{1, 2, 3, 4, 5};
+
+        SUBCASE("optional") {
+            SUBCASE("continue") {
+                auto res = dtl::try_fold_left(ints, 0, [](int acc, int elem) -> std::optional<int> {
+                    return acc + elem;
+                });
+
+                CHECK_EQ(res, 15);
+            }
+
+            SUBCASE("break") {
+                auto res = dtl::try_fold_left(ints, 0, [](int acc, int elem) -> std::optional<int> {
+                    if (acc > 5) {
+                        return std::nullopt;
+                    }
+
+                    return acc + elem;
+                });
+
+                CHECK_EQ(res, std::nullopt);
+            }
+        }
+
+        SUBCASE("control_flow") {
+            SUBCASE("continue") {
+                auto res = dtl::try_fold_left(ints, 0, [](int acc, int elem) -> dtl::control_flow<int, int> {
+                    return dtl::cfcontinue{acc + elem};
+                });
+
+                CHECK_EQ(res.get_continue(), 15);
+            }
+
+            SUBCASE("break") {
+                auto res = dtl::try_fold_left(ints, 0, [](int acc, int elem) -> dtl::control_flow<int, int> {
+                    if (acc > 5) {
+                        return dtl::cfbreak{acc};
+                    }
+
+                    return dtl::cfcontinue{acc + elem};
+                });
+
+                CHECK_EQ(res.get_break(), 6);
+            }
+        }
+
+#if __cpp_lib_expected >= 202202L
+        SUBCASE("expected") {
+            SUBCASE("continue") {
+                auto res = dtl::try_fold_left(ints, 0, [](int acc, int elem) -> std::expected<int, std::string> {
+                    return acc + elem;
+                });
+
+                REQUIRE(res.has_value());
+                CHECK_EQ(*res, 15);
+            }
+
+            SUBCASE("break") {
+                auto res = dtl::try_fold_left(ints, 0, [](int acc, int elem) -> std::expected<int, std::string> {
+                    if (acc > 5) {
+                        return std::unexpected{"acc too large"};
+                    }
+
+                    return acc + elem;
+                });
+
+                REQUIRE_FALSE(res.has_value());
+                CHECK_EQ(res.error(), "acc too large");
+            }
+        }
+#endif // __cpp_lib_expected >= 202202L
+    }
+
+    TEST_CASE("empty range") {
+        std::array<int, 0> no_ints{};
+
+        SUBCASE("optional") {
+            auto res = dtl::try_fold_left(no_ints, 42, [](int acc, int elem) -> std::optional<int> {
+                return acc + elem;
+            });
+
+            CHECK_EQ(res, 42);
+        }
+
+        SUBCASE("control_flow") {
+            auto res = dtl::try_fold_left(no_ints, 42, [](int acc, int elem) -> dtl::control_flow<int, int> {
+                return dtl::cfcontinue{acc + elem};
+            });
+
+            REQUIRE(res.is_continue());
+            CHECK_EQ(res.get_continue(), 42);
+        }
+
+#if __cpp_lib_expected >= 202202L
+        SUBCASE("expected") {
+            auto res = dtl::try_fold_left(no_ints, 42, [](int acc, int elem) -> std::expected<int, std::string> {
+                return acc + elem;
+            });
+
+            REQUIRE(res.has_value());
+            CHECK_EQ(*res, 42);
+        }
+#endif // __cpp_lib_expected >= 202202L
+    }
+
+    TEST_CASE("iterator and sentinel overload") {
+        std::list<int> ints{1, 2, 3, 4, 5};
+
+        auto res = dtl::try_fold_left(ints.begin(), ints.end(), 0, [](int acc, int elem) -> std::optional<int> {
+            return acc + elem;
+        });
+
+        CHECK_EQ(res, 15);
+    }
+
+    TEST_CASE("pred is not invoked after a break") {
+        std::array ints{1, 2, 3, 4, 5};
+        size_t calls = 0;
+
+        auto res = dtl::try_fold_left(ints, 0, [&calls](int acc, int elem) -> std::optional<int> {
+            ++calls;
+            if (elem == 3) {
+                return std::nullopt;
+            }
+
+            return acc + elem;
+        });
+
+        CHECK_EQ(res, std::nullopt);
+        CHECK_EQ(calls, 3);
+    }
+
+    TEST_CASE("accumulator type independent of element type") {
+        std::array ints{1, 2, 3, 4, 5};
+
+        SUBCASE("continue") {
+            auto res = dtl::try_fold_left(ints, std::string{}, [](std::string acc, int elem) -> std::optional<std::string> {
+                return acc + std::to_string(elem);
+            });
+
+            CHECK_EQ(res, "12345");
+        }
+
+        SUBCASE("break") {
+            auto res = dtl::try_fold_left(ints, std::string{}, [](std::string acc, int elem) -> std::optional<std::string> {
+                if (acc.size() >= 3) {
+                    return std::nullopt;
+                }
+
+                return acc + std::to_string(elem);
+            });
+
+            CHECK_EQ(res, std::nullopt);
+        }
+    }
+
+    TEST_CASE("elements are passed by reference") {
+        std::array ints{1, 2, 3};
+
+        auto res = dtl::try_fold_left(ints, 0, [](int acc, int &elem) -> std::optional<int> {
+            elem *= 2;
+            return acc + elem;
+        });
+
+        CHECK_EQ(res, 12);
+        CHECK_EQ(ints, std::array{2, 4, 6});
+    }
+
+    TEST_CASE("move only accumulator") {
+        std::array ints{1, 2, 3, 4, 5};
+
+        SUBCASE("continue") {
+            auto res = dtl::try_fold_left(ints, std::make_unique<int>(0), [](std::unique_ptr<int> acc, int elem) -> std::optional<std::unique_ptr<int>> {
+                *acc += elem;
+                return std::move(acc);
+            });
+
+            REQUIRE(res.has_value());
+            CHECK_EQ(**res, 15);
+        }
+
+        SUBCASE("break") {
+            auto res = dtl::try_fold_left(ints, std::make_unique<int>(0), [](std::unique_ptr<int> acc, int elem) -> std::optional<std::unique_ptr<int>> {
+                if (*acc > 5) {
+                    return std::nullopt;
+                }
+
+                *acc += elem;
+                return std::move(acc);
+            });
+
+            CHECK_EQ(res, std::nullopt);
+        }
+    }
+
+    TEST_CASE("break and continue type may differ") {
+        std::array ints{1, 2, 3, 4, 5};
+
+        auto res = dtl::try_fold_left(ints, 0, [](int acc, int elem) -> dtl::control_flow<std::string, int> {
+            if (elem == 4) {
+                return dtl::cfbreak{std::string{"hit 4"}};
+            }
+
+            return dtl::cfcontinue{acc + elem};
+        });
+
+        REQUIRE(res.is_break());
+        CHECK_EQ(res.get_break(), "hit 4");
+    }
+
+    TEST_CASE("input only range") {
+        std::istringstream ints{"1 2 3 4 5"};
+        auto view = std::views::istream<int>(ints);
+
+        auto res = dtl::try_fold_left(view, 0, [](int acc, int elem) -> std::optional<int> {
+            return acc + elem;
+        });
+
+        CHECK_EQ(res, 15);
+    }
+}
+
+TEST_SUITE("try_for_each") {
+    TEST_CASE("sanity check") {
+        std::array ints{1, 2, 3, 4, 5};
+
+        SUBCASE("optional") {
+            SUBCASE("continue") {
+                std::vector<int> seen;
+
+                auto res = dtl::try_for_each(ints, [&seen](int elem) -> std::optional<std::monostate> {
+                    seen.push_back(elem);
+                    return std::monostate{};
+                });
+
+                CHECK_NE(res, std::nullopt);
+                CHECK_EQ(seen, std::vector{1, 2, 3, 4, 5});
+            }
+
+            SUBCASE("break") {
+                std::vector<int> seen;
+
+                auto res = dtl::try_for_each(ints, [&seen](int elem) -> std::optional<std::monostate> {
+                    if (elem == 3) {
+                        return std::nullopt;
+                    }
+
+                    seen.push_back(elem);
+                    return std::monostate{};
+                });
+
+                CHECK_EQ(res, std::nullopt);
+                CHECK_EQ(seen, std::vector{1, 2});
+            }
+        }
+
+        SUBCASE("control_flow") {
+            SUBCASE("continue") {
+                auto res = dtl::try_for_each(ints, [](int) -> dtl::control_flow<std::string> {
+                    return dtl::cfcontinue{std::monostate{}};
+                });
+
+                CHECK(res.is_continue());
+            }
+
+            SUBCASE("break") {
+                auto res = dtl::try_for_each(ints, [](int elem) -> dtl::control_flow<std::string> {
+                    if (elem == 4) {
+                        return dtl::cfbreak{std::string{"hit 4"}};
+                    }
+
+                    return dtl::cfcontinue{std::monostate{}};
+                });
+
+                REQUIRE(res.is_break());
+                CHECK_EQ(res.get_break(), "hit 4");
+            }
+        }
+
+#if __cpp_lib_expected >= 202202L
+        SUBCASE("expected") {
+            SUBCASE("continue") {
+                int sum = 0;
+
+                auto res = dtl::try_for_each(ints, [&sum](int elem) -> std::expected<std::monostate, std::string> {
+                    sum += elem;
+                    return std::monostate{};
+                });
+
+                CHECK(res.has_value());
+                CHECK_EQ(sum, 15);
+            }
+
+            SUBCASE("break") {
+                auto res = dtl::try_for_each(ints, [](int elem) -> std::expected<std::monostate, std::string> {
+                    if (elem == 3) {
+                        return std::unexpected{"hit 3"};
+                    }
+
+                    return std::monostate{};
+                });
+
+                REQUIRE_FALSE(res.has_value());
+                CHECK_EQ(res.error(), "hit 3");
+            }
+        }
+#endif // __cpp_lib_expected >= 202202L
+    }
+
+    TEST_CASE("empty range") {
+        std::array<int, 0> no_ints{};
+
+        SUBCASE("optional") {
+            auto res = dtl::try_for_each(no_ints, [](int) -> std::optional<std::monostate> {
+                FAIL("pred must not be called for an empty range");
+                return std::nullopt;
+            });
+
+            CHECK_NE(res, std::nullopt);
+        }
+
+        SUBCASE("control_flow") {
+            auto res = dtl::try_for_each(no_ints, [](int) -> dtl::control_flow<std::string> {
+                FAIL("pred must not be called for an empty range");
+                return dtl::cfbreak{std::string{}};
+            });
+
+            CHECK(res.is_continue());
+        }
+    }
+
+    TEST_CASE("iterator and sentinel overload") {
+        std::list<int> ints{1, 2, 3, 4, 5};
+        int sum = 0;
+
+        auto res = dtl::try_for_each(ints.begin(), ints.end(), [&sum](int elem) -> std::optional<std::monostate> {
+            sum += elem;
+            return std::monostate{};
+        });
+
+        CHECK_NE(res, std::nullopt);
+        CHECK_EQ(sum, 15);
+    }
+
+    TEST_CASE("elements are passed by reference") {
+        std::array ints{1, 2, 3};
+
+        auto res = dtl::try_for_each(ints, [](int &elem) -> std::optional<std::monostate> {
+            elem *= 2;
+            return std::monostate{};
+        });
+
+        CHECK_NE(res, std::nullopt);
+        CHECK_EQ(ints, std::array{2, 4, 6});
+    }
+
+    TEST_CASE("move only elements") {
+        std::vector<std::unique_ptr<int>> ptrs;
+        ptrs.push_back(std::make_unique<int>(1));
+        ptrs.push_back(std::make_unique<int>(2));
+        ptrs.push_back(std::make_unique<int>(3));
+
+        int sum = 0;
+        auto res = dtl::try_for_each(ptrs, [&sum](std::unique_ptr<int> const &ptr) -> std::optional<std::monostate> {
+            sum += *ptr;
+            return std::monostate{};
+        });
+
+        CHECK_NE(res, std::nullopt);
+        CHECK_EQ(sum, 6);
+    }
+
+    TEST_CASE("input only range") {
+        std::istringstream ints{"1 2 3 4 5"};
+        auto view = std::views::istream<int>(ints);
+
+        int sum = 0;
+        auto res = dtl::try_for_each(view, [&sum](int elem) -> std::optional<std::monostate> {
+            sum += elem;
+            return std::monostate{};
+        });
+
+        CHECK_NE(res, std::nullopt);
+        CHECK_EQ(sum, 15);
+    }
+}
+
+TEST_SUITE("try_fold_left_first") {
+    TEST_CASE("sanity check") {
+        std::array ints{1, 2, 3, 4, 5};
+        std::array<int, 0> no_ints{};
+
+        SUBCASE("optional") {
+            SUBCASE("continue") {
+                auto res = dtl::try_fold_left_first(ints, [](int acc, int elem) -> std::optional<int> {
+                    return acc + elem;
+                });
+
+                static_assert(std::is_same_v<decltype(res), std::optional<std::optional<int>>>);
+                CHECK_EQ(res, std::optional<int>{15});
+            }
+
+            SUBCASE("break") {
+                auto res = dtl::try_fold_left_first(ints, [](int acc, int elem) -> std::optional<int> {
+                    if (acc > 5) {
+                        return std::nullopt;
+                    }
+
+                    return acc + elem;
+                });
+
+                CHECK_EQ(res, std::nullopt);
+            }
+
+            SUBCASE("empty range") {
+                auto res = dtl::try_fold_left_first(no_ints, [](int acc, int elem) -> std::optional<int> {
+                    return acc + elem;
+                });
+
+                CHECK_NE(res, std::nullopt);
+                CHECK_EQ(*res, std::nullopt);
+            }
+
+            SUBCASE("single element is never passed to pred") {
+                std::array single{42};
+                auto res = dtl::try_fold_left_first(single, [](int, int) -> std::optional<int> {
+                    FAIL("pred must not be called for a single element range");
+                    return std::nullopt;
+                });
+
+                CHECK_EQ(res, std::optional<int>{42});
+            }
+        }
+
+        SUBCASE("control_flow") {
+            SUBCASE("continue") {
+                auto res = dtl::try_fold_left_first(ints, [](int acc, int elem) -> dtl::control_flow<int, int> {
+                    return dtl::cfcontinue{acc + elem};
+                });
+
+                static_assert(std::is_same_v<decltype(res), dtl::control_flow<int, std::optional<int>>>);
+                CHECK_EQ(res.get_continue(), std::optional<int>{15});
+            }
+
+            SUBCASE("break") {
+                auto res = dtl::try_fold_left_first(ints, [](int acc, int elem) -> dtl::control_flow<int, int> {
+                    if (acc > 5) {
+                        return dtl::cfbreak{acc};
+                    }
+
+                    return dtl::cfcontinue{acc + elem};
+                });
+
+                CHECK_EQ(res.get_break(), 6);
+            }
+
+            SUBCASE("empty range") {
+                auto res = dtl::try_fold_left_first(no_ints, [](int acc, int elem) -> dtl::control_flow<int, int> {
+                    return dtl::cfcontinue{acc + elem};
+                });
+
+                CHECK_EQ(res.get_continue(), std::nullopt);
+            }
+        }
+
+#if __cpp_lib_expected >= 202202L
+        SUBCASE("expected") {
+            SUBCASE("continue") {
+                auto res = dtl::try_fold_left_first(ints.begin(), ints.end(), [](int acc, int elem) -> std::expected<int, std::string> {
+                    return acc + elem;
+                });
+
+                static_assert(std::is_same_v<decltype(res), std::expected<std::optional<int>, std::string>>);
+                REQUIRE(res.has_value());
+                CHECK_EQ(*res, std::optional<int>{15});
+            }
+
+            SUBCASE("break") {
+                auto res = dtl::try_fold_left_first(ints.begin(), ints.end(), [](int acc, int elem) -> std::expected<int, std::string> {
+                    if (acc > 5) {
+                        return std::unexpected{"too large"};
+                    }
+
+                    return acc + elem;
+                });
+
+                REQUIRE_FALSE(res.has_value());
+                CHECK_EQ(res.error(), "too large");
+            }
+
+            SUBCASE("empty range") {
+                auto res = dtl::try_fold_left_first(no_ints.begin(), no_ints.end(), [](int acc, int elem) -> std::expected<int, std::string> {
+                    return acc + elem;
+                });
+
+                REQUIRE(res.has_value());
+                CHECK_EQ(*res, std::nullopt);
+            }
+        }
+#endif // __cpp_lib_expected >= 202202L
     }
 }

--- a/tests/tests_ranges.cpp
+++ b/tests/tests_ranges.cpp
@@ -599,7 +599,8 @@ TEST_SUITE("try_fold_left") {
                     return acc + elem;
                 });
 
-                CHECK_EQ(res, 15);
+                CHECK_EQ(res.in, ints.end());
+                CHECK_EQ(res.value, 15);
             }
 
             SUBCASE("break") {
@@ -611,7 +612,8 @@ TEST_SUITE("try_fold_left") {
                     return acc + elem;
                 });
 
-                CHECK_EQ(res, std::nullopt);
+                CHECK_EQ(res.in, ints.begin() + 3);
+                CHECK_EQ(res.value, std::nullopt);
             }
         }
 
@@ -621,7 +623,8 @@ TEST_SUITE("try_fold_left") {
                     return dtl::cfcontinue{acc + elem};
                 });
 
-                CHECK_EQ(res.get_continue(), 15);
+                CHECK_EQ(res.in, ints.end());
+                CHECK_EQ(res.value.get_continue(), 15);
             }
 
             SUBCASE("break") {
@@ -633,7 +636,8 @@ TEST_SUITE("try_fold_left") {
                     return dtl::cfcontinue{acc + elem};
                 });
 
-                CHECK_EQ(res.get_break(), 6);
+                CHECK_EQ(res.in, ints.begin() + 3);
+                CHECK_EQ(res.value.get_break(), 6);
             }
         }
 
@@ -644,8 +648,9 @@ TEST_SUITE("try_fold_left") {
                     return acc + elem;
                 });
 
-                REQUIRE(res.has_value());
-                CHECK_EQ(*res, 15);
+                CHECK_EQ(res.in, ints.end());
+                REQUIRE(res.value.has_value());
+                CHECK_EQ(*res.value, 15);
             }
 
             SUBCASE("break") {
@@ -657,8 +662,9 @@ TEST_SUITE("try_fold_left") {
                     return acc + elem;
                 });
 
-                REQUIRE_FALSE(res.has_value());
-                CHECK_EQ(res.error(), "acc too large");
+                CHECK_EQ(res.in, ints.begin() + 3);
+                REQUIRE_FALSE(res.value.has_value());
+                CHECK_EQ(res.value.error(), "acc too large");
             }
         }
 #endif // __cpp_lib_expected >= 202202L
@@ -672,7 +678,8 @@ TEST_SUITE("try_fold_left") {
                 return acc + elem;
             });
 
-            CHECK_EQ(res, 42);
+            CHECK_EQ(res.in, no_ints.end());
+            CHECK_EQ(res.value, 42);
         }
 
         SUBCASE("control_flow") {
@@ -680,8 +687,9 @@ TEST_SUITE("try_fold_left") {
                 return dtl::cfcontinue{acc + elem};
             });
 
-            REQUIRE(res.is_continue());
-            CHECK_EQ(res.get_continue(), 42);
+            CHECK_EQ(res.in, no_ints.end());
+            REQUIRE(res.value.is_continue());
+            CHECK_EQ(res.value.get_continue(), 42);
         }
 
 #if __cpp_lib_expected >= 202202L
@@ -690,8 +698,9 @@ TEST_SUITE("try_fold_left") {
                 return acc + elem;
             });
 
-            REQUIRE(res.has_value());
-            CHECK_EQ(*res, 42);
+            CHECK_EQ(res.in, no_ints.end());
+            REQUIRE(res.value.has_value());
+            CHECK_EQ(*res.value, 42);
         }
 #endif // __cpp_lib_expected >= 202202L
     }
@@ -703,7 +712,17 @@ TEST_SUITE("try_fold_left") {
             return acc + elem;
         });
 
-        CHECK_EQ(res, 15);
+        CHECK_EQ(res.in, ints.end());
+        CHECK_EQ(res.value, 15);
+    }
+
+    TEST_CASE("rvalue range yields a dangling iterator") {
+        auto res = dtl::try_fold_left(std::vector{1, 2, 3, 4, 5}, 0, [](int acc, int elem) -> std::optional<int> {
+            return acc + elem;
+        });
+
+        static_assert(std::is_same_v<decltype(res.in), std::ranges::dangling>);
+        CHECK_EQ(res.value, 15);
     }
 
     TEST_CASE("pred is not invoked after a break") {
@@ -719,7 +738,8 @@ TEST_SUITE("try_fold_left") {
             return acc + elem;
         });
 
-        CHECK_EQ(res, std::nullopt);
+        CHECK_EQ(res.in, ints.begin() + 2);
+        CHECK_EQ(res.value, std::nullopt);
         CHECK_EQ(calls, 3);
     }
 
@@ -731,7 +751,8 @@ TEST_SUITE("try_fold_left") {
                 return acc + std::to_string(elem);
             });
 
-            CHECK_EQ(res, "12345");
+            CHECK_EQ(res.in, ints.end());
+            CHECK_EQ(res.value, "12345");
         }
 
         SUBCASE("break") {
@@ -743,7 +764,8 @@ TEST_SUITE("try_fold_left") {
                 return acc + std::to_string(elem);
             });
 
-            CHECK_EQ(res, std::nullopt);
+            CHECK_EQ(res.in, ints.begin() + 3);
+            CHECK_EQ(res.value, std::nullopt);
         }
     }
 
@@ -755,7 +777,8 @@ TEST_SUITE("try_fold_left") {
             return acc + elem;
         });
 
-        CHECK_EQ(res, 12);
+        CHECK_EQ(res.in, ints.end());
+        CHECK_EQ(res.value, 12);
         CHECK_EQ(ints, std::array{2, 4, 6});
     }
 
@@ -768,8 +791,9 @@ TEST_SUITE("try_fold_left") {
                 return std::move(acc);
             });
 
-            REQUIRE(res.has_value());
-            CHECK_EQ(**res, 15);
+            CHECK_EQ(res.in, ints.end());
+            REQUIRE(res.value.has_value());
+            CHECK_EQ(**res.value, 15);
         }
 
         SUBCASE("break") {
@@ -782,7 +806,8 @@ TEST_SUITE("try_fold_left") {
                 return std::move(acc);
             });
 
-            CHECK_EQ(res, std::nullopt);
+            CHECK_EQ(res.in, ints.begin() + 3);
+            CHECK_EQ(res.value, std::nullopt);
         }
     }
 
@@ -797,8 +822,9 @@ TEST_SUITE("try_fold_left") {
             return dtl::cfcontinue{acc + elem};
         });
 
-        REQUIRE(res.is_break());
-        CHECK_EQ(res.get_break(), "hit 4");
+        CHECK_EQ(res.in, ints.begin() + 3);
+        REQUIRE(res.value.is_break());
+        CHECK_EQ(res.value.get_break(), "hit 4");
     }
 
     TEST_CASE("input only range") {
@@ -809,7 +835,8 @@ TEST_SUITE("try_fold_left") {
             return acc + elem;
         });
 
-        CHECK_EQ(res, 15);
+        CHECK(res.in == std::default_sentinel);
+        CHECK_EQ(res.value, 15);
     }
 }
 
@@ -826,7 +853,8 @@ TEST_SUITE("try_for_each") {
                     return std::monostate{};
                 });
 
-                CHECK_NE(res, std::nullopt);
+                CHECK_EQ(res.in, ints.end());
+                CHECK_NE(res.value, std::nullopt);
                 CHECK_EQ(seen, std::vector{1, 2, 3, 4, 5});
             }
 
@@ -842,7 +870,8 @@ TEST_SUITE("try_for_each") {
                     return std::monostate{};
                 });
 
-                CHECK_EQ(res, std::nullopt);
+                CHECK_EQ(res.in, ints.begin() + 2);
+                CHECK_EQ(res.value, std::nullopt);
                 CHECK_EQ(seen, std::vector{1, 2});
             }
         }
@@ -853,7 +882,8 @@ TEST_SUITE("try_for_each") {
                     return dtl::cfcontinue{std::monostate{}};
                 });
 
-                CHECK(res.is_continue());
+                CHECK_EQ(res.in, ints.end());
+                CHECK(res.value.is_continue());
             }
 
             SUBCASE("break") {
@@ -865,8 +895,9 @@ TEST_SUITE("try_for_each") {
                     return dtl::cfcontinue{std::monostate{}};
                 });
 
-                REQUIRE(res.is_break());
-                CHECK_EQ(res.get_break(), "hit 4");
+                CHECK_EQ(res.in, ints.begin() + 3);
+                REQUIRE(res.value.is_break());
+                CHECK_EQ(res.value.get_break(), "hit 4");
             }
         }
 
@@ -880,7 +911,8 @@ TEST_SUITE("try_for_each") {
                     return std::monostate{};
                 });
 
-                CHECK(res.has_value());
+                CHECK_EQ(res.in, ints.end());
+                CHECK(res.value.has_value());
                 CHECK_EQ(sum, 15);
             }
 
@@ -893,8 +925,9 @@ TEST_SUITE("try_for_each") {
                     return std::monostate{};
                 });
 
-                REQUIRE_FALSE(res.has_value());
-                CHECK_EQ(res.error(), "hit 3");
+                CHECK_EQ(res.in, ints.begin() + 2);
+                REQUIRE_FALSE(res.value.has_value());
+                CHECK_EQ(res.value.error(), "hit 3");
             }
         }
 #endif // __cpp_lib_expected >= 202202L
@@ -909,7 +942,8 @@ TEST_SUITE("try_for_each") {
                 return std::nullopt;
             });
 
-            CHECK_NE(res, std::nullopt);
+            CHECK_EQ(res.in, no_ints.end());
+            CHECK_NE(res.value, std::nullopt);
         }
 
         SUBCASE("control_flow") {
@@ -918,7 +952,8 @@ TEST_SUITE("try_for_each") {
                 return dtl::cfbreak{std::string{}};
             });
 
-            CHECK(res.is_continue());
+            CHECK_EQ(res.in, no_ints.end());
+            CHECK(res.value.is_continue());
         }
     }
 
@@ -931,7 +966,39 @@ TEST_SUITE("try_for_each") {
             return std::monostate{};
         });
 
-        CHECK_NE(res, std::nullopt);
+        CHECK_EQ(res.in, ints.end());
+        CHECK_NE(res.value, std::nullopt);
+        CHECK_EQ(sum, 15);
+    }
+
+    TEST_CASE("pred is returned") {
+        struct summer {
+            int sum = 0;
+
+            std::optional<std::monostate> operator()(int elem) {
+                sum += elem;
+                return std::monostate{};
+            }
+        };
+
+        std::array ints{1, 2, 3, 4, 5};
+
+        auto res = dtl::try_for_each(ints, summer{});
+
+        CHECK_NE(res.value, std::nullopt);
+        CHECK_EQ(res.fun.sum, 15);
+    }
+
+    TEST_CASE("rvalue range yields a dangling iterator") {
+        int sum = 0;
+
+        auto res = dtl::try_for_each(std::vector{1, 2, 3, 4, 5}, [&sum](int elem) -> std::optional<std::monostate> {
+            sum += elem;
+            return std::monostate{};
+        });
+
+        static_assert(std::is_same_v<decltype(res.in), std::ranges::dangling>);
+        CHECK_NE(res.value, std::nullopt);
         CHECK_EQ(sum, 15);
     }
 
@@ -943,7 +1010,8 @@ TEST_SUITE("try_for_each") {
             return std::monostate{};
         });
 
-        CHECK_NE(res, std::nullopt);
+        CHECK_EQ(res.in, ints.end());
+        CHECK_NE(res.value, std::nullopt);
         CHECK_EQ(ints, std::array{2, 4, 6});
     }
 
@@ -959,7 +1027,8 @@ TEST_SUITE("try_for_each") {
             return std::monostate{};
         });
 
-        CHECK_NE(res, std::nullopt);
+        CHECK_EQ(res.in, ptrs.end());
+        CHECK_NE(res.value, std::nullopt);
         CHECK_EQ(sum, 6);
     }
 
@@ -973,7 +1042,8 @@ TEST_SUITE("try_for_each") {
             return std::monostate{};
         });
 
-        CHECK_NE(res, std::nullopt);
+        CHECK(res.in == std::default_sentinel);
+        CHECK_NE(res.value, std::nullopt);
         CHECK_EQ(sum, 15);
     }
 }
@@ -989,8 +1059,9 @@ TEST_SUITE("try_fold_left_first") {
                     return acc + elem;
                 });
 
-                static_assert(std::is_same_v<decltype(res), std::optional<std::optional<int>>>);
-                CHECK_EQ(res, std::optional<int>{15});
+                static_assert(std::is_same_v<decltype(res.value), std::optional<std::optional<int>>>);
+                CHECK_EQ(res.in, ints.end());
+                CHECK_EQ(res.value, std::optional<int>{15});
             }
 
             SUBCASE("break") {
@@ -1002,7 +1073,8 @@ TEST_SUITE("try_fold_left_first") {
                     return acc + elem;
                 });
 
-                CHECK_EQ(res, std::nullopt);
+                CHECK_EQ(res.in, ints.begin() + 3);
+                CHECK_EQ(res.value, std::nullopt);
             }
 
             SUBCASE("empty range") {
@@ -1010,8 +1082,9 @@ TEST_SUITE("try_fold_left_first") {
                     return acc + elem;
                 });
 
-                CHECK_NE(res, std::nullopt);
-                CHECK_EQ(*res, std::nullopt);
+                CHECK_EQ(res.in, no_ints.end());
+                CHECK_NE(res.value, std::nullopt);
+                CHECK_EQ(*res.value, std::nullopt);
             }
 
             SUBCASE("single element is never passed to pred") {
@@ -1021,7 +1094,8 @@ TEST_SUITE("try_fold_left_first") {
                     return std::nullopt;
                 });
 
-                CHECK_EQ(res, std::optional<int>{42});
+                CHECK_EQ(res.in, single.end());
+                CHECK_EQ(res.value, std::optional<int>{42});
             }
         }
 
@@ -1031,8 +1105,9 @@ TEST_SUITE("try_fold_left_first") {
                     return dtl::cfcontinue{acc + elem};
                 });
 
-                static_assert(std::is_same_v<decltype(res), dtl::control_flow<int, std::optional<int>>>);
-                CHECK_EQ(res.get_continue(), std::optional<int>{15});
+                static_assert(std::is_same_v<decltype(res.value), dtl::control_flow<int, std::optional<int>>>);
+                CHECK_EQ(res.in, ints.end());
+                CHECK_EQ(res.value.get_continue(), std::optional<int>{15});
             }
 
             SUBCASE("break") {
@@ -1044,7 +1119,8 @@ TEST_SUITE("try_fold_left_first") {
                     return dtl::cfcontinue{acc + elem};
                 });
 
-                CHECK_EQ(res.get_break(), 6);
+                CHECK_EQ(res.in, ints.begin() + 3);
+                CHECK_EQ(res.value.get_break(), 6);
             }
 
             SUBCASE("empty range") {
@@ -1052,7 +1128,8 @@ TEST_SUITE("try_fold_left_first") {
                     return dtl::cfcontinue{acc + elem};
                 });
 
-                CHECK_EQ(res.get_continue(), std::nullopt);
+                CHECK_EQ(res.in, no_ints.end());
+                CHECK_EQ(res.value.get_continue(), std::nullopt);
             }
         }
 
@@ -1063,9 +1140,10 @@ TEST_SUITE("try_fold_left_first") {
                     return acc + elem;
                 });
 
-                static_assert(std::is_same_v<decltype(res), std::expected<std::optional<int>, std::string>>);
-                REQUIRE(res.has_value());
-                CHECK_EQ(*res, std::optional<int>{15});
+                static_assert(std::is_same_v<decltype(res.value), std::expected<std::optional<int>, std::string>>);
+                CHECK_EQ(res.in, ints.end());
+                REQUIRE(res.value.has_value());
+                CHECK_EQ(*res.value, std::optional<int>{15});
             }
 
             SUBCASE("break") {
@@ -1077,8 +1155,9 @@ TEST_SUITE("try_fold_left_first") {
                     return acc + elem;
                 });
 
-                REQUIRE_FALSE(res.has_value());
-                CHECK_EQ(res.error(), "too large");
+                CHECK_EQ(res.in, ints.begin() + 3);
+                REQUIRE_FALSE(res.value.has_value());
+                CHECK_EQ(res.value.error(), "too large");
             }
 
             SUBCASE("empty range") {
@@ -1086,10 +1165,32 @@ TEST_SUITE("try_fold_left_first") {
                     return acc + elem;
                 });
 
-                REQUIRE(res.has_value());
-                CHECK_EQ(*res, std::nullopt);
+                CHECK_EQ(res.in, no_ints.end());
+                REQUIRE(res.value.has_value());
+                CHECK_EQ(*res.value, std::nullopt);
             }
         }
 #endif // __cpp_lib_expected >= 202202L
+    }
+
+    TEST_CASE("input only range") {
+        std::istringstream ints{"1 2 3 4 5"};
+        auto view = std::views::istream<int>(ints);
+
+        auto res = dtl::try_fold_left_first(view, [](int acc, int elem) -> std::optional<int> {
+            return acc + elem;
+        });
+
+        CHECK(res.in == std::default_sentinel);
+        CHECK_EQ(res.value, std::optional<int>{15});
+    }
+
+    TEST_CASE("rvalue range yields a dangling iterator") {
+        auto res = dtl::try_fold_left_first(std::vector{1, 2, 3, 4, 5}, [](int acc, int elem) -> std::optional<int> {
+            return acc + elem;
+        });
+
+        static_assert(std::is_same_v<decltype(res.in), std::ranges::dangling>);
+        CHECK_EQ(res.value, std::optional<int>{15});
     }
 }

--- a/tests/tests_try.cpp
+++ b/tests/tests_try.cpp
@@ -1,0 +1,558 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <dice/template-library/try_traits.hpp>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace dtl = dice::template_library;
+
+TEST_SUITE("try_result concept") {
+    static_assert(dtl::try_result<std::optional<int>>);
+    static_assert(dtl::try_result<std::optional<std::string>>);
+    static_assert(dtl::try_result<std::optional<std::unique_ptr<int>>>);
+    static_assert(dtl::try_result<dtl::control_flow<int, int>>);
+    static_assert(dtl::try_result<dtl::control_flow<std::string, std::unique_ptr<int>>>);
+
+#if __cpp_lib_expected >= 202202L
+    static_assert(dtl::try_result<std::expected<int, int>>);
+    static_assert(dtl::try_result<std::expected<std::string, std::unique_ptr<int>>>);
+#endif // __cpp_lib_expected >= 202202L
+
+    // types without a try_traits specialization are not try_results
+    static_assert(!dtl::try_result<int>);
+    static_assert(!dtl::try_result<std::vector<int>>);
+    static_assert(!dtl::try_result<std::variant<int, double>>);
+    static_assert(!dtl::try_result<dtl::cfbreak<int>>);
+    static_assert(!dtl::try_result<dtl::cfcontinue<int>>);
+
+    // a control_flow with a void arm has either no output_type or no representable residual_type,
+    // so it cannot be a try_result (and must not be a hard error to ask)
+    static_assert(!dtl::try_result<dtl::control_flow<int, void>>);
+    static_assert(!dtl::try_result<dtl::control_flow<void, int>>);
+
+    TEST_CASE("rebind_output") {
+        static_assert(std::same_as<dtl::try_traits<std::optional<int>>::rebind_output<std::string>, std::optional<std::string>>);
+        static_assert(std::same_as<dtl::try_traits<dtl::control_flow<int, double>>::rebind_output<std::string>, dtl::control_flow<int, std::string>>);
+#if __cpp_lib_expected >= 202202L
+        static_assert(std::same_as<dtl::try_traits<std::expected<int, std::string>>::rebind_output<double>, std::expected<double, std::string>>);
+#endif // __cpp_lib_expected >= 202202L
+    }
+
+    TEST_CASE("residuals stay usable after rebinding the output") {
+        static_assert(std::convertible_to<dtl::try_traits<std::optional<int>>::residual_type, std::optional<std::string>>);
+        static_assert(std::convertible_to<dtl::try_traits<dtl::control_flow<int, double>>::residual_type, dtl::control_flow<int, std::string>>);
+#if __cpp_lib_expected >= 202202L
+        static_assert(std::convertible_to<dtl::try_traits<std::expected<int, std::string>>::residual_type, std::expected<double, std::string>>);
+#endif // __cpp_lib_expected >= 202202L
+    }
+}
+
+TEST_SUITE("try_traits") {
+    TEST_CASE("optional") {
+        using traits = dtl::try_traits<std::optional<int>>;
+
+        SUBCASE("branch continue") {
+            auto res = traits::branch(std::optional<int>{42});
+            REQUIRE(res.is_continue());
+            CHECK_EQ(res.get_continue(), 42);
+        }
+
+        SUBCASE("branch break") {
+            auto res = traits::branch(std::optional<int>{std::nullopt});
+            REQUIRE(res.is_break());
+
+            // the residual is usable for any rebound output type, not just for optional<int>
+            std::optional<std::string> const propagated = res.get_break();
+            CHECK_EQ(propagated, std::nullopt);
+        }
+
+        SUBCASE("from_output") {
+            CHECK_EQ(traits::from_output(42), std::optional<int>{42});
+        }
+    }
+
+    TEST_CASE("control_flow") {
+        using traits = dtl::try_traits<dtl::control_flow<std::string, int>>;
+
+        SUBCASE("branch continue") {
+            auto res = traits::branch(dtl::cfcontinue{42});
+            REQUIRE(res.is_continue());
+            CHECK_EQ(res.get_continue(), 42);
+        }
+
+        SUBCASE("branch break") {
+            auto res = traits::branch(dtl::cfbreak{std::string{"stop"}});
+            REQUIRE(res.is_break());
+            CHECK_EQ(res.get_break().get_break(), "stop");
+        }
+
+        SUBCASE("from_output") {
+            auto cf = traits::from_output(42);
+            REQUIRE(cf.is_continue());
+            CHECK_EQ(cf.get_continue(), 42);
+        }
+    }
+
+#if __cpp_lib_expected >= 202202L
+    TEST_CASE("expected") {
+        using traits = dtl::try_traits<std::expected<int, std::string>>;
+
+        SUBCASE("branch continue") {
+            auto res = traits::branch(std::expected<int, std::string>{42});
+            REQUIRE(res.is_continue());
+            CHECK_EQ(res.get_continue(), 42);
+        }
+
+        SUBCASE("branch break") {
+            auto res = traits::branch(std::expected<int, std::string>{std::unexpect, "boom"});
+            REQUIRE(res.is_break());
+            CHECK_EQ(res.get_break().error(), "boom");
+        }
+
+        SUBCASE("from_output") {
+            auto exp = traits::from_output(42);
+            REQUIRE(exp.has_value());
+            CHECK_EQ(*exp, 42);
+        }
+    }
+#endif // __cpp_lib_expected >= 202202L
+}
+
+namespace {
+    template<typename Out, typename Ignored>
+    std::optional<Out> two_type_params(bool ok) {
+        if (!ok) {
+            return std::nullopt;
+        }
+
+        return Out{1};
+    }
+
+    int calls = 0;
+
+    std::optional<int> counted_success() {
+        calls += 1;
+        return 42;
+    }
+
+    /**
+     * counts how often it is copied, so that the tests can tell
+     * whether DICE_TRY moved or copied the expression it was given
+     */
+    struct counter {
+        static inline int copies = 0;
+        static inline int moves = 0;
+
+        int value;
+
+        explicit counter(int value) noexcept : value{value} {
+        }
+
+        counter(counter const &other) : value{other.value} {
+            copies += 1;
+        }
+
+        counter(counter &&other) noexcept : value{other.value} {
+            moves += 1;
+        }
+
+        static void reset() noexcept {
+            copies = 0;
+            moves = 0;
+        }
+    };
+
+    std::optional<counter> make_counted(int value) {
+        return counter{value};
+    }
+
+    // free function (not a lambda) to make sure DICE_TRY returns from plain functions as well
+    std::optional<std::string> free_function(bool ok) {
+        auto const x = DICE_TRY(two_type_params<int, double>(ok));
+        return std::to_string(x + 1);
+    }
+} // namespace
+
+TEST_SUITE("DICE_TRY") {
+    TEST_CASE("sanity check") {
+        auto const fail = [] -> std::optional<int> {
+            return std::nullopt;
+        };
+
+        auto const success = [] -> std::optional<int> {
+            return 42;
+        };
+
+        SUBCASE("1") {
+            auto const f = [&] -> std::optional<int> {
+                auto const x = DICE_TRY(fail());
+                return x + 1;
+            };
+
+            CHECK_EQ(f(), std::nullopt);
+        }
+
+        SUBCASE("2") {
+            auto const f = [&] -> std::optional<int> {
+                auto const x = DICE_TRY(success());
+                return x + 1;
+            };
+
+            CHECK_EQ(f(), 43);
+        }
+
+        SUBCASE("3") {
+            auto const f = [&] -> std::optional<int> {
+                return DICE_TRY(success()) + DICE_TRY(fail());
+            };
+
+            CHECK_EQ(f(), std::nullopt);
+        }
+    }
+
+    TEST_CASE("control_flow") {
+        auto const brk = [] -> dtl::control_flow<std::string, int> {
+            return dtl::cfbreak{std::string{"stop"}};
+        };
+
+        auto const cont = [] -> dtl::control_flow<std::string, int> {
+            return dtl::cfcontinue{42};
+        };
+
+        SUBCASE("break") {
+            auto const f = [&] -> dtl::control_flow<std::string, int> {
+                auto const x = DICE_TRY(brk());
+                return dtl::cfcontinue{x + 1};
+            };
+
+            auto const res = f();
+            REQUIRE(res.is_break());
+            CHECK_EQ(res.get_break(), "stop");
+        }
+
+        SUBCASE("continue") {
+            auto const f = [&] -> dtl::control_flow<std::string, int> {
+                auto const x = DICE_TRY(cont());
+                return dtl::cfcontinue{x + 1};
+            };
+
+            auto const res = f();
+            REQUIRE(res.is_continue());
+            CHECK_EQ(res.get_continue(), 43);
+        }
+    }
+
+#if __cpp_lib_expected >= 202202L
+    TEST_CASE("expected") {
+        auto const fail = [] -> std::expected<int, std::string> {
+            return std::unexpected{"boom"};
+        };
+
+        auto const success = [] -> std::expected<int, std::string> {
+            return 42;
+        };
+
+        SUBCASE("error") {
+            auto const f = [&] -> std::expected<int, std::string> {
+                auto const x = DICE_TRY(fail());
+                return x + 1;
+            };
+
+            auto const res = f();
+            REQUIRE_FALSE(res.has_value());
+            CHECK_EQ(res.error(), "boom");
+        }
+
+        SUBCASE("value") {
+            auto const f = [&] -> std::expected<int, std::string> {
+                auto const x = DICE_TRY(success());
+                return x + 1;
+            };
+
+            auto const res = f();
+            REQUIRE(res.has_value());
+            CHECK_EQ(*res, 43);
+        }
+    }
+#endif // __cpp_lib_expected >= 202202L
+
+    TEST_CASE("residual propagates into a differently parameterized try_result") {
+        SUBCASE("optional") {
+            auto const fail = [] -> std::optional<int> {
+                return std::nullopt;
+            };
+
+            auto const f = [&] -> std::optional<std::string> {
+                auto const x = DICE_TRY(fail());
+                return std::to_string(x);
+            };
+
+            CHECK_EQ(f(), std::nullopt);
+        }
+
+        SUBCASE("control_flow") {
+            auto const brk = [] -> dtl::control_flow<std::string, int> {
+                return dtl::cfbreak{std::string{"stop"}};
+            };
+
+            auto const f = [&] -> dtl::control_flow<std::string, double> {
+                auto const x = DICE_TRY(brk());
+                return dtl::cfcontinue{static_cast<double>(x)};
+            };
+
+            auto const res = f();
+            REQUIRE(res.is_break());
+            CHECK_EQ(res.get_break(), "stop");
+        }
+
+#if __cpp_lib_expected >= 202202L
+        SUBCASE("expected") {
+            auto const fail = [] -> std::expected<int, std::string> {
+                return std::unexpected{"boom"};
+            };
+
+            auto const f = [&] -> std::expected<std::string, std::string> {
+                auto const x = DICE_TRY(fail());
+                return std::to_string(x);
+            };
+
+            auto const res = f();
+            REQUIRE_FALSE(res.has_value());
+            CHECK_EQ(res.error(), "boom");
+        }
+#endif // __cpp_lib_expected >= 202202L
+    }
+
+    TEST_CASE("move only output") {
+        auto const fail = [] -> std::optional<std::unique_ptr<int>> {
+            return std::nullopt;
+        };
+
+        auto const success = [] -> std::optional<std::unique_ptr<int>> {
+            return std::make_unique<int>(42);
+        };
+
+        SUBCASE("break") {
+            auto const f = [&] -> std::optional<int> {
+                auto const ptr = DICE_TRY(fail());
+                return *ptr;
+            };
+
+            CHECK_EQ(f(), std::nullopt);
+        }
+
+        SUBCASE("continue") {
+            auto const f = [&] -> std::optional<int> {
+                auto const ptr = DICE_TRY(success());
+                return *ptr;
+            };
+
+            CHECK_EQ(f(), 42);
+        }
+    }
+
+#if __cpp_lib_expected >= 202202L
+    TEST_CASE("move only residual") {
+        auto const fail = [] -> std::expected<int, std::unique_ptr<int>> {
+            return std::unexpected{std::make_unique<int>(42)};
+        };
+
+        auto const f = [&] -> std::expected<std::string, std::unique_ptr<int>> {
+            auto const x = DICE_TRY(fail());
+            return std::to_string(x);
+        };
+
+        auto const res = f();
+        REQUIRE_FALSE(res.has_value());
+        REQUIRE_NE(res.error(), nullptr);
+        CHECK_EQ(*res.error(), 42);
+    }
+#endif // __cpp_lib_expected >= 202202L
+
+    TEST_CASE("the expression is evaluated exactly once") {
+        calls = 0;
+
+        auto const f = [] -> std::optional<int> {
+            return DICE_TRY(counted_success());
+        };
+
+        CHECK_EQ(f(), 42);
+        CHECK_EQ(calls, 1);
+    }
+
+    TEST_CASE("the expression may contain commas") {
+        CHECK_EQ(free_function(true), "2");
+        CHECK_EQ(free_function(false), std::nullopt);
+
+        auto const f = [] -> std::optional<int> {
+            return DICE_TRY(std::optional<std::pair<int, int>>{std::pair{1, 2}}).first;
+        };
+
+        CHECK_EQ(f(), 1);
+    }
+
+    TEST_CASE("nested") {
+        auto const success = [] -> std::optional<int> {
+            return 42;
+        };
+
+        auto const fail = [] -> std::optional<int> {
+            return std::nullopt;
+        };
+
+        auto const twice = [](int x) -> std::optional<int> {
+            return x * 2;
+        };
+
+        SUBCASE("continue") {
+            auto const f = [&] -> std::optional<int> {
+                return DICE_TRY(twice(DICE_TRY(success())));
+            };
+
+            CHECK_EQ(f(), 84);
+        }
+
+        SUBCASE("break") {
+            auto const f = [&] -> std::optional<int> {
+                return DICE_TRY(twice(DICE_TRY(fail())));
+            };
+
+            CHECK_EQ(f(), std::nullopt);
+        }
+    }
+
+    TEST_CASE("breaks out of loops") {
+        auto const half = [](int x) -> std::optional<int> {
+            if (x % 2 != 0) {
+                return std::nullopt;
+            }
+
+            return x / 2;
+        };
+
+        auto const f = [&](std::vector<int> const &xs) -> std::optional<int> {
+            int sum = 0;
+            for (int const x : xs) {
+                sum += DICE_TRY(half(x));
+            }
+
+            return sum;
+        };
+
+        CHECK_EQ(f({2, 4, 6}), 6);
+        CHECK_EQ(f({2, 3, 6}), std::nullopt);
+    }
+
+    TEST_CASE("move only types") {
+        auto const f = [] -> std::optional<int> {
+            std::optional<std::unique_ptr<int>> opt = std::make_unique<int>(42);
+
+            auto const ptr = DICE_TRY(std::move(opt));
+            CHECK(opt.has_value()); // std::optional stays engaged, its content was moved out
+            CHECK_EQ(*opt, nullptr);
+
+            return *ptr;
+        };
+
+        CHECK_EQ(f(), 42);
+
+        // note: a move only try_result can only be passed as an rvalue,
+        // passing one as an lvalue does not compile because it would have to be copied
+    }
+
+    TEST_CASE("only rvalue expressions are moved from") {
+        SUBCASE("lvalues are left intact") {
+            auto const f = [] -> std::optional<std::size_t> {
+                std::optional<std::string> opt{"hello"};
+
+                auto const s = DICE_TRY(opt);
+                CHECK_EQ(opt, "hello"); // copied, not moved
+
+                return s.size();
+            };
+
+            CHECK_EQ(f(), 5);
+        }
+
+        SUBCASE("const lvalues are left intact") {
+            auto const f = [] -> std::optional<std::size_t> {
+                std::optional<std::string> const opt{"hello"};
+
+                auto const s = DICE_TRY(opt);
+                CHECK_EQ(opt, "hello");
+
+                return s.size();
+            };
+
+            CHECK_EQ(f(), 5);
+        }
+
+        SUBCASE("rvalues are moved from") {
+            auto const f = [] -> std::optional<std::size_t> {
+                std::optional<std::string> opt{"hello"};
+
+                auto const s = DICE_TRY(std::move(opt));
+                REQUIRE(opt.has_value());
+                CHECK_NE(opt, "hello"); // moved from
+
+                return s.size();
+            };
+
+            CHECK_EQ(f(), 5);
+        }
+    }
+
+    TEST_CASE("expressions are copied only if they have to be") {
+        counter::reset();
+
+        SUBCASE("prvalue") {
+            auto const f = [] -> std::optional<int> {
+                return DICE_TRY(make_counted(42)).value;
+            };
+
+            CHECK_EQ(f(), 42);
+            CHECK_EQ(counter::copies, 0);
+        }
+
+        SUBCASE("lvalue") {
+            auto const f = [] -> std::optional<int> {
+                auto opt = make_counted(42);
+                counter::reset();
+
+                return DICE_TRY(opt).value;
+            };
+
+            CHECK_EQ(f(), 42);
+            CHECK_EQ(counter::copies, 1);
+        }
+
+        SUBCASE("const lvalue") {
+            auto const f = [] -> std::optional<int> {
+                auto const opt = make_counted(42);
+                counter::reset();
+
+                return DICE_TRY(opt).value;
+            };
+
+            CHECK_EQ(f(), 42);
+            CHECK_EQ(counter::copies, 1);
+        }
+
+        SUBCASE("xvalue") {
+            auto const f = [] -> std::optional<int> {
+                auto opt = make_counted(42);
+                counter::reset();
+
+                return DICE_TRY(std::move(opt)).value;
+            };
+
+            CHECK_EQ(f(), 42);
+            CHECK_EQ(counter::copies, 0);
+        }
+    }
+}


### PR DESCRIPTION
Implement `dtl::{try_for_each,try_fold_left,try_fold_left_first}` which are fallible variants of `std::ranges::{for_each,fold_left,fold_left_first}`

Also adds `DICE_TRY` a c++ equivalent for the `?` operator in rust.

Inspiration from rust. Justification: I have found myself multiple times in the past wanting these kinds of algorithms and always had to fall back to imperative loops.

### Motivating Example
```c++
std::expected<int, std::string> parse_int(std::string const &s) {
    try {
        return std::stoi(s);
    } catch (std::exception const &) {
        return std::unexpected{"not a number: " + s};
    }
}

std::array<std::string, 3> const numbers{"1", "2", "3"};
auto const sum = dtl::try_fold_left(numbers, 0, [](int acc, std::string const &s) -> std::expected<int, std::string> {
    return acc + DICE_TRY(parse_int(s));
});
std::cout << "try_fold_left(sum) = " << sum.value.value_or(-1) << "\n";
```


### AI disclaimer
Tests and docs are mostly AI gen, rest is not.